### PR TITLE
feat(transport): add Azure Service Bus & in-memory support

### DIFF
--- a/HoneyDrunk.Transport/.github/copilot-instructions.md
+++ b/HoneyDrunk.Transport/.github/copilot-instructions.md
@@ -1,0 +1,223 @@
+# HoneyDrunk.Transport Codebase Guide
+
+## Architecture Overview
+
+HoneyDrunk.Transport is a **transport-agnostic messaging library** for .NET 10.0 that provides a unified abstraction layer over different message brokers. The architecture follows a **middleware pipeline pattern** similar to ASP.NET Core.
+
+### Core Projects Structure
+
+```
+HoneyDrunk.Transport/           # Core abstractions and middleware pipeline
+├── Abstractions/               # Publisher/Consumer interfaces, envelope contracts
+├── Pipeline/                   # Middleware execution engine
+├── Configuration/              # Retry, backoff, error handling options
+├── DependencyInjection/        # Fluent builder pattern for service registration
+├── Outbox/                     # Transactional outbox pattern abstractions
+└── Primitives/                 # EnvelopeFactory, TransportEnvelope implementations
+
+HoneyDrunk.Transport.AzureServiceBus/   # Azure Service Bus transport implementation
+HoneyDrunk.Transport.InMemory/          # In-memory broker for testing
+HoneyDrunk.Transport.Tests/             # xUnit test suite
+```
+
+## Key Concepts
+
+### Transport Envelope Pattern
+All messages are wrapped in `ITransportEnvelope` which provides:
+- `MessageId`, `CorrelationId`, `CausationId` for distributed tracing
+- `MessageType` (full type name string) for deserialization routing
+- `Headers` dictionary for metadata
+- `Payload` as `ReadOnlyMemory<byte>` for zero-copy performance
+- Immutable design with `WithHeaders()` and `WithCorrelation()` methods
+
+Example from `Primitives/TransportEnvelope.cs`:
+```csharp
+public ITransportEnvelope WithHeaders(IDictionary<string, string> additionalHeaders)
+{
+    var combined = new Dictionary<string, string>(Headers);
+    foreach (var kvp in additionalHeaders)
+        combined[kvp.Key] = kvp.Value;
+    
+    return new TransportEnvelope { /* copy all properties */ };
+}
+```
+
+### Middleware Pipeline Architecture
+Message processing follows an **onion-style middleware pattern**:
+1. Built-in middleware (Correlation → Telemetry → Logging) executes first
+2. Custom middleware can be registered via `ITransportBuilder`
+3. Pipeline terminates at message handler invocation
+4. Middleware registered in `ServiceCollectionExtensions.cs` using `IMessageMiddleware`
+
+Key implementation in `Pipeline/MessagePipeline.cs`:
+```csharp
+// Middleware wraps handlers in reverse order (LIFO)
+foreach (var middleware in _middlewares.Reverse())
+{
+    var next = handler;
+    handler = () => middleware.InvokeAsync(envelope, context, next, cancellationToken);
+}
+```
+
+### Fluent Registration Pattern
+All transport configuration uses **builder pattern returning `ITransportBuilder`**:
+
+```csharp
+services.AddHoneyDrunkTransportCore()
+    .AddHoneyDrunkServiceBusTransport(options => { /* ... */ })
+    .WithTopicSubscription("my-subscription")
+    .WithSessions()
+    .WithRetry(retry => retry.MaxAttempts = 5);
+```
+
+See `DependencyInjection/ServiceCollectionExtensions.cs` for the pattern.
+
+### Message Handler Registration
+Handlers implement `IMessageHandler<TMessage>`:
+```csharp
+services.AddMessageHandler<MyMessage, MyMessageHandler>();
+// OR delegate-based:
+services.AddMessageHandler<MyMessage>(async (msg, ctx, ct) => { /* ... */ });
+```
+
+## Critical Dependencies
+
+### HoneyDrunk.Kernel
+Core infrastructure package providing:
+- `IIdGenerator` - Message ID generation
+- `IClock` - Timestamp abstraction for testability
+- `IContextAccessor` - Ambient context propagation
+- Registered via `services.AddKernelDefaults()` in core setup
+
+**Important**: Always use `EnvelopeFactory` (depends on Kernel) to create envelopes, never construct `TransportEnvelope` directly in production code.
+
+### Documentation Generation
+All projects have `<GenerateDocumentationFile>true</GenerateDocumentationFile>` enabled. **Always add XML doc comments** to public APIs.
+
+## Implementation Patterns
+
+### Transport Implementations
+Each transport provider must implement:
+1. `ITransportPublisher` - Sends envelopes to broker
+2. `ITransportConsumer` - Receives messages and invokes pipeline
+3. Registration extension methods in `DependencyInjection/ServiceCollectionExtensions.cs`
+
+Example from `AzureServiceBus/ServiceBusTransportPublisher.cs`:
+- Use `TransportTelemetry.StartPublishActivity()` for distributed tracing
+- Call `EnvelopeMapper.ToServiceBusMessage()` for format conversion
+- Always record outcome with `TransportTelemetry.RecordOutcome()`
+
+### Retry & Error Handling
+Three-tier error handling:
+1. **Transport-level retries** - `RetryOptions` with `BackoffStrategy` (Fixed/Linear/Exponential)
+2. **Middleware retries** - `RetryMiddleware` (currently in Middleware/ folder)
+3. **Message processing results** - Return `MessageProcessingResult` enum:
+   - `Success` - Complete successfully
+   - `Retry` - Reprocess with backoff
+   - `DeadLetter` - Move to DLQ, no retry
+
+Example from `Pipeline/MessagePipeline.cs`:
+```csharp
+catch (MessageHandlerException ex)
+{
+    return ex.Result; // Handler controls retry behavior
+}
+catch (Exception ex)
+{
+    return MessageProcessingResult.Retry; // Default to retry on unexpected errors
+}
+```
+
+### Transactional Outbox Pattern
+For exactly-once processing with database transactions:
+1. Implement `IOutboxStore` against your database
+2. Save messages via `SaveAsync()` within your unit-of-work transaction
+3. Background `IOutboxDispatcher` polls `LoadPendingAsync()` and publishes
+4. Track state with `OutboxMessageState` (Pending → Dispatched/Failed/Poisoned)
+
+See `Outbox/IOutboxStore.cs` for the contract.
+
+## Development Workflows
+
+### Building & Testing
+```powershell
+dotnet build HoneyDrunk.Transport.slnx
+dotnet test HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+```
+
+### Adding New Transport Providers
+1. Create project `HoneyDrunk.Transport.{BrokerName}/`
+2. Reference `HoneyDrunk.Transport` core project
+3. Implement `ITransportPublisher` and `ITransportConsumer`
+4. Create `Configuration/{BrokerName}Options.cs` for broker-specific settings
+5. Add extension methods: `AddHoneyDrunk{BrokerName}Transport(this IServiceCollection)`
+6. Follow Azure Service Bus implementation as reference template
+
+### Testing with InMemory Transport
+Use `HoneyDrunk.Transport.InMemory` for integration tests:
+- `InMemoryBroker` provides observable queues via `Channel<T>`
+- Supports both queue-based consumption and pub/sub subscriptions
+- No external dependencies, runs in-process
+
+## Code Style Conventions
+
+### Nullable Reference Types
+Project uses `<Nullable>enable</Nullable>`. **Always annotate**:
+- Use `?` for nullable parameters and properties
+- Use `!` null-forgiving operator only when justified with comment
+- Prefer `ArgumentNullException.ThrowIfNull()` for guard clauses
+
+### Primary Constructors
+Modern C# 12 syntax used throughout:
+```csharp
+public sealed class ServiceBusTransportPublisher(
+    ServiceBusClient client,
+    IOptions<AzureServiceBusOptions> options,
+    ILogger<ServiceBusTransportPublisher> logger) : ITransportPublisher
+{
+    private readonly ServiceBusClient _client = client;
+    // ...
+}
+```
+
+### Service Registration
+- Use `TryAddSingleton/TryAddScoped` for overrideable defaults
+- Use `AddSingleton` when replacement should be explicit
+- Middleware uses `AddEnumerable` to support multiple registrations
+
+### Telemetry Integration
+**Always wrap operations** with telemetry activities:
+```csharp
+using var activity = TransportTelemetry.StartPublishActivity(envelope, destination);
+try 
+{
+    // operation
+    TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+}
+catch (Exception ex)
+{
+    TransportTelemetry.RecordError(activity, ex);
+    throw;
+}
+```
+
+## Common Pitfalls
+
+1. **Don't construct `TransportEnvelope` directly** - Use `EnvelopeFactory` which provides `MessageId` and `Timestamp` from Kernel services
+2. **Message type resolution** - `MessageType` must be fully qualified type name resolvable via `Type.GetType()`
+3. **Middleware order matters** - Correlation must run before telemetry to populate trace context
+4. **Async disposal** - Transport implementations like `ServiceBusTransportPublisher` implement `IAsyncDisposable` for cleanup
+5. **Immutable envelopes** - Use `With*()` methods to create modified copies, never mutate
+
+## Extension Points
+
+- **Custom middleware**: Implement `IMessageMiddleware` and register with `services.AddEnumerable()`
+- **Custom serializers**: Implement `IMessageSerializer` and register as singleton
+- **Error handling strategies**: Implement `IErrorHandlingStrategy` for custom retry logic
+- **Outbox stores**: Implement `IOutboxStore` for database-specific transactional outbox
+
+## Related Documentation
+
+- See `Configuration/TransportCoreOptions.cs` for available toggles (telemetry, logging, correlation)
+- Check `Abstractions/MessageProcessingResult.cs` for message outcome enumeration
+- Review `AzureServiceBus/Mapping/EnvelopeMapper.cs` for transport format conversion patterns

--- a/HoneyDrunk.Transport/.github/workflows/publish.yml
+++ b/HoneyDrunk.Transport/.github/workflows/publish.yml
@@ -1,0 +1,171 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without v prefix, e.g., 0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write        # For creating GitHub releases
+  packages: write        # For publishing to NuGet/GitHub Packages
+  id-token: write        # For OIDC authentication (if needed)
+
+jobs:
+  # Determine version from tag or manual input
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      version-tag: ${{ steps.get_version.outputs.version-tag }}
+    steps:
+      - name: Determine version
+        id: get_version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+            VERSION_TAG="v${VERSION}"
+          else
+            # Extract version from tag (removes 'v' prefix)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            VERSION_TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >>"$GITHUB_OUTPUT"
+          echo "version-tag=${VERSION_TAG}" >>"$GITHUB_OUTPUT"
+          echo "Publishing version: ${VERSION}"
+          echo "Publishing tag: ${VERSION_TAG}"
+
+  # Build, test, pack, and publish all packages
+  release:
+    name: Build, Pack & Publish
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore HoneyDrunk.Transport.slnx
+
+      - name: Build
+        run: dotnet build HoneyDrunk.Transport.slnx -c Release --no-restore /p:ContinuousIntegrationBuild=true
+
+      - name: Test
+        run: dotnet test HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj -c Release --no-build
+
+      - name: Pack HoneyDrunk.Transport
+        run: >
+          dotnet pack HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+          -c Release --no-build -o ./artifacts
+          /p:Version=${{ needs.prepare.outputs.version }}
+          /p:ContinuousIntegrationBuild=true
+
+      - name: Pack HoneyDrunk.Transport.InMemory
+        run: >
+          dotnet pack HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+          -c Release --no-build -o ./artifacts
+          /p:Version=${{ needs.prepare.outputs.version }}
+          /p:ContinuousIntegrationBuild=true
+
+      - name: Pack HoneyDrunk.Transport.AzureServiceBus
+        run: >
+          dotnet pack HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+          -c Release --no-build -o ./artifacts
+          /p:Version=${{ needs.prepare.outputs.version }}
+          /p:ContinuousIntegrationBuild=true
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages-${{ needs.prepare.outputs.version }}
+          path: ./artifacts/*.nupkg
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Publish to NuGet.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          dotnet nuget push ./artifacts/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  # Create GitHub Release
+  github-release:
+    name: Create GitHub Release
+    needs: [prepare, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.prepare.outputs.version-tag }}
+          name: HoneyDrunk.Transport ${{ needs.prepare.outputs.version-tag }}
+          body: |
+            ## HoneyDrunk.Transport ${{ needs.prepare.outputs.version-tag }}
+
+            Transport-agnostic messaging library for .NET with middleware pipeline pattern.
+
+            ### ?? Packages
+
+            **HoneyDrunk.Transport** - Core abstractions and middleware pipeline
+            ```xml
+            <PackageReference Include="HoneyDrunk.Transport" Version="${{ needs.prepare.outputs.version }}" />
+            ```
+
+            **HoneyDrunk.Transport.InMemory** - In-memory broker for testing
+            ```xml
+            <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="${{ needs.prepare.outputs.version }}" />
+            ```
+
+            **HoneyDrunk.Transport.AzureServiceBus** - Azure Service Bus implementation
+            ```xml
+            <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="${{ needs.prepare.outputs.version }}" />
+            ```
+
+            ### ?? Links
+            - [NuGet: HoneyDrunk.Transport](https://www.nuget.org/packages/HoneyDrunk.Transport/${{ needs.prepare.outputs.version }})
+            - [NuGet: HoneyDrunk.Transport.InMemory](https://www.nuget.org/packages/HoneyDrunk.Transport.InMemory/${{ needs.prepare.outputs.version }})
+            - [NuGet: HoneyDrunk.Transport.AzureServiceBus](https://www.nuget.org/packages/HoneyDrunk.Transport.AzureServiceBus/${{ needs.prepare.outputs.version }})
+            - [Documentation](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport#readme)
+
+            ### ?? Quick Start
+
+            ```csharp
+            using HoneyDrunk.Transport.DependencyInjection;
+
+            var builder = WebApplication.CreateBuilder(args);
+
+            // Add transport core with Azure Service Bus
+            builder.Services.AddHoneyDrunkTransportCore()
+                .AddHoneyDrunkServiceBusTransport(options => 
+                {
+                    options.ConnectionString = builder.Configuration["ServiceBus:ConnectionString"];
+                })
+                .WithTopicSubscription("my-subscription")
+                .WithRetry(retry => retry.MaxAttempts = 5);
+
+            // Register message handlers
+            builder.Services.AddMessageHandler<MyMessage, MyMessageHandler>();
+            ```
+          draft: false
+          prerelease: false

--- a/HoneyDrunk.Transport/.github/workflows/validate-pr.yml
+++ b/HoneyDrunk.Transport/.github/workflows/validate-pr.yml
@@ -1,0 +1,32 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.slnx'
+      - '**.props'
+      - '**.targets'
+      - '**/.editorconfig'
+      - '**/stylecop.json'
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write  # This allows posting PR comments
+
+jobs:
+  pr-validation:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-validation.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Transport'
+      enable-code-quality: true
+      post-pr-comment: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/AzureServiceBusOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/AzureServiceBusOptions.cs
@@ -1,0 +1,112 @@
+using HoneyDrunk.Transport.Configuration;
+
+namespace HoneyDrunk.Transport.AzureServiceBus.Configuration;
+
+/// <summary>
+/// Configuration options for Azure Service Bus transport.
+/// </summary>
+public sealed class AzureServiceBusOptions : TransportOptions
+{
+    /// <summary>
+    /// Fully qualified namespace (e.g., "mynamespace.servicebus.windows.net").
+    /// </summary>
+    public string FullyQualifiedNamespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Connection string (alternative to FullyQualifiedNamespace with managed identity).
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Entity type: Queue or Topic.
+    /// </summary>
+    public ServiceBusEntityType EntityType { get; set; } = ServiceBusEntityType.Queue;
+
+    /// <summary>
+    /// Subscription name (required for Topic entity type).
+    /// </summary>
+    public string? SubscriptionName { get; set; }
+
+    /// <summary>
+    /// Maximum wait time for receiving messages.
+    /// </summary>
+    public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Service Bus retry options.
+    /// </summary>
+    public ServiceBusRetryOptions ServiceBusRetry { get; set; } = new();
+
+    /// <summary>
+    /// Whether to use sub-queue (dead letter queue).
+    /// </summary>
+    public bool EnableDeadLetterQueue { get; set; } = true;
+
+    /// <summary>
+    /// Maximum delivery count before moving to dead letter queue.
+    /// </summary>
+    public int MaxDeliveryCount { get; set; } = 10;
+}
+
+/// <summary>
+/// Entity type for Azure Service Bus.
+/// </summary>
+public enum ServiceBusEntityType
+{
+    /// <summary>
+    /// Queue entity type.
+    /// </summary>
+    Queue,
+    
+    /// <summary>
+    /// Topic entity type.
+    /// </summary>
+    Topic
+}
+
+/// <summary>
+/// Service Bus specific retry configuration.
+/// </summary>
+public sealed class ServiceBusRetryOptions
+{
+    /// <summary>
+    /// Retry mode for Service Bus operations.
+    /// </summary>
+    public ServiceBusRetryMode Mode { get; set; } = ServiceBusRetryMode.Exponential;
+
+    /// <summary>
+    /// Maximum number of retry attempts.
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Delay between retry attempts.
+    /// </summary>
+    public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(0.8);
+
+    /// <summary>
+    /// Maximum delay between retries.
+    /// </summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Timeout for Service Bus operations.
+    /// </summary>
+    public TimeSpan TryTimeout { get; set; } = TimeSpan.FromMinutes(1);
+}
+
+/// <summary>
+/// Retry mode for Service Bus.
+/// </summary>
+public enum ServiceBusRetryMode
+{
+    /// <summary>
+    /// Fixed delay between retries.
+    /// </summary>
+    Fixed,
+    
+    /// <summary>
+    /// Exponential backoff between retries.
+    /// </summary>
+    Exponential
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,156 @@
+using Azure.Messaging.ServiceBus;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.AzureServiceBus.Configuration;
+using HoneyDrunk.Transport.DependencyInjection;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using AzureSBRetryOptions = Azure.Messaging.ServiceBus.ServiceBusRetryOptions;
+
+namespace HoneyDrunk.Transport.AzureServiceBus.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering Azure Service Bus transport services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the HoneyDrunk Azure Service Bus transport implementation.
+    /// </summary>
+    public static ITransportBuilder AddHoneyDrunkServiceBusTransport(
+        this IServiceCollection services,
+        Action<AzureServiceBusOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Ensure core transport services are registered
+        var builder = services.AddHoneyDrunkTransportCore();
+
+        // Configure options
+        services.Configure(configure);
+
+        // Register Service Bus client
+        services.AddSingleton<ServiceBusClient>(sp =>
+        {
+            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<AzureServiceBusOptions>>().Value;
+
+            var clientOptions = new ServiceBusClientOptions
+            {
+                RetryOptions = new AzureSBRetryOptions
+                {
+                    Mode = options.ServiceBusRetry.Mode == Configuration.ServiceBusRetryMode.Exponential
+                        ? Azure.Messaging.ServiceBus.ServiceBusRetryMode.Exponential
+                        : Azure.Messaging.ServiceBus.ServiceBusRetryMode.Fixed,
+                    MaxRetries = options.ServiceBusRetry.MaxRetries,
+                    Delay = options.ServiceBusRetry.Delay,
+                    MaxDelay = options.ServiceBusRetry.MaxDelay,
+                    TryTimeout = options.ServiceBusRetry.TryTimeout
+                }
+            };
+
+            if (!string.IsNullOrEmpty(options.ConnectionString))
+            {
+                return new ServiceBusClient(options.ConnectionString, clientOptions);
+            }
+            else if (!string.IsNullOrEmpty(options.FullyQualifiedNamespace))
+            {
+                // Use managed identity (DefaultAzureCredential)
+                return new ServiceBusClient(
+                    options.FullyQualifiedNamespace,
+                    new Azure.Identity.DefaultAzureCredential(),
+                    clientOptions);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    "Either ConnectionString or FullyQualifiedNamespace must be configured");
+            }
+        });
+
+        // Register publisher and consumer
+        services.TryAddSingleton<ITransportPublisher, ServiceBusTransportPublisher>();
+        services.TryAddSingleton<ITransportConsumer, ServiceBusTransportConsumer>();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds Azure Service Bus transport with connection string.
+    /// </summary>
+    public static ITransportBuilder AddHoneyDrunkServiceBusTransport(
+        this IServiceCollection services,
+        string connectionString,
+        string queueOrTopicName,
+        Action<AzureServiceBusOptions>? configure = null)
+    {
+        return services.AddHoneyDrunkServiceBusTransport(options =>
+        {
+            options.ConnectionString = connectionString;
+            options.Address = queueOrTopicName;
+            options.EndpointName = queueOrTopicName;
+            configure?.Invoke(options);
+        });
+    }
+
+    /// <summary>
+    /// Adds Azure Service Bus transport with managed identity.
+    /// </summary>
+    public static ITransportBuilder AddHoneyDrunkServiceBusTransportWithManagedIdentity(
+        this IServiceCollection services,
+        string fullyQualifiedNamespace,
+        string queueOrTopicName,
+        Action<AzureServiceBusOptions>? configure = null)
+    {
+        return services.AddHoneyDrunkServiceBusTransport(options =>
+        {
+            options.FullyQualifiedNamespace = fullyQualifiedNamespace;
+            options.Address = queueOrTopicName;
+            options.EndpointName = queueOrTopicName;
+            configure?.Invoke(options);
+        });
+    }
+
+    /// <summary>
+    /// Configures the transport for a topic with subscription.
+    /// </summary>
+    public static ITransportBuilder WithTopicSubscription(
+        this ITransportBuilder builder,
+        string subscriptionName)
+    {
+        builder.Services.Configure<AzureServiceBusOptions>(options =>
+        {
+            options.EntityType = ServiceBusEntityType.Topic;
+            options.SubscriptionName = subscriptionName;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables session support for ordered message processing.
+    /// </summary>
+    public static ITransportBuilder WithSessions(this ITransportBuilder builder)
+    {
+        builder.Services.Configure<AzureServiceBusOptions>(options =>
+        {
+            options.SessionEnabled = true;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures retry behavior for the transport.
+    /// </summary>
+    public static ITransportBuilder WithRetry(
+        this ITransportBuilder builder,
+        Action<Configuration.ServiceBusRetryOptions> configure)
+    {
+        builder.Services.Configure<AzureServiceBusOptions>(options =>
+        {
+            configure(options.ServiceBusRetry);
+        });
+
+        return builder;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -4,6 +4,19 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HoneyDrunk.Transport\HoneyDrunk.Transport.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
+  </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -5,6 +5,24 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Package Metadata -->
+    <PackageId>HoneyDrunk.Transport.AzureServiceBus</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <Description>Azure Service Bus transport implementation for HoneyDrunk.Transport. Provides topic/subscription support, session handling, and distributed tracing integration for Service Bus messaging.</Description>
+    <PackageReleaseNotes>v0.1.0: Initial release with Azure Service Bus publisher and consumer, topic subscription management, session support, envelope mapping, and telemetry integration.</PackageReleaseNotes>
+    <PackageTags>messaging;transport;azure;servicebus;cloud;distributed;queue;topic;session</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</PackageProjectUrl>
+
+    <!-- Symbol Package Configuration -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,11 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Mapping/EnvelopeMapper.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Mapping/EnvelopeMapper.cs
@@ -1,0 +1,149 @@
+using Azure.Messaging.ServiceBus;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Primitives;
+
+namespace HoneyDrunk.Transport.AzureServiceBus.Mapping;
+
+/// <summary>
+/// Maps between HoneyDrunk transport envelopes and Azure Service Bus messages.
+/// </summary>
+public static class EnvelopeMapper
+{
+    private const string MessageTypeProperty = "MessageType";
+    private const string TimestampProperty = "Timestamp";
+
+    /// <summary>
+    /// Converts a transport envelope to a Service Bus message.
+    /// </summary>
+    public static ServiceBusMessage ToServiceBusMessage(ITransportEnvelope envelope)
+    {
+        var message = new ServiceBusMessage(envelope.Payload)
+        {
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            Subject = envelope.MessageType,
+            ContentType = "application/octet-stream"
+        };
+
+        // Add custom properties
+        message.ApplicationProperties[MessageTypeProperty] = envelope.MessageType;
+        message.ApplicationProperties[TimestampProperty] = envelope.Timestamp.ToString("o");
+
+        if (!string.IsNullOrEmpty(envelope.CausationId))
+        {
+            message.ApplicationProperties["CausationId"] = envelope.CausationId;
+        }
+
+        // Copy all headers
+        foreach (var header in envelope.Headers)
+        {
+            message.ApplicationProperties[header.Key] = header.Value;
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Converts a Service Bus received message to a transport envelope.
+    /// </summary>
+    public static ITransportEnvelope FromServiceBusMessage(ServiceBusReceivedMessage message)
+    {
+        var headers = new Dictionary<string, string>();
+
+        // Extract headers from application properties
+        foreach (var property in message.ApplicationProperties)
+        {
+            if (property.Key != MessageTypeProperty && 
+                property.Key != TimestampProperty && 
+                property.Key != "CausationId")
+            {
+                headers[property.Key] = property.Value?.ToString() ?? string.Empty;
+            }
+        }
+
+        // Parse timestamp
+        var timestamp = DateTimeOffset.UtcNow;
+        if (message.ApplicationProperties.TryGetValue(TimestampProperty, out var timestampValue) 
+            && timestampValue is string timestampStr)
+        {
+            DateTimeOffset.TryParse(timestampStr, out timestamp);
+        }
+
+        // Get message type
+        var messageType = message.Subject;
+        if (message.ApplicationProperties.TryGetValue(MessageTypeProperty, out var messageTypeValue))
+        {
+            messageType = messageTypeValue?.ToString() ?? messageType;
+        }
+
+        // Get causation ID
+        string? causationId = null;
+        if (message.ApplicationProperties.TryGetValue("CausationId", out var causationValue))
+        {
+            causationId = causationValue?.ToString();
+        }
+
+        return new TransportEnvelope
+        {
+            MessageId = message.MessageId,
+            CorrelationId = message.CorrelationId,
+            CausationId = causationId,
+            Timestamp = timestamp,
+            MessageType = messageType ?? "Unknown",
+            Headers = headers,
+            Payload = message.Body.ToMemory()
+        };
+    }
+
+    /// <summary>
+    /// Extracts delivery count from Service Bus message.
+    /// </summary>
+    public static int GetDeliveryCount(ServiceBusReceivedMessage message)
+    {
+        return (int)message.DeliveryCount;
+    }
+
+    /// <summary>
+    /// Creates a transaction context from Service Bus message.
+    /// </summary>
+    public static ITransportTransaction CreateTransaction(ServiceBusReceivedMessage message)
+    {
+        return new ServiceBusTransportTransaction(message);
+    }
+}
+
+/// <summary>
+/// Service Bus specific transaction context.
+/// </summary>
+internal sealed class ServiceBusTransportTransaction : ITransportTransaction
+{
+    private readonly ServiceBusReceivedMessage _message;
+
+    public ServiceBusTransportTransaction(ServiceBusReceivedMessage message)
+    {
+        _message = message;
+        TransactionId = message.MessageId;
+    }
+
+    public string TransactionId { get; }
+
+    public IReadOnlyDictionary<string, object> Context => new Dictionary<string, object>
+    {
+        ["ServiceBusMessage"] = _message,
+        ["LockToken"] = _message.LockToken,
+        ["SequenceNumber"] = _message.SequenceNumber,
+        ["EnqueuedTime"] = _message.EnqueuedTime
+    };
+
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        // Completion is handled by the processor
+        return Task.CompletedTask;
+    }
+
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        // Abandonment is handled by the processor
+        return Task.CompletedTask;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
@@ -1,0 +1,355 @@
+using Azure.Messaging.ServiceBus;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.AzureServiceBus.Configuration;
+using HoneyDrunk.Transport.AzureServiceBus.Mapping;
+using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.Pipeline;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.AzureServiceBus;
+
+/// <summary>
+/// Azure Service Bus implementation of transport consumer.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ServiceBusTransportConsumer"/> class.
+/// </remarks>
+/// <param name="client">The Service Bus client.</param>
+/// <param name="pipeline">The message processing pipeline.</param>
+/// <param name="options">The Azure Service Bus configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+public sealed class ServiceBusTransportConsumer(
+    ServiceBusClient client,
+    IMessagePipeline pipeline,
+    IOptions<AzureServiceBusOptions> options,
+    ILogger<ServiceBusTransportConsumer> logger) : ITransportConsumer, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client = client;
+    private readonly IMessagePipeline _pipeline = pipeline;
+    private readonly IOptions<AzureServiceBusOptions> _options = options;
+    private readonly ILogger<ServiceBusTransportConsumer> _logger = logger;
+    private ServiceBusProcessor? _processor;
+    private ServiceBusSessionProcessor? _sessionProcessor;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_processor != null || _sessionProcessor != null)
+            {
+                throw new InvalidOperationException("Consumer is already started");
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Starting Service Bus consumer for endpoint {EndpointName}",
+                    _options.Value.EndpointName);
+            }
+
+            var processorOptions = CreateProcessorOptions();
+
+            if (_options.Value.SessionEnabled)
+            {
+                await StartSessionProcessorAsync(processorOptions, cancellationToken);
+            }
+            else
+            {
+                await StartStandardProcessorAsync(processorOptions, cancellationToken);
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("Service Bus consumer started");
+            }
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Stopping Service Bus consumer");
+        }
+
+        if (_processor != null)
+        {
+            await _processor.StopProcessingAsync(cancellationToken);
+            await _processor.DisposeAsync();
+            _processor = null;
+        }
+
+        if (_sessionProcessor != null)
+        {
+            await _sessionProcessor.StopProcessingAsync(cancellationToken);
+            await _sessionProcessor.DisposeAsync();
+            _sessionProcessor = null;
+        }
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Service Bus consumer stopped");
+        }
+    }
+
+    private async Task StartStandardProcessorAsync(
+        ServiceBusProcessorOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (_options.Value.EntityType == ServiceBusEntityType.Queue)
+        {
+            _processor = _client.CreateProcessor(_options.Value.Address, options);
+        }
+        else
+        {
+            if (string.IsNullOrEmpty(_options.Value.SubscriptionName))
+            {
+                throw new InvalidOperationException(
+                    "SubscriptionName is required when EntityType is Topic");
+            }
+
+            _processor = _client.CreateProcessor(
+                _options.Value.Address,
+                _options.Value.SubscriptionName,
+                options);
+        }
+
+        _processor.ProcessMessageAsync += ProcessMessageAsync;
+        _processor.ProcessErrorAsync += ProcessErrorAsync;
+
+        await _processor.StartProcessingAsync(cancellationToken);
+    }
+
+    private async Task StartSessionProcessorAsync(
+        ServiceBusProcessorOptions baseOptions,
+        CancellationToken cancellationToken)
+    {
+        var sessionOptions = new ServiceBusSessionProcessorOptions
+        {
+            AutoCompleteMessages = baseOptions.AutoCompleteMessages,
+            MaxConcurrentSessions = _options.Value.MaxConcurrency,
+            MaxConcurrentCallsPerSession = 1,
+            PrefetchCount = baseOptions.PrefetchCount,
+            ReceiveMode = baseOptions.ReceiveMode,
+            MaxAutoLockRenewalDuration = baseOptions.MaxAutoLockRenewalDuration
+        };
+
+        if (_options.Value.EntityType == ServiceBusEntityType.Queue)
+        {
+            _sessionProcessor = _client.CreateSessionProcessor(_options.Value.Address, sessionOptions);
+        }
+        else
+        {
+            if (string.IsNullOrEmpty(_options.Value.SubscriptionName))
+            {
+                throw new InvalidOperationException(
+                    "SubscriptionName is required when EntityType is Topic");
+            }
+
+            _sessionProcessor = _client.CreateSessionProcessor(
+                _options.Value.Address,
+                _options.Value.SubscriptionName,
+                sessionOptions);
+        }
+
+        _sessionProcessor.ProcessMessageAsync += ProcessSessionMessageAsync;
+        _sessionProcessor.ProcessErrorAsync += ProcessErrorAsync;
+
+        await _sessionProcessor.StartProcessingAsync(cancellationToken);
+    }
+
+    private ServiceBusProcessorOptions CreateProcessorOptions()
+    {
+        return new ServiceBusProcessorOptions
+        {
+            AutoCompleteMessages = _options.Value.AutoComplete,
+            MaxConcurrentCalls = _options.Value.MaxConcurrency,
+            PrefetchCount = _options.Value.PrefetchCount,
+            ReceiveMode = ServiceBusReceiveMode.PeekLock,
+            MaxAutoLockRenewalDuration = _options.Value.MessageLockDuration
+        };
+    }
+
+    private async Task ProcessMessageAsync(ProcessMessageEventArgs args)
+    {
+        var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
+        var deliveryCount = EnvelopeMapper.GetDeliveryCount(args.Message);
+        var transaction = EnvelopeMapper.CreateTransaction(args.Message);
+
+        await ProcessMessageCoreAsync(envelope, transaction, deliveryCount, args, args.CancellationToken);
+    }
+
+    private async Task ProcessSessionMessageAsync(ProcessSessionMessageEventArgs args)
+    {
+        var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
+        var deliveryCount = EnvelopeMapper.GetDeliveryCount(args.Message);
+        var transaction = EnvelopeMapper.CreateTransaction(args.Message);
+
+        await ProcessMessageCoreAsync(envelope, transaction, deliveryCount, args, args.CancellationToken);
+    }
+
+    private async Task ProcessMessageCoreAsync(
+        ITransportEnvelope envelope,
+        ITransportTransaction transaction,
+        int deliveryCount,
+        object args,
+        CancellationToken cancellationToken)
+    {
+        var context = new MessageContext
+        {
+            Envelope = envelope,
+            Transaction = transaction,
+            DeliveryCount = deliveryCount
+        };
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Processing message {MessageId} (Delivery count: {DeliveryCount})",
+                    envelope.MessageId,
+                    deliveryCount);
+            }
+
+            var result = await _pipeline.ProcessAsync(envelope, context, cancellationToken);
+
+            await HandleProcessingResultAsync(result, args, envelope, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Unhandled error processing message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            // Let Service Bus retry mechanism handle it
+            if (args is ProcessMessageEventArgs msgArgs && !_options.Value.AutoComplete)
+            {
+                await msgArgs.AbandonMessageAsync(msgArgs.Message, cancellationToken: cancellationToken);
+            }
+            else if (args is ProcessSessionMessageEventArgs sessionArgs && !_options.Value.AutoComplete)
+            {
+                await sessionArgs.AbandonMessageAsync(sessionArgs.Message, cancellationToken: cancellationToken);
+            }
+        }
+    }
+
+    private async Task HandleProcessingResultAsync(
+        MessageProcessingResult result,
+        object args,
+        ITransportEnvelope envelope,
+        CancellationToken cancellationToken)
+    {
+        if (_options.Value.AutoComplete)
+        {
+            // Auto-complete is enabled; Service Bus handles it
+            return;
+        }
+
+        switch (result)
+        {
+            case MessageProcessingResult.Success:
+                await CompleteMessageAsync(args, cancellationToken);
+                break;
+
+            case MessageProcessingResult.Retry:
+            case MessageProcessingResult.Abandon:
+                await AbandonMessageAsync(args, cancellationToken);
+                break;
+
+            case MessageProcessingResult.DeadLetter:
+                await DeadLetterMessageAsync(args, envelope, cancellationToken);
+                break;
+        }
+    }
+
+    private static async Task CompleteMessageAsync(object args, CancellationToken cancellationToken)
+    {
+        if (args is ProcessMessageEventArgs msgArgs)
+        {
+            await msgArgs.CompleteMessageAsync(msgArgs.Message, cancellationToken);
+        }
+        else if (args is ProcessSessionMessageEventArgs sessionArgs)
+        {
+            await sessionArgs.CompleteMessageAsync(sessionArgs.Message, cancellationToken);
+        }
+    }
+
+    private static async Task AbandonMessageAsync(object args, CancellationToken cancellationToken)
+    {
+        if (args is ProcessMessageEventArgs msgArgs)
+        {
+            await msgArgs.AbandonMessageAsync(msgArgs.Message, cancellationToken: cancellationToken);
+        }
+        else if (args is ProcessSessionMessageEventArgs sessionArgs)
+        {
+            await sessionArgs.AbandonMessageAsync(sessionArgs.Message, cancellationToken: cancellationToken);
+        }
+    }
+
+    private static async Task DeadLetterMessageAsync(
+        object args,
+        ITransportEnvelope envelope,
+        CancellationToken cancellationToken)
+    {
+        var reason = "Message processing failed";
+        var description = $"Message {envelope.MessageId} could not be processed";
+
+        if (args is ProcessMessageEventArgs msgArgs)
+        {
+            await msgArgs.DeadLetterMessageAsync(
+                msgArgs.Message,
+                reason,
+                description,
+                cancellationToken);
+        }
+        else if (args is ProcessSessionMessageEventArgs sessionArgs)
+        {
+            await sessionArgs.DeadLetterMessageAsync(
+                sessionArgs.Message,
+                reason,
+                description,
+                cancellationToken);
+        }
+    }
+
+    private Task ProcessErrorAsync(ProcessErrorEventArgs args)
+    {
+        if (_logger.IsEnabled(LogLevel.Error))
+        {
+            _logger.LogError(
+                args.Exception,
+                "Service Bus error in {Source}: {ErrorSource}",
+                args.EntityPath,
+                args.ErrorSource);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        await StopAsync();
+        _initLock.Dispose();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportPublisher.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportPublisher.cs
@@ -1,0 +1,207 @@
+using Azure.Messaging.ServiceBus;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.AzureServiceBus.Configuration;
+using HoneyDrunk.Transport.AzureServiceBus.Mapping;
+using HoneyDrunk.Transport.Telemetry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.AzureServiceBus;
+
+/// <summary>
+/// Azure Service Bus implementation of transport publisher.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ServiceBusTransportPublisher"/> class.
+/// </remarks>
+/// <param name="client">The Service Bus client.</param>
+/// <param name="options">The Azure Service Bus configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+public sealed class ServiceBusTransportPublisher(
+    ServiceBusClient client,
+    IOptions<AzureServiceBusOptions> options,
+    ILogger<ServiceBusTransportPublisher> logger) : ITransportPublisher, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client = client;
+    private readonly IOptions<AzureServiceBusOptions> _options = options;
+    private readonly ILogger<ServiceBusTransportPublisher> _logger = logger;
+    private ServiceBusSender? _sender;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public async Task PublishAsync(
+        ITransportEnvelope envelope,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        using var activity = TransportTelemetry.StartPublishActivity(envelope, destination);
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Publishing message {MessageId} to {Destination}",
+                    envelope.MessageId,
+                    destination.Address);
+            }
+
+            var serviceBusMessage = EnvelopeMapper.ToServiceBusMessage(envelope);
+
+            // Apply partition key if provided
+            if (destination.Properties.TryGetValue("PartitionKey", out var partitionKey))
+            {
+                serviceBusMessage.PartitionKey = partitionKey;
+            }
+
+            // Apply session ID if provided
+            if (destination.Properties.TryGetValue("SessionId", out var sessionId))
+            {
+                serviceBusMessage.SessionId = sessionId;
+            }
+
+            await _sender!.SendMessageAsync(serviceBusMessage, cancellationToken);
+
+            TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Successfully published message {MessageId}",
+                    envelope.MessageId);
+            }
+        }
+        catch (Exception ex)
+        {
+            TransportTelemetry.RecordError(activity, ex);
+
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to publish message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PublishBatchAsync(
+        IEnumerable<ITransportEnvelope> envelopes,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var messages = envelopes
+            .Select(envelope =>
+            {
+                var message = EnvelopeMapper.ToServiceBusMessage(envelope);
+
+                // Apply partition key if provided
+                if (destination.Properties.TryGetValue("PartitionKey", out var partitionKey))
+                {
+                    message.PartitionKey = partitionKey;
+                }
+
+                // Apply session ID if provided
+                if (destination.Properties.TryGetValue("SessionId", out var sessionId))
+                {
+                    message.SessionId = sessionId;
+                }
+
+                return message;
+            })
+            .ToList();
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Publishing batch of {Count} messages to {Destination}",
+                    messages.Count,
+                    destination.Address);
+            }
+
+            // Create a batch and send
+            using var messageBatch = await _sender!.CreateMessageBatchAsync(cancellationToken);
+
+            foreach (var message in messages)
+            {
+                if (!messageBatch.TryAddMessage(message))
+                {
+                    // If message doesn't fit, send current batch and create new one
+                    await _sender.SendMessagesAsync(messageBatch, cancellationToken);
+                    messageBatch.TryAddMessage(message);
+                }
+            }
+
+            if (messageBatch.Count > 0)
+            {
+                await _sender.SendMessagesAsync(messageBatch, cancellationToken);
+            }
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Successfully published batch");
+            }
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(ex, "Failed to publish batch");
+            }
+            throw;
+        }
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_sender != null)
+            return;
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_sender != null)
+                return;
+
+            var queueOrTopicName = _options.Value.Address;
+            _sender = _client.CreateSender(queueOrTopicName);
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Initialized Service Bus sender for {Entity}",
+                    queueOrTopicName);
+            }
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        if (_sender != null)
+        {
+            await _sender.DisposeAsync();
+        }
+
+        _initLock.Dispose();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,65 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace HoneyDrunk.Transport.InMemory.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering in-memory transport services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the HoneyDrunk in-memory transport implementation.
+    /// </summary>
+    public static ITransportBuilder AddHoneyDrunkInMemoryTransport(
+        this IServiceCollection services,
+        Action<TransportOptions>? configure = null)
+    {
+        // Ensure core transport services are registered
+        var builder = services.AddHoneyDrunkTransportCore();
+
+        // Register the in-memory broker as a singleton
+        services.TryAddSingleton<InMemoryBroker>();
+
+        // Register publisher and consumer
+        services.TryAddSingleton<ITransportPublisher, InMemoryTransportPublisher>();
+        services.TryAddSingleton<ITransportConsumer, InMemoryTransportConsumer>();
+
+        // Configure transport options
+        if (configure != null)
+        {
+            services.Configure(configure);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the HoneyDrunk in-memory transport with specific endpoint configuration.
+    /// </summary>
+    public static ITransportBuilder AddHoneyDrunkInMemoryTransport(
+        this IServiceCollection services,
+        string endpointName,
+        string address,
+        Action<TransportOptions>? configure = null)
+    {
+        return services.AddHoneyDrunkInMemoryTransport(options =>
+        {
+            options.EndpointName = endpointName;
+            options.Address = address;
+            configure?.Invoke(options);
+        });
+    }
+
+    /// <summary>
+    /// Extension to start the in-memory consumer from the builder.
+    /// </summary>
+    public static ITransportBuilder WithConsumer(this ITransportBuilder builder)
+    {
+        // Consumer is already registered; this is for fluent API completeness
+        return builder;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -4,6 +4,15 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HoneyDrunk.Transport\HoneyDrunk.Transport.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+  </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -5,6 +5,24 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Package Metadata -->
+    <PackageId>HoneyDrunk.Transport.InMemory</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <Description>In-memory transport implementation for HoneyDrunk.Transport. Provides observable queues and pub/sub subscriptions for testing without external dependencies.</Description>
+    <PackageReleaseNotes>v0.1.0: Initial release with InMemoryBroker supporting channel-based queues, pub/sub subscriptions, and in-process message routing for integration tests.</PackageReleaseNotes>
+    <PackageTags>messaging;transport;inmemory;testing;broker;queue;pubsub</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</PackageProjectUrl>
+
+    <!-- Symbol Package Configuration -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	  
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryBroker.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryBroker.cs
@@ -1,0 +1,166 @@
+using HoneyDrunk.Transport.Abstractions;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
+namespace HoneyDrunk.Transport.InMemory;
+
+/// <summary>
+/// In-memory message broker for local development and testing.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="InMemoryBroker"/> class.
+/// </remarks>
+/// <param name="logger">The logger instance.</param>
+public sealed class InMemoryBroker(ILogger<InMemoryBroker> logger)
+{
+    private readonly ConcurrentDictionary<string, Channel<ITransportEnvelope>> _queues = new();
+    private readonly ConcurrentDictionary<string, List<Func<ITransportEnvelope, CancellationToken, Task>>> _subscribers = new();
+    private readonly ILogger<InMemoryBroker> _logger = logger;
+
+    /// <summary>
+    /// Publishes a message to a queue.
+    /// </summary>
+    public async Task PublishAsync(
+        string address,
+        ITransportEnvelope envelope,
+        CancellationToken cancellationToken = default)
+    {
+        var queue = GetOrCreateQueue(address);
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Publishing message {MessageId} to address {Address}",
+                envelope.MessageId,
+                address);
+        }
+
+        await queue.Writer.WriteAsync(envelope, cancellationToken);
+
+        // Also notify any direct subscribers
+        if (_subscribers.TryGetValue(address, out var handlers))
+        {
+            foreach (var handler in handlers.ToList())
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await handler(envelope, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (_logger.IsEnabled(LogLevel.Error))
+                        {
+                            _logger.LogError(
+                                ex,
+                                "Error in subscriber for address {Address}",
+                                address);
+                        }
+                    }
+                }, cancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Subscribes to messages from an address.
+    /// </summary>
+    public void Subscribe(
+        string address,
+        Func<ITransportEnvelope, CancellationToken, Task> handler)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Subscribing to address {Address}", address);
+        }
+
+        var handlers = _subscribers.GetOrAdd(address, _ => []);
+        lock (handlers)
+        {
+            handlers.Add(handler);
+        }
+    }
+
+    /// <summary>
+    /// Starts consuming messages from an address.
+    /// </summary>
+    public async Task ConsumeAsync(
+        string address,
+        Func<ITransportEnvelope, CancellationToken, Task> handler,
+        CancellationToken cancellationToken = default)
+    {
+        var queue = GetOrCreateQueue(address);
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Started consuming from address {Address}", address);
+        }
+
+        await foreach (var envelope in queue.Reader.ReadAllAsync(cancellationToken))
+        {
+            try
+            {
+                await handler(envelope, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsEnabled(LogLevel.Error))
+                {
+                    _logger.LogError(
+                        ex,
+                        "Error processing message {MessageId} from address {Address}",
+                        envelope.MessageId,
+                        address);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current message count for an address.
+    /// </summary>
+    public int GetMessageCount(string address)
+    {
+        if (_queues.TryGetValue(address, out var queue))
+        {
+            return queue.Reader.Count;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Clears all messages from an address.
+    /// </summary>
+    public void ClearQueue(string address)
+    {
+        if (_queues.TryRemove(address, out var queue))
+        {
+            queue.Writer.Complete();
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Cleared queue for address {Address}", address);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or creates a queue for the specified address.
+    /// </summary>
+    private Channel<ITransportEnvelope> GetOrCreateQueue(string address)
+    {
+        return _queues.GetOrAdd(address, _ =>
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Creating queue for address {Address}", address);
+            }
+            return Channel.CreateUnbounded<ITransportEnvelope>(new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = false
+            });
+        });
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportConsumer.cs
@@ -1,0 +1,189 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.Pipeline;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.InMemory;
+
+/// <summary>
+/// In-memory implementation of transport consumer.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="InMemoryTransportConsumer"/> class.
+/// </remarks>
+/// <param name="broker">The in-memory message broker.</param>
+/// <param name="pipeline">The message processing pipeline.</param>
+/// <param name="options">The transport configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+public sealed class InMemoryTransportConsumer(
+    InMemoryBroker broker,
+    IMessagePipeline pipeline,
+    IOptions<TransportOptions> options,
+    ILogger<InMemoryTransportConsumer> logger) : ITransportConsumer
+{
+    private readonly InMemoryBroker _broker = broker;
+    private readonly IMessagePipeline _pipeline = pipeline;
+    private readonly IOptions<TransportOptions> _options = options;
+    private readonly ILogger<InMemoryTransportConsumer> _logger = logger;
+    private CancellationTokenSource? _cts;
+    private Task? _consumeTask;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cts != null)
+        {
+            throw new InvalidOperationException("Consumer is already started");
+        }
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Starting in-memory consumer for endpoint {EndpointName}",
+                _options.Value.EndpointName);
+        }
+
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        // Start multiple concurrent consumers based on MaxConcurrency
+        var tasks = new List<Task>();
+        for (int i = 0; i < _options.Value.MaxConcurrency; i++)
+        {
+            var consumerId = i;
+            var task = Task.Run(async () =>
+            {
+                await ConsumeMessagesAsync(consumerId, _cts.Token);
+            }, _cts.Token);
+            tasks.Add(task);
+        }
+
+        _consumeTask = Task.WhenAll(tasks);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cts == null)
+        {
+            return;
+        }
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Stopping in-memory consumer for endpoint {EndpointName}",
+                _options.Value.EndpointName);
+        }
+
+        _cts.Cancel();
+
+        if (_consumeTask != null)
+        {
+            try
+            {
+                await _consumeTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when stopping
+            }
+        }
+
+        _cts.Dispose();
+        _cts = null;
+        _consumeTask = null;
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Consumer stopped");
+        }
+    }
+
+    private async Task ConsumeMessagesAsync(int consumerId, CancellationToken cancellationToken)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Consumer {ConsumerId} started for address {Address}",
+                consumerId,
+                _options.Value.Address);
+        }
+
+        try
+        {
+            await _broker.ConsumeAsync(
+                _options.Value.Address,
+                async (envelope, ct) => await ProcessMessageAsync(envelope, ct),
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Consumer {ConsumerId} encountered an error",
+                    consumerId);
+            }
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Consumer {ConsumerId} stopped",
+                consumerId);
+        }
+    }
+
+    private async Task ProcessMessageAsync(ITransportEnvelope envelope, CancellationToken cancellationToken)
+    {
+        var context = new MessageContext
+        {
+            Envelope = envelope,
+            Transaction = NoOpTransportTransaction.Instance,
+            DeliveryCount = 1
+        };
+
+        try
+        {
+            var result = await _pipeline.ProcessAsync(envelope, context, cancellationToken);
+
+            if (result != MessageProcessingResult.Success)
+            {
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning(
+                        "Message {MessageId} processing returned {Result}",
+                        envelope.MessageId,
+                        result);
+                }
+
+                // In-memory transport doesn't support retry/DLQ, so we just log
+                if (result == MessageProcessingResult.Retry)
+                {
+                    // Could re-publish to the same queue for simple retry
+                    await _broker.PublishAsync(_options.Value.Address, envelope, cancellationToken);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to process message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            // In a real transport, this would trigger retry logic
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportPublisher.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportPublisher.cs
@@ -1,0 +1,78 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Telemetry;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Transport.InMemory;
+
+/// <summary>
+/// In-memory implementation of transport publisher.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="InMemoryTransportPublisher"/> class.
+/// </remarks>
+/// <param name="broker">The in-memory message broker.</param>
+/// <param name="logger">The logger instance.</param>
+public sealed class InMemoryTransportPublisher(
+    InMemoryBroker broker,
+    ILogger<InMemoryTransportPublisher> logger) : ITransportPublisher
+{
+    private readonly InMemoryBroker _broker = broker;
+    private readonly ILogger<InMemoryTransportPublisher> _logger = logger;
+
+    /// <inheritdoc />
+    public async Task PublishAsync(
+        ITransportEnvelope envelope,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = TransportTelemetry.StartPublishActivity(envelope, destination);
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Publishing message {MessageId} to {Destination}",
+                    envelope.MessageId,
+                    destination.Address);
+            }
+
+            await _broker.PublishAsync(destination.Address, envelope, cancellationToken);
+
+            TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Successfully published message {MessageId}",
+                    envelope.MessageId);
+            }
+        }
+        catch (Exception ex)
+        {
+            TransportTelemetry.RecordError(activity, ex);
+
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to publish message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PublishBatchAsync(
+        IEnumerable<ITransportEnvelope> envelopes,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var envelope in envelopes)
+        {
+            await PublishAsync(envelope, destination, cancellationToken);
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
@@ -5,13 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);NU1900</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);NU1900</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +17,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HoneyDrunk.Transport\HoneyDrunk.Transport.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Transport.InMemory\HoneyDrunk.Transport.InMemory.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Transport.AzureServiceBus\HoneyDrunk.Transport.AzureServiceBus.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
@@ -1,4 +1,13 @@
 <Solution>
+  <Folder Name="/Docs/">
+    <File Path="../README.md" />
+    <File Path=".github/copilot-instructions.md" />
+    <File Path="docs/FILE_GUIDE.md" />
+  </Folder>
+  <Folder Name="/Pipelines/">
+    <File Path=".github/workflows/publish.yml" />
+    <File Path=".github/workflows/validate-pr.yml" />
+  </Folder>
   <Project Path="HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj" />
   <Project Path="HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj" />
   <Project Path="HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj" />

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/EndpointAddress.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/EndpointAddress.cs
@@ -1,0 +1,55 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Default implementation of endpoint address.
+/// </summary>
+public sealed class EndpointAddress : IEndpointAddress
+{
+    /// <summary>
+    /// Gets or initializes the logical name of the endpoint.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or initializes the transport-specific address.
+    /// </summary>
+    public string Address { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or initializes the optional transport-specific properties.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Properties { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Creates an endpoint address with the specified name and address.
+    /// </summary>
+    /// <param name="name">The logical name.</param>
+    /// <param name="address">The physical address.</param>
+    /// <returns>A new endpoint address instance.</returns>
+    public static IEndpointAddress Create(string name, string address)
+    {
+        return new EndpointAddress
+        {
+            Name = name,
+            Address = address,
+            Properties = new Dictionary<string, string>()
+        };
+    }
+
+    /// <summary>
+    /// Creates an endpoint address with the specified name, address, and properties.
+    /// </summary>
+    /// <param name="name">The logical name.</param>
+    /// <param name="address">The physical address.</param>
+    /// <param name="properties">The transport-specific properties.</param>
+    /// <returns>A new endpoint address instance.</returns>
+    public static IEndpointAddress Create(string name, string address, IDictionary<string, string> properties)
+    {
+        return new EndpointAddress
+        {
+            Name = name,
+            Address = address,
+            Properties = new Dictionary<string, string>(properties)
+        };
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IEndpointAddress.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IEndpointAddress.cs
@@ -1,0 +1,22 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Represents a logical transport endpoint address.
+/// </summary>
+public interface IEndpointAddress
+{
+    /// <summary>
+    /// Gets the logical name of the endpoint.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the transport-specific address information (queue name, topic name, etc.).
+    /// </summary>
+    string Address { get; }
+
+    /// <summary>
+    /// Gets the optional transport-specific properties (partition key, session id, etc.).
+    /// </summary>
+    IReadOnlyDictionary<string, string> Properties { get; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageHandler.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageHandler.cs
@@ -1,0 +1,18 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Handles a specific message type.
+/// </summary>
+/// <typeparam name="TMessage">The message type to handle.</typeparam>
+public interface IMessageHandler<in TMessage>
+    where TMessage : class
+{
+    /// <summary>
+    /// Handles the message.
+    /// </summary>
+    /// <param name="message">The message to handle.</param>
+    /// <param name="context">The message context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task HandleAsync(TMessage message, MessageContext context, CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageReceiver.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageReceiver.cs
@@ -1,0 +1,19 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Receives and processes individual messages.
+/// </summary>
+public interface IMessageReceiver
+{
+    /// <summary>
+    /// Processes a received message envelope.
+    /// </summary>
+    /// <param name="envelope">The message envelope to process.</param>
+    /// <param name="transaction">The transaction context for this message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of processing the message.</returns>
+    Task<MessageProcessingResult> ReceiveAsync(
+        ITransportEnvelope envelope,
+        ITransportTransaction transaction,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageSerializer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/IMessageSerializer.cs
@@ -1,0 +1,38 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Serializes and deserializes message payloads.
+/// </summary>
+public interface IMessageSerializer
+{
+    /// <summary>
+    /// Gets the content type identifier for this serializer (e.g., "application/json").
+    /// </summary>
+    string ContentType { get; }
+
+    /// <summary>
+    /// Serializes a message to bytes.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to serialize.</typeparam>
+    /// <param name="message">The message instance.</param>
+    /// <returns>The serialized message as a byte array.</returns>
+    ReadOnlyMemory<byte> Serialize<TMessage>(TMessage message)
+        where TMessage : class;
+
+    /// <summary>
+    /// Deserializes bytes to a strongly-typed message.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to deserialize to.</typeparam>
+    /// <param name="payload">The serialized payload.</param>
+    /// <returns>The deserialized message instance.</returns>
+    TMessage Deserialize<TMessage>(ReadOnlyMemory<byte> payload)
+        where TMessage : class;
+
+    /// <summary>
+    /// Deserializes bytes to a message of the specified type.
+    /// </summary>
+    /// <param name="payload">The serialized payload.</param>
+    /// <param name="messageType">The target message type.</param>
+    /// <returns>The deserialized message instance.</returns>
+    object Deserialize(ReadOnlyMemory<byte> payload, Type messageType);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportConsumer.cs
@@ -1,0 +1,21 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Consumes messages from transport endpoints.
+/// </summary>
+public interface ITransportConsumer
+{
+    /// <summary>
+    /// Starts consuming messages from the configured endpoint.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops consuming messages gracefully.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task StopAsync(CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportEnvelope.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportEnvelope.cs
@@ -1,0 +1,57 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Represents a transport-agnostic message envelope that wraps all messages moving through the system.
+/// </summary>
+public interface ITransportEnvelope
+{
+    /// <summary>
+    /// Gets the unique identifier for this message instance.
+    /// </summary>
+    string MessageId { get; }
+
+    /// <summary>
+    /// Gets the identifier that groups related messages together (e.g., all messages in a workflow).
+    /// </summary>
+    string? CorrelationId { get; }
+
+    /// <summary>
+    /// Gets the identifier of the message that caused this message to be created.
+    /// </summary>
+    string? CausationId { get; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the message was created.
+    /// </summary>
+    DateTimeOffset Timestamp { get; }
+
+    /// <summary>
+    /// Gets the logical type or name of the message content.
+    /// </summary>
+    string MessageType { get; }
+
+    /// <summary>
+    /// Gets the custom headers for extensibility (routing hints, security tokens, etc.).
+    /// </summary>
+    IReadOnlyDictionary<string, string> Headers { get; }
+
+    /// <summary>
+    /// Gets the serialized message body.
+    /// </summary>
+    ReadOnlyMemory<byte> Payload { get; }
+
+    /// <summary>
+    /// Creates a new envelope with updated headers.
+    /// </summary>
+    /// <param name="additionalHeaders">Headers to add or update.</param>
+    /// <returns>A new envelope instance with the updated headers.</returns>
+    ITransportEnvelope WithHeaders(IDictionary<string, string> additionalHeaders);
+
+    /// <summary>
+    /// Creates a new envelope with updated correlation context.
+    /// </summary>
+    /// <param name="correlationId">The correlation identifier.</param>
+    /// <param name="causationId">The causation identifier.</param>
+    /// <returns>A new envelope instance with the updated correlation context.</returns>
+    ITransportEnvelope WithCorrelation(string? correlationId, string? causationId);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportPublisher.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportPublisher.cs
@@ -1,0 +1,31 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Publishes messages to transport endpoints.
+/// </summary>
+public interface ITransportPublisher
+{
+    /// <summary>
+    /// Publishes an envelope to a destination endpoint.
+    /// </summary>
+    /// <param name="envelope">The message envelope to publish.</param>
+    /// <param name="destination">The destination endpoint address.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task PublishAsync(
+        ITransportEnvelope envelope,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes multiple envelopes as a batch.
+    /// </summary>
+    /// <param name="envelopes">The collection of envelopes to publish.</param>
+    /// <param name="destination">The destination endpoint address.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task PublishBatchAsync(
+        IEnumerable<ITransportEnvelope> envelopes,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportTransaction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/ITransportTransaction.cs
@@ -1,0 +1,31 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Represents a transport-specific transaction context for message processing.
+/// </summary>
+public interface ITransportTransaction
+{
+    /// <summary>
+    /// Gets the unique identifier for this transaction context.
+    /// </summary>
+    string TransactionId { get; }
+
+    /// <summary>
+    /// Gets the transport-specific transaction context data.
+    /// </summary>
+    IReadOnlyDictionary<string, object> Context { get; }
+
+    /// <summary>
+    /// Commits the transaction, acknowledging successful message processing.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task CommitAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rolls back the transaction, typically abandoning the message for reprocessing.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task RollbackAsync(CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageContext.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageContext.cs
@@ -1,0 +1,27 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Context information available during message handling.
+/// </summary>
+public sealed class MessageContext
+{
+    /// <summary>
+    /// Gets or initializes the envelope containing metadata about the message.
+    /// </summary>
+    public required ITransportEnvelope Envelope { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the transaction context for this message.
+    /// </summary>
+    public required ITransportTransaction Transaction { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the number of delivery attempts for this message.
+    /// </summary>
+    public int DeliveryCount { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the additional context properties set by middleware.
+    /// </summary>
+    public Dictionary<string, object> Properties { get; init; } = [];
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageHandler.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageHandler.cs
@@ -1,0 +1,15 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Handler function for processing messages of a specific type.
+/// </summary>
+/// <typeparam name="TMessage">The message type.</typeparam>
+/// <param name="message">The message to process.</param>
+/// <param name="context">The message context.</param>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
+public delegate Task MessageHandler<in TMessage>(
+    TMessage message,
+    MessageContext context,
+    CancellationToken cancellationToken)
+    where TMessage : class;

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageProcessingResult.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/MessageProcessingResult.cs
@@ -1,0 +1,27 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Result of processing a message.
+/// </summary>
+public enum MessageProcessingResult
+{
+    /// <summary>
+    /// Message was successfully processed and should be acknowledged/completed.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// Message processing failed but should be retried.
+    /// </summary>
+    Retry,
+
+    /// <summary>
+    /// Message processing failed and should be moved to dead letter queue.
+    /// </summary>
+    DeadLetter,
+
+    /// <summary>
+    /// Message should be abandoned back to the queue.
+    /// </summary>
+    Abandon
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
@@ -1,0 +1,37 @@
+namespace HoneyDrunk.Transport.Abstractions;
+
+/// <summary>
+/// Default no-op transaction implementation for transports that don't support transactions.
+/// </summary>
+public sealed class NoOpTransportTransaction : ITransportTransaction
+{
+    /// <summary>
+    /// Gets the singleton instance of the no-op transaction.
+    /// </summary>
+    public static readonly ITransportTransaction Instance = new NoOpTransportTransaction();
+
+    /// <summary>
+    /// Prevents a default instance of the <see cref="NoOpTransportTransaction"/> class from being created.
+    /// </summary>
+    private NoOpTransportTransaction()
+    {
+    }
+
+    /// <inheritdoc/>
+    public string TransactionId => Guid.NewGuid().ToString();
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, object> Context => new Dictionary<string, object>();
+
+    /// <inheritdoc/>
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
@@ -10,18 +10,23 @@ public sealed class NoOpTransportTransaction : ITransportTransaction
     /// </summary>
     public static readonly ITransportTransaction Instance = new NoOpTransportTransaction();
 
+    private static readonly IReadOnlyDictionary<string, object> EmptyContext = new Dictionary<string, object>();
+
+    private readonly string _transactionId;
+
     /// <summary>
     /// Prevents a default instance of the <see cref="NoOpTransportTransaction"/> class from being created.
     /// </summary>
     private NoOpTransportTransaction()
     {
+        _transactionId = Guid.NewGuid().ToString();
     }
 
     /// <inheritdoc/>
-    public string TransactionId => Guid.NewGuid().ToString();
+    public string TransactionId => _transactionId;
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<string, object> Context => new Dictionary<string, object>();
+    public IReadOnlyDictionary<string, object> Context => EmptyContext;
 
     /// <inheritdoc/>
     public Task CommitAsync(CancellationToken cancellationToken = default)

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/BackoffStrategy.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/BackoffStrategy.cs
@@ -1,0 +1,22 @@
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Backoff strategy for retries.
+/// </summary>
+public enum BackoffStrategy
+{
+    /// <summary>
+    /// Fixed delay between retries.
+    /// </summary>
+    Fixed,
+
+    /// <summary>
+    /// Linear increase in delay.
+    /// </summary>
+    Linear,
+
+    /// <summary>
+    /// Exponential increase in delay.
+    /// </summary>
+    Exponential
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/ErrorHandlingAction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/ErrorHandlingAction.cs
@@ -1,0 +1,22 @@
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Action to take for a failed message.
+/// </summary>
+public enum ErrorHandlingAction
+{
+    /// <summary>
+    /// Retry processing the message.
+    /// </summary>
+    Retry,
+
+    /// <summary>
+    /// Move the message to the dead letter queue.
+    /// </summary>
+    DeadLetter,
+
+    /// <summary>
+    /// Abandon the message back to the queue.
+    /// </summary>
+    Abandon
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/ErrorHandlingDecision.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/ErrorHandlingDecision.cs
@@ -1,0 +1,47 @@
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Decision on how to handle a failed message.
+/// </summary>
+public sealed class ErrorHandlingDecision
+{
+    /// <summary>
+    /// Gets or initializes the action to take for the failed message.
+    /// </summary>
+    public required ErrorHandlingAction Action { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the optional retry delay.
+    /// </summary>
+    public TimeSpan? RetryDelay { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the optional reason for the decision.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Creates a retry decision with the specified delay.
+    /// </summary>
+    /// <param name="delay">The retry delay duration.</param>
+    /// <param name="reason">Optional reason for retry.</param>
+    /// <returns>An error handling decision.</returns>
+    public static ErrorHandlingDecision Retry(TimeSpan delay, string? reason = null)
+        => new() { Action = ErrorHandlingAction.Retry, RetryDelay = delay, Reason = reason };
+
+    /// <summary>
+    /// Creates a dead letter decision.
+    /// </summary>
+    /// <param name="reason">Optional reason for dead lettering.</param>
+    /// <returns>An error handling decision.</returns>
+    public static ErrorHandlingDecision DeadLetter(string? reason = null)
+        => new() { Action = ErrorHandlingAction.DeadLetter, Reason = reason };
+
+    /// <summary>
+    /// Creates an abandon decision.
+    /// </summary>
+    /// <param name="reason">Optional reason for abandoning.</param>
+    /// <returns>An error handling decision.</returns>
+    public static ErrorHandlingDecision Abandon(string? reason = null)
+        => new() { Action = ErrorHandlingAction.Abandon, Reason = reason };
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/IErrorHandlingStrategy.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/IErrorHandlingStrategy.cs
@@ -1,0 +1,19 @@
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Strategy for handling failed messages.
+/// </summary>
+public interface IErrorHandlingStrategy
+{
+    /// <summary>
+    /// Determines how to handle a failed message.
+    /// </summary>
+    /// <param name="exception">The exception that occurred.</param>
+    /// <param name="deliveryCount">The number of delivery attempts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The error handling decision.</returns>
+    Task<ErrorHandlingDecision> HandleErrorAsync(
+        Exception exception,
+        int deliveryCount,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/RetryOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/RetryOptions.cs
@@ -62,11 +62,12 @@ public sealed class RetryOptions
             delay = MaxDelay;
         }
 
-        // Add jitter if enabled
+        // Add jitter if enabled (±30% randomization)
         if (UseJitter)
         {
-            var jitter = Random.Shared.NextDouble() * 0.3; // ±30% jitter
-            delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * (1.0 + jitter - 0.15));
+            var jitter = Random.Shared.NextDouble(); // [0.0, 1.0)
+            var jitterMultiplier = 0.7 + (jitter * 0.6); // [0.7, 1.3) = ±30%
+            delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * jitterMultiplier);
         }
 
         return delay;

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/RetryOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/RetryOptions.cs
@@ -1,0 +1,74 @@
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Retry and backoff configuration.
+/// </summary>
+public sealed class RetryOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts.
+    /// </summary>
+    public int MaxAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the initial delay before first retry.
+    /// </summary>
+    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets the maximum delay between retries.
+    /// </summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Gets or sets the backoff strategy.
+    /// </summary>
+    public BackoffStrategy Strategy { get; set; } = BackoffStrategy.Exponential;
+
+    /// <summary>
+    /// Gets or sets the multiplier for exponential backoff.
+    /// </summary>
+    public double BackoffMultiplier { get; set; } = 2.0;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to add jitter to retry delays.
+    /// </summary>
+    public bool UseJitter { get; set; } = true;
+
+    /// <summary>
+    /// Calculates the delay for a given retry attempt.
+    /// </summary>
+    /// <param name="attempt">The attempt number (1-based).</param>
+    /// <returns>The calculated delay duration.</returns>
+    public TimeSpan CalculateDelay(int attempt)
+    {
+        if (attempt <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        TimeSpan delay = Strategy switch
+        {
+            BackoffStrategy.Fixed => InitialDelay,
+            BackoffStrategy.Linear => TimeSpan.FromMilliseconds(InitialDelay.TotalMilliseconds * attempt),
+            BackoffStrategy.Exponential => TimeSpan.FromMilliseconds(
+                InitialDelay.TotalMilliseconds * Math.Pow(BackoffMultiplier, attempt - 1)),
+            _ => InitialDelay
+        };
+
+        // Cap at max delay
+        if (delay > MaxDelay)
+        {
+            delay = MaxDelay;
+        }
+
+        // Add jitter if enabled
+        if (UseJitter)
+        {
+            var jitter = Random.Shared.NextDouble() * 0.3; // ±30% jitter
+            delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * (1.0 + jitter - 0.15));
+        }
+
+        return delay;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportCoreOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportCoreOptions.cs
@@ -1,0 +1,34 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Configuration for the transport core system.
+/// </summary>
+public sealed class TransportCoreOptions
+{
+    /// <summary>
+    /// Gets or sets the default serializer content type.
+    /// </summary>
+    public string DefaultSerializerType { get; set; } = "application/json";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable built-in telemetry.
+    /// </summary>
+    public bool EnableTelemetry { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable built-in logging middleware.
+    /// </summary>
+    public bool EnableLogging { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable correlation middleware.
+    /// </summary>
+    public bool EnableCorrelation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the global retry options (can be overridden per endpoint).
+    /// </summary>
+    public RetryOptions DefaultRetry { get; set; } = new();
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportCoreOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportCoreOptions.cs
@@ -1,5 +1,3 @@
-using HoneyDrunk.Transport.Abstractions;
-
 namespace HoneyDrunk.Transport.Configuration;
 
 /// <summary>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportOptions.cs
@@ -1,5 +1,3 @@
-using HoneyDrunk.Transport.Abstractions;
-
 namespace HoneyDrunk.Transport.Configuration;
 
 /// <summary>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Configuration/TransportOptions.cs
@@ -1,0 +1,54 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Configuration;
+
+/// <summary>
+/// Configuration options for a transport endpoint.
+/// </summary>
+public class TransportOptions
+{
+    /// <summary>
+    /// Gets or sets the logical name of the endpoint.
+    /// </summary>
+    public string EndpointName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the physical address (queue name, topic name, etc.).
+    /// </summary>
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent message processors.
+    /// </summary>
+    public int MaxConcurrency { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the prefetch count for message retrieval optimization.
+    /// </summary>
+    public int PrefetchCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the retry configuration.
+    /// </summary>
+    public RetryOptions Retry { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the message lock/visibility timeout.
+    /// </summary>
+    public TimeSpan MessageLockDuration { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically complete messages on success.
+    /// </summary>
+    public bool AutoComplete { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use sessions for ordered processing.
+    /// </summary>
+    public bool SessionEnabled { get; set; }
+
+    /// <summary>
+    /// Gets the additional transport-specific properties.
+    /// </summary>
+    public Dictionary<string, string> Properties { get; } = [];
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/IKernelContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/IKernelContextFactory.cs
@@ -1,0 +1,18 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Context;
+
+/// <summary>
+/// Factory for creating kernel context instances from transport envelopes.
+/// </summary>
+public interface IKernelContextFactory
+{
+    /// <summary>
+    /// Creates a kernel context from a transport envelope.
+    /// </summary>
+    /// <param name="envelope">The transport envelope.</param>
+    /// <param name="cancellationToken">The cancellation token for the operation.</param>
+    /// <returns>A new kernel context instance.</returns>
+    IKernelContext CreateFromEnvelope(ITransportEnvelope envelope, CancellationToken cancellationToken);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/KernelContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/KernelContextFactory.cs
@@ -1,0 +1,28 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Context;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Context;
+
+/// <summary>
+/// Default implementation of kernel context factory.
+/// </summary>
+public sealed class KernelContextFactory : IKernelContextFactory
+{
+    /// <inheritdoc />
+    public IKernelContext CreateFromEnvelope(ITransportEnvelope envelope, CancellationToken cancellationToken)
+    {
+        // Use CorrelationId from envelope, or generate from MessageId
+        var correlationId = envelope.CorrelationId ?? envelope.MessageId;
+
+        // Use CausationId from envelope, or use MessageId
+        var causationId = envelope.CausationId ?? envelope.MessageId;
+
+        // Create baggage from envelope headers
+        var baggage = envelope.Headers != null
+            ? new Dictionary<string, string>(envelope.Headers)
+            : [];
+
+        return new KernelContext(correlationId, causationId, baggage, cancellationToken);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/DelegateMessageHandler.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/DelegateMessageHandler.cs
@@ -1,0 +1,23 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Adapter for delegate-based message handlers.
+/// </summary>
+/// <typeparam name="TMessage">The message type.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="DelegateMessageHandler{TMessage}"/> class.
+/// </remarks>
+/// <param name="handler">The handler delegate.</param>
+internal sealed class DelegateMessageHandler<TMessage>(MessageHandler<TMessage> handler) : IMessageHandler<TMessage>
+    where TMessage : class
+{
+    private readonly MessageHandler<TMessage> _handler = handler;
+
+    /// <inheritdoc/>
+    public Task HandleAsync(TMessage message, MessageContext context, CancellationToken cancellationToken = default)
+    {
+        return _handler(message, context, cancellationToken);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/DelegateMessageMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/DelegateMessageMiddleware.cs
@@ -1,0 +1,26 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Pipeline;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Adapter for delegate-based middleware.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="DelegateMessageMiddleware"/> class.
+/// </remarks>
+/// <param name="middleware">The middleware delegate.</param>
+internal sealed class DelegateMessageMiddleware(MessageMiddleware middleware) : IMessageMiddleware
+{
+    private readonly MessageMiddleware _middleware = middleware;
+
+    /// <inheritdoc/>
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        return _middleware(envelope, context, next, cancellationToken);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ITransportBuilder.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ITransportBuilder.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Builder for configuring transport services.
+/// </summary>
+public interface ITransportBuilder
+{
+    /// <summary>
+    /// Gets the service collection.
+    /// </summary>
+    IServiceCollection Services { get; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/JsonMessageSerializer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/JsonMessageSerializer.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Default JSON serializer implementation.
+/// </summary>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
+internal sealed class JsonMessageSerializer : IMessageSerializer
+{
+    private readonly JsonSerializerOptions _options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <inheritdoc/>
+    public string ContentType => "application/json";
+
+    /// <inheritdoc/>
+    public ReadOnlyMemory<byte> Serialize<TMessage>(TMessage message)
+        where TMessage : class
+    {
+        return JsonSerializer.SerializeToUtf8Bytes(message, _options);
+    }
+
+    /// <inheritdoc/>
+    public TMessage Deserialize<TMessage>(ReadOnlyMemory<byte> payload)
+        where TMessage : class
+    {
+        return JsonSerializer.Deserialize<TMessage>(payload.Span, _options)
+            ?? throw new InvalidOperationException("Deserialization returned null");
+    }
+
+    /// <inheritdoc/>
+    public object Deserialize(ReadOnlyMemory<byte> payload, Type messageType)
+    {
+        return JsonSerializer.Deserialize(payload.Span, messageType, _options)
+            ?? throw new InvalidOperationException("Deserialization returned null");
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/NoOpMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/NoOpMiddleware.cs
@@ -1,0 +1,20 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Pipeline;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// No-op middleware for conditional registration.
+/// </summary>
+internal sealed class NoOpMiddleware : IMessageMiddleware
+{
+    /// <inheritdoc/>
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        return next();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
-using System.Text.Json;
+using HoneyDrunk.Kernel.DI;
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.Context;
 using HoneyDrunk.Transport.Pipeline;
 using HoneyDrunk.Transport.Pipeline.Middleware;
+using HoneyDrunk.Transport.Primitives;
 using HoneyDrunk.Transport.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -25,6 +27,9 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         Action<TransportCoreOptions>? configure = null)
     {
+        // Register Kernel defaults (Clock, IdGenerator, Context, Metrics)
+        services.AddKernelDefaults();
+
         // Configure options
         if (configure != null)
         {
@@ -34,6 +39,12 @@ public static class ServiceCollectionExtensions
         {
             services.Configure<TransportCoreOptions>(_ => { });
         }
+
+        // Register kernel context factory
+        services.TryAddSingleton<IKernelContextFactory, KernelContextFactory>();
+
+        // Register envelope factory
+        services.TryAddSingleton<EnvelopeFactory>();
 
         // Register default serializer
         services.TryAddSingleton<IMessageSerializer, JsonMessageSerializer>();

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.Pipeline;
+using HoneyDrunk.Transport.Pipeline.Middleware;
+using HoneyDrunk.Transport.Telemetry;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering transport services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the HoneyDrunk Transport core services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration action.</param>
+    /// <returns>A transport builder for fluent configuration.</returns>
+    public static ITransportBuilder AddHoneyDrunkTransportCore(
+        this IServiceCollection services,
+        Action<TransportCoreOptions>? configure = null)
+    {
+        // Configure options
+        if (configure != null)
+        {
+            services.Configure(configure);
+        }
+        else
+        {
+            services.Configure<TransportCoreOptions>(_ => { });
+        }
+
+        // Register default serializer
+        services.TryAddSingleton<IMessageSerializer, JsonMessageSerializer>();
+
+        // Register pipeline
+        services.TryAddSingleton<IMessagePipeline, MessagePipeline>();
+
+        // Register middleware collection
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IMessageMiddleware, CorrelationMiddleware>());
+
+        // Conditionally add telemetry and logging middleware
+        services.AddSingleton<IMessageMiddleware>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<TransportCoreOptions>>().Value;
+            return options.EnableTelemetry
+                ? new TelemetryMiddleware()
+                : new NoOpMiddleware();
+        });
+
+        services.AddSingleton<IMessageMiddleware>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<TransportCoreOptions>>().Value;
+            var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<LoggingMiddleware>>();
+            return options.EnableLogging
+                ? new LoggingMiddleware(logger)
+                : new NoOpMiddleware();
+        });
+
+        return new TransportBuilder(services);
+    }
+
+    /// <summary>
+    /// Registers a message handler.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type.</typeparam>
+    /// <typeparam name="THandler">The handler implementation type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMessageHandler<TMessage, THandler>(this IServiceCollection services)
+        where TMessage : class
+        where THandler : class, IMessageHandler<TMessage>
+    {
+        services.AddScoped<IMessageHandler<TMessage>, THandler>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a message handler using a delegate.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="handler">The handler delegate.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMessageHandler<TMessage>(
+        this IServiceCollection services,
+        MessageHandler<TMessage> handler)
+        where TMessage : class
+    {
+        services.AddScoped<IMessageHandler<TMessage>>(sp => new DelegateMessageHandler<TMessage>(handler));
+        return services;
+    }
+
+    /// <summary>
+    /// Adds custom middleware to the pipeline.
+    /// </summary>
+    /// <typeparam name="TMiddleware">The middleware type.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMessageMiddleware<TMiddleware>(this IServiceCollection services)
+        where TMiddleware : class, IMessageMiddleware
+    {
+        services.AddSingleton<IMessageMiddleware, TMiddleware>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds middleware using a delegate.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="middleware">The middleware delegate.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMessageMiddleware(
+        this IServiceCollection services,
+        MessageMiddleware middleware)
+    {
+        services.AddSingleton<IMessageMiddleware>(new DelegateMessageMiddleware(middleware));
+        return services;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/TransportBuilder.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/TransportBuilder.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Transport.DependencyInjection;
+
+/// <summary>
+/// Default implementation of transport builder.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="TransportBuilder"/> class.
+/// </remarks>
+/// <param name="services">The service collection.</param>
+internal sealed class TransportBuilder(IServiceCollection services) : ITransportBuilder
+{
+    /// <inheritdoc/>
+    public IServiceCollection Services { get; } = services;
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -5,6 +5,23 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Package Metadata -->
+    <PackageId>HoneyDrunk.Transport</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <Description>Transport-agnostic messaging library for .NET. Provides a unified abstraction layer over different message brokers with middleware pipeline pattern, retry strategies, and transactional outbox support.</Description>
+    <PackageReleaseNotes>v0.1.0: Initial release with core abstractions (ITransportPublisher, ITransportConsumer, ITransportEnvelope), middleware pipeline architecture, retry and error handling strategies, transactional outbox pattern, and dependency injection extensions.</PackageReleaseNotes>
+    <PackageTags>messaging;transport;broker;middleware;pipeline;outbox;retry;servicebus;distributed</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</PackageProjectUrl>
+
+    <!-- Symbol Package Configuration -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +30,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxDispatcher.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxDispatcher.cs
@@ -1,0 +1,17 @@
+namespace HoneyDrunk.Transport.Outbox;
+
+/// <summary>
+/// Dispatches outbox messages to the transport.
+/// </summary>
+public interface IOutboxDispatcher
+{
+    /// <summary>
+    /// Processes pending outbox messages and dispatches them.
+    /// </summary>
+    /// <param name="batchSize">Maximum number of messages to process.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DispatchPendingAsync(
+        int batchSize = 100,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxMessage.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxMessage.cs
@@ -1,0 +1,54 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Outbox;
+
+/// <summary>
+/// Represents an outbox message pending dispatch.
+/// </summary>
+public interface IOutboxMessage
+{
+    /// <summary>
+    /// Gets the unique identifier for the outbox record.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the destination endpoint for the message.
+    /// </summary>
+    IEndpointAddress Destination { get; }
+
+    /// <summary>
+    /// Gets the envelope to be sent.
+    /// </summary>
+    ITransportEnvelope Envelope { get; }
+
+    /// <summary>
+    /// Gets the current state of the outbox message.
+    /// </summary>
+    OutboxMessageState State { get; }
+
+    /// <summary>
+    /// Gets the number of dispatch attempts.
+    /// </summary>
+    int Attempts { get; }
+
+    /// <summary>
+    /// Gets the timestamp when the message was created.
+    /// </summary>
+    DateTimeOffset CreatedAt { get; }
+
+    /// <summary>
+    /// Gets the timestamp when the message was last processed.
+    /// </summary>
+    DateTimeOffset? ProcessedAt { get; }
+
+    /// <summary>
+    /// Gets the timestamp when to attempt next dispatch (for retry scenarios).
+    /// </summary>
+    DateTimeOffset? ScheduledAt { get; }
+
+    /// <summary>
+    /// Gets the error message if dispatch failed.
+    /// </summary>
+    string? ErrorMessage { get; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxStore.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/IOutboxStore.cs
@@ -1,0 +1,87 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Outbox;
+
+/// <summary>
+/// Storage abstraction for the transactional outbox pattern.
+/// </summary>
+public interface IOutboxStore
+{
+    /// <summary>
+    /// Saves an outgoing message to the outbox within a transaction.
+    /// </summary>
+    /// <param name="destination">The destination endpoint.</param>
+    /// <param name="envelope">The message envelope to save.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SaveAsync(
+        IEndpointAddress destination,
+        ITransportEnvelope envelope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves multiple outgoing messages as a batch within a transaction.
+    /// </summary>
+    /// <param name="messages">The collection of message tuples containing destination and envelope.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SaveBatchAsync(
+        IEnumerable<(IEndpointAddress destination, ITransportEnvelope envelope)> messages,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads pending messages ready for dispatch.
+    /// </summary>
+    /// <param name="batchSize">Maximum number of messages to load.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A collection of pending outbox messages.</returns>
+    Task<IEnumerable<IOutboxMessage>> LoadPendingAsync(
+        int batchSize = 100,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a message as successfully dispatched.
+    /// </summary>
+    /// <param name="outboxMessageId">The outbox message identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task MarkDispatchedAsync(
+        string outboxMessageId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a message as failed with error details and schedules retry.
+    /// </summary>
+    /// <param name="outboxMessageId">The outbox message identifier.</param>
+    /// <param name="errorMessage">The error message.</param>
+    /// <param name="retryAt">Optional timestamp for next retry attempt.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task MarkFailedAsync(
+        string outboxMessageId,
+        string errorMessage,
+        DateTimeOffset? retryAt = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a message as poisoned when it exceeds retry limits.
+    /// </summary>
+    /// <param name="outboxMessageId">The outbox message identifier.</param>
+    /// <param name="errorMessage">The error message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task MarkPoisonedAsync(
+        string outboxMessageId,
+        string errorMessage,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes old dispatched messages for cleanup.
+    /// </summary>
+    /// <param name="olderThan">Timestamp threshold for cleanup.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task CleanupDispatchedAsync(
+        DateTimeOffset olderThan,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/OutboxMessage.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/OutboxMessage.cs
@@ -1,0 +1,36 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Outbox;
+
+/// <summary>
+/// Default implementation of outbox message.
+/// </summary>
+public sealed class OutboxMessage : IOutboxMessage
+{
+    /// <inheritdoc/>
+    public required string Id { get; init; }
+
+    /// <inheritdoc/>
+    public required IEndpointAddress Destination { get; init; }
+
+    /// <inheritdoc/>
+    public required ITransportEnvelope Envelope { get; init; }
+
+    /// <inheritdoc/>
+    public OutboxMessageState State { get; init; }
+
+    /// <inheritdoc/>
+    public int Attempts { get; init; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset? ProcessedAt { get; init; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset? ScheduledAt { get; init; }
+
+    /// <inheritdoc/>
+    public string? ErrorMessage { get; init; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/OutboxMessageState.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Outbox/OutboxMessageState.cs
@@ -1,0 +1,32 @@
+namespace HoneyDrunk.Transport.Outbox;
+
+/// <summary>
+/// State of an outbox message.
+/// </summary>
+public enum OutboxMessageState
+{
+    /// <summary>
+    /// Message is pending dispatch.
+    /// </summary>
+    Pending,
+
+    /// <summary>
+    /// Message is currently being dispatched.
+    /// </summary>
+    Processing,
+
+    /// <summary>
+    /// Message was successfully dispatched.
+    /// </summary>
+    Dispatched,
+
+    /// <summary>
+    /// Message dispatch failed and is awaiting retry.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// Message has exceeded retry limits and is poisoned.
+    /// </summary>
+    Poisoned
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/IMessageMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/IMessageMiddleware.cs
@@ -1,0 +1,23 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Middleware component in the message processing pipeline.
+/// </summary>
+public interface IMessageMiddleware
+{
+    /// <summary>
+    /// Processes the envelope and invokes the next middleware in the pipeline.
+    /// </summary>
+    /// <param name="envelope">The message envelope.</param>
+    /// <param name="context">The message context.</param>
+    /// <param name="next">The next middleware delegate to invoke.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/IMessagePipeline.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/IMessagePipeline.cs
@@ -1,0 +1,21 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Executes a composable message processing pipeline.
+/// </summary>
+public interface IMessagePipeline
+{
+    /// <summary>
+    /// Processes an envelope through the pipeline.
+    /// </summary>
+    /// <param name="envelope">The message envelope to process.</param>
+    /// <param name="context">The message context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of processing the message.</returns>
+    Task<MessageProcessingResult> ProcessAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageHandlerException.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageHandlerException.cs
@@ -1,0 +1,37 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Exception thrown by message handlers to control processing outcome.
+/// </summary>
+public sealed class MessageHandlerException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageHandlerException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="result">The desired processing result.</param>
+    public MessageHandlerException(string message, MessageProcessingResult result)
+        : base(message)
+    {
+        Result = result;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageHandlerException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="result">The desired processing result.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public MessageHandlerException(string message, MessageProcessingResult result, Exception innerException)
+        : base(message, innerException)
+    {
+        Result = result;
+    }
+
+    /// <summary>
+    /// Gets the desired message processing result.
+    /// </summary>
+    public MessageProcessingResult Result { get; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageHandlerInvoker.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageHandlerInvoker.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Provides high-performance message handler invocation using compiled delegates.
+/// </summary>
+/// <remarks>
+/// This class caches compiled expression trees per message type to avoid reflection overhead
+/// on every message processing operation. The delegates are thread-safe and built lazily.
+/// </remarks>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MessageHandlerInvoker"/> class.
+/// </remarks>
+/// <param name="serviceProvider">The service provider for resolving handlers.</param>
+internal sealed class MessageHandlerInvoker(IServiceProvider serviceProvider)
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly ConcurrentDictionary<Type, Func<object, object, MessageContext, CancellationToken, Task>> _invokerCache = new();
+
+    /// <summary>
+    /// Invokes the message handler for the specified message type.
+    /// </summary>
+    /// <param name="message">The message instance to handle.</param>
+    /// <param name="messageType">The message type.</param>
+    /// <param name="context">The message context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation, or null if no handler is registered.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when message or messageType is null.</exception>
+    public Task? InvokeHandlerAsync(
+        object message,
+        Type messageType,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(messageType);
+
+        // Get or compile the invoker for this message type
+        var invoker = _invokerCache.GetOrAdd(messageType, BuildInvoker);
+
+        // Resolve the handler instance
+        var handlerType = typeof(IMessageHandler<>).MakeGenericType(messageType);
+        var handler = _serviceProvider.GetService(handlerType);
+
+        // Return null if no handler is registered
+        if (handler == null)
+        {
+            return null;
+        }
+
+        // Invoke the handler using the compiled delegate
+        return invoker(handler, message, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds a compiled delegate for invoking the handler's HandleAsync method.
+    /// </summary>
+    /// <param name="messageType">The message type.</param>
+    /// <returns>A compiled delegate that can invoke the handler.</returns>
+    private static Func<object, object, MessageContext, CancellationToken, Task> BuildInvoker(Type messageType)
+    {
+        // Create the handler interface type: IMessageHandler<TMessage>
+        var handlerInterfaceType = typeof(IMessageHandler<>).MakeGenericType(messageType);
+
+        // Get the HandleAsync method from the interface
+        var handleMethod = handlerInterfaceType.GetMethod(
+            nameof(IMessageHandler<>.HandleAsync),
+            [messageType, typeof(MessageContext), typeof(CancellationToken)])
+            ?? throw new InvalidOperationException(
+                $"HandleAsync method not found on {handlerInterfaceType.Name}");
+
+        // Create parameters for the expression
+        // Signature: (object handler, object message, MessageContext context, CancellationToken ct) => Task
+        var handlerParam = Expression.Parameter(typeof(object), "handler");
+        var messageParam = Expression.Parameter(typeof(object), "message");
+        var contextParam = Expression.Parameter(typeof(MessageContext), "context");
+        var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+
+        // Cast the handler to the correct interface type
+        var handlerCast = Expression.Convert(handlerParam, handlerInterfaceType);
+
+        // Cast the message to the correct message type
+        var messageCast = Expression.Convert(messageParam, messageType);
+
+        // Create the method call expression
+        var methodCall = Expression.Call(
+            handlerCast,
+            handleMethod,
+            messageCast,
+            contextParam,
+            cancellationTokenParam);
+
+        // Compile the expression into a delegate
+        var lambda = Expression.Lambda<Func<object, object, MessageContext, CancellationToken, Task>>(
+            methodCall,
+            handlerParam,
+            messageParam,
+            contextParam,
+            cancellationTokenParam);
+
+        return lambda.Compile();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessageMiddleware.cs
@@ -1,0 +1,17 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Function for message middleware processing.
+/// </summary>
+/// <param name="envelope">The message envelope.</param>
+/// <param name="context">The message context.</param>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>A task representing the asynchronous operation.</returns>
+public delegate Task MessageMiddleware(
+    ITransportEnvelope envelope,
+    MessageContext context,
+    Func<Task> next,
+    CancellationToken cancellationToken);

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessagePipeline.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/MessagePipeline.cs
@@ -1,0 +1,164 @@
+using HoneyDrunk.Transport.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Transport.Pipeline;
+
+/// <summary>
+/// Default implementation of the message processing pipeline.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MessagePipeline"/> class.
+/// </remarks>
+/// <param name="middlewares">The collection of middleware components.</param>
+/// <param name="serializer">The message serializer.</param>
+/// <param name="serviceProvider">The service provider for resolving handlers.</param>
+/// <param name="logger">The logger instance.</param>
+public sealed class MessagePipeline(
+    IEnumerable<IMessageMiddleware> middlewares,
+    IMessageSerializer serializer,
+    IServiceProvider serviceProvider,
+    ILogger<MessagePipeline> logger) : IMessagePipeline
+{
+    private readonly IEnumerable<IMessageMiddleware> _middlewares = middlewares;
+    private readonly IMessageSerializer _serializer = serializer;
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly ILogger<MessagePipeline> _logger = logger;
+
+    /// <inheritdoc/>
+    public async Task<MessageProcessingResult> ProcessAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Processing message {MessageId} of type {MessageType}",
+                    envelope.MessageId,
+                    envelope.MessageType);
+            }
+
+            // Build the pipeline with middleware
+            var pipeline = BuildPipeline(envelope, context, cancellationToken);
+
+            // Execute the pipeline
+            await pipeline();
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Successfully processed message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            return MessageProcessingResult.Success;
+        }
+        catch (MessageHandlerException ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Message handler error for {MessageId}: {ErrorMessage}",
+                    envelope.MessageId,
+                    ex.Message);
+            }
+
+            return ex.Result;
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Unexpected error processing message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            return MessageProcessingResult.Retry;
+        }
+    }
+
+    private static Type? ResolveMessageType(string typeName)
+    {
+        try
+        {
+            return Type.GetType(typeName, throwOnError: false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private Func<Task> BuildPipeline(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        // The final handler in the pipeline
+        Func<Task> handler = async () =>
+        {
+            await InvokeMessageHandlerAsync(envelope, context, cancellationToken);
+        };
+
+        // Apply middleware in reverse order
+        foreach (var middleware in _middlewares.Reverse())
+        {
+            var next = handler;
+            handler = () => middleware.InvokeAsync(envelope, context, next, cancellationToken);
+        }
+
+        return handler;
+    }
+
+    private async Task InvokeMessageHandlerAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        // Resolve the message type
+        var messageType = ResolveMessageType(envelope.MessageType) ?? throw new MessageHandlerException(
+                $"Cannot resolve message type: {envelope.MessageType}",
+                MessageProcessingResult.DeadLetter);
+
+        // Deserialize the message
+        object message;
+        try
+        {
+            message = _serializer.Deserialize(envelope.Payload, messageType);
+        }
+        catch (Exception ex)
+        {
+            throw new MessageHandlerException(
+                $"Failed to deserialize message: {ex.Message}",
+                MessageProcessingResult.DeadLetter,
+                ex);
+        }
+
+        // Resolve and invoke the handler
+        var handlerType = typeof(IMessageHandler<>).MakeGenericType(messageType);
+        var handler = _serviceProvider.GetService(handlerType);
+
+        if (handler == null)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "No handler registered for message type {MessageType}",
+                    envelope.MessageType);
+            }
+            return;
+        }
+
+        var handleMethod = handlerType.GetMethod(nameof(IMessageHandler<>.HandleAsync));
+        if (handleMethod != null)
+        {
+            var task = (Task)handleMethod.Invoke(handler, [message, context, cancellationToken])!;
+            await task;
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/CorrelationMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/CorrelationMiddleware.cs
@@ -1,0 +1,23 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Pipeline.Middleware;
+
+/// <summary>
+/// Middleware that enriches the message context with correlation information.
+/// </summary>
+public sealed class CorrelationMiddleware : IMessageMiddleware
+{
+    /// <inheritdoc/>
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        // Enrich context with correlation data
+        context.Properties["CorrelationId"] = envelope.CorrelationId ?? envelope.MessageId;
+        context.Properties["CausationId"] = envelope.CausationId ?? string.Empty;
+
+        return next();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/LoggingMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/LoggingMiddleware.cs
@@ -1,0 +1,42 @@
+using HoneyDrunk.Transport.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Transport.Pipeline.Middleware;
+
+/// <summary>
+/// Middleware that logs message processing activities.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="LoggingMiddleware"/> class.
+/// </remarks>
+/// <param name="logger">The logger instance.</param>
+public sealed class LoggingMiddleware(ILogger<LoggingMiddleware> logger) : IMessageMiddleware
+{
+    private readonly ILogger<LoggingMiddleware> _logger = logger;
+
+    /// <inheritdoc/>
+    public async Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Received message {MessageId} of type {MessageType} (CorrelationId: {CorrelationId})",
+                envelope.MessageId,
+                envelope.MessageType,
+                envelope.CorrelationId ?? "none");
+        }
+
+        await next();
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Completed processing message {MessageId}",
+                envelope.MessageId);
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/RetryMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/RetryMiddleware.cs
@@ -1,0 +1,43 @@
+using HoneyDrunk.Transport.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Transport.Pipeline.Middleware;
+
+/// <summary>
+/// Middleware that handles retries with exponential backoff.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="RetryMiddleware"/> class.
+/// </remarks>
+/// <param name="logger">The logger instance.</param>
+/// <param name="maxAttempts">Maximum number of retry attempts.</param>
+public sealed class RetryMiddleware(ILogger<RetryMiddleware> logger, int maxAttempts = 3) : IMessageMiddleware
+{
+    private readonly ILogger<RetryMiddleware> _logger = logger;
+    private readonly int _maxAttempts = maxAttempts;
+
+    /// <inheritdoc/>
+    public async Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        if (context.DeliveryCount > _maxAttempts)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "Message {MessageId} exceeded max retry attempts ({MaxAttempts})",
+                    envelope.MessageId,
+                    _maxAttempts);
+            }
+
+            throw new MessageHandlerException(
+                "Max retry attempts exceeded",
+                MessageProcessingResult.DeadLetter);
+        }
+
+        await next();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/EnvelopeFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/EnvelopeFactory.cs
@@ -1,3 +1,5 @@
+using HoneyDrunk.Kernel.Abstractions.Ids;
+using HoneyDrunk.Kernel.Abstractions.Time;
 using HoneyDrunk.Transport.Abstractions;
 
 namespace HoneyDrunk.Transport.Primitives;
@@ -5,8 +7,16 @@ namespace HoneyDrunk.Transport.Primitives;
 /// <summary>
 /// Factory for creating transport envelopes from typed messages.
 /// </summary>
-public static class EnvelopeFactory
+/// <remarks>
+/// Initializes a new instance of the <see cref="EnvelopeFactory"/> class.
+/// </remarks>
+/// <param name="idGenerator">The ID generator for creating message identifiers.</param>
+/// <param name="clock">The clock for timestamps.</param>
+public sealed class EnvelopeFactory(IIdGenerator idGenerator, IClock clock)
 {
+    private readonly IIdGenerator _idGenerator = idGenerator;
+    private readonly IClock _clock = clock;
+
     /// <summary>
     /// Creates an envelope from a typed message and serialized payload.
     /// </summary>
@@ -16,7 +26,7 @@ public static class EnvelopeFactory
     /// <param name="causationId">Optional causation identifier.</param>
     /// <param name="headers">Optional message headers.</param>
     /// <returns>A new transport envelope.</returns>
-    public static ITransportEnvelope CreateEnvelope<TMessage>(
+    public ITransportEnvelope CreateEnvelope<TMessage>(
         ReadOnlyMemory<byte> payload,
         string? correlationId = null,
         string? causationId = null,
@@ -25,10 +35,10 @@ public static class EnvelopeFactory
     {
         return new TransportEnvelope
         {
-            MessageId = Guid.NewGuid().ToString(),
+            MessageId = _idGenerator.NewString(),
             CorrelationId = correlationId,
             CausationId = causationId,
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = _clock.UtcNow,
             MessageType = typeof(TMessage).FullName ?? typeof(TMessage).Name,
             Headers = headers != null
                 ? new Dictionary<string, string>(headers)
@@ -47,7 +57,7 @@ public static class EnvelopeFactory
     /// <param name="causationId">Optional causation identifier.</param>
     /// <param name="headers">Optional message headers.</param>
     /// <returns>A new transport envelope.</returns>
-    public static ITransportEnvelope CreateEnvelopeWithId(
+    public ITransportEnvelope CreateEnvelopeWithId(
         string messageId,
         string messageType,
         ReadOnlyMemory<byte> payload,
@@ -60,7 +70,7 @@ public static class EnvelopeFactory
             MessageId = messageId,
             CorrelationId = correlationId,
             CausationId = causationId,
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = _clock.UtcNow,
             MessageType = messageType,
             Headers = headers != null
                 ? new Dictionary<string, string>(headers)
@@ -77,7 +87,7 @@ public static class EnvelopeFactory
     /// <param name="payload">The serialized reply payload.</param>
     /// <param name="additionalHeaders">Optional additional headers.</param>
     /// <returns>A new reply envelope.</returns>
-    public static ITransportEnvelope CreateReply(
+    public ITransportEnvelope CreateReply(
         ITransportEnvelope original,
         string replyMessageType,
         ReadOnlyMemory<byte> payload,
@@ -94,10 +104,10 @@ public static class EnvelopeFactory
 
         return new TransportEnvelope
         {
-            MessageId = Guid.NewGuid().ToString(),
+            MessageId = _idGenerator.NewString(),
             CorrelationId = original.CorrelationId ?? original.MessageId,
             CausationId = original.MessageId,
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = _clock.UtcNow,
             MessageType = replyMessageType,
             Headers = headers,
             Payload = payload

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/EnvelopeFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/EnvelopeFactory.cs
@@ -1,0 +1,106 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Primitives;
+
+/// <summary>
+/// Factory for creating transport envelopes from typed messages.
+/// </summary>
+public static class EnvelopeFactory
+{
+    /// <summary>
+    /// Creates an envelope from a typed message and serialized payload.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type.</typeparam>
+    /// <param name="payload">The serialized payload.</param>
+    /// <param name="correlationId">Optional correlation identifier.</param>
+    /// <param name="causationId">Optional causation identifier.</param>
+    /// <param name="headers">Optional message headers.</param>
+    /// <returns>A new transport envelope.</returns>
+    public static ITransportEnvelope CreateEnvelope<TMessage>(
+        ReadOnlyMemory<byte> payload,
+        string? correlationId = null,
+        string? causationId = null,
+        IDictionary<string, string>? headers = null)
+        where TMessage : class
+    {
+        return new TransportEnvelope
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            CorrelationId = correlationId,
+            CausationId = causationId,
+            Timestamp = DateTimeOffset.UtcNow,
+            MessageType = typeof(TMessage).FullName ?? typeof(TMessage).Name,
+            Headers = headers != null
+                ? new Dictionary<string, string>(headers)
+                : [],
+            Payload = payload
+        };
+    }
+
+    /// <summary>
+    /// Creates an envelope with a specified message ID.
+    /// </summary>
+    /// <param name="messageId">The message identifier.</param>
+    /// <param name="messageType">The message type name.</param>
+    /// <param name="payload">The serialized payload.</param>
+    /// <param name="correlationId">Optional correlation identifier.</param>
+    /// <param name="causationId">Optional causation identifier.</param>
+    /// <param name="headers">Optional message headers.</param>
+    /// <returns>A new transport envelope.</returns>
+    public static ITransportEnvelope CreateEnvelopeWithId(
+        string messageId,
+        string messageType,
+        ReadOnlyMemory<byte> payload,
+        string? correlationId = null,
+        string? causationId = null,
+        IDictionary<string, string>? headers = null)
+    {
+        return new TransportEnvelope
+        {
+            MessageId = messageId,
+            CorrelationId = correlationId,
+            CausationId = causationId,
+            Timestamp = DateTimeOffset.UtcNow,
+            MessageType = messageType,
+            Headers = headers != null
+                ? new Dictionary<string, string>(headers)
+                : [],
+            Payload = payload
+        };
+    }
+
+    /// <summary>
+    /// Creates a reply envelope derived from an original envelope.
+    /// </summary>
+    /// <param name="original">The original envelope to reply to.</param>
+    /// <param name="replyMessageType">The reply message type name.</param>
+    /// <param name="payload">The serialized reply payload.</param>
+    /// <param name="additionalHeaders">Optional additional headers.</param>
+    /// <returns>A new reply envelope.</returns>
+    public static ITransportEnvelope CreateReply(
+        ITransportEnvelope original,
+        string replyMessageType,
+        ReadOnlyMemory<byte> payload,
+        IDictionary<string, string>? additionalHeaders = null)
+    {
+        var headers = new Dictionary<string, string>(original.Headers);
+        if (additionalHeaders != null)
+        {
+            foreach (var kvp in additionalHeaders)
+            {
+                headers[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return new TransportEnvelope
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            CorrelationId = original.CorrelationId ?? original.MessageId,
+            CausationId = original.MessageId,
+            Timestamp = DateTimeOffset.UtcNow,
+            MessageType = replyMessageType,
+            Headers = headers,
+            Payload = payload
+        };
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/TransportEnvelope.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Primitives/TransportEnvelope.cs
@@ -1,0 +1,74 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Primitives;
+
+/// <summary>
+/// Default implementation of a transport envelope.
+/// </summary>
+public sealed class TransportEnvelope : ITransportEnvelope
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransportEnvelope"/> class.
+    /// </summary>
+    public TransportEnvelope()
+    {
+        Timestamp = DateTimeOffset.UtcNow;
+    }
+
+    /// <inheritdoc/>
+    public string MessageId { get; init; } = string.Empty;
+
+    /// <inheritdoc/>
+    public string? CorrelationId { get; init; }
+
+    /// <inheritdoc/>
+    public string? CausationId { get; init; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <inheritdoc/>
+    public string MessageType { get; init; } = string.Empty;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> Headers { get; init; } = new Dictionary<string, string>();
+
+    /// <inheritdoc/>
+    public ReadOnlyMemory<byte> Payload { get; init; }
+
+    /// <inheritdoc/>
+    public ITransportEnvelope WithHeaders(IDictionary<string, string> additionalHeaders)
+    {
+        var combined = new Dictionary<string, string>(Headers);
+        foreach (var kvp in additionalHeaders)
+        {
+            combined[kvp.Key] = kvp.Value;
+        }
+
+        return new TransportEnvelope
+        {
+            MessageId = MessageId,
+            CorrelationId = CorrelationId,
+            CausationId = CausationId,
+            Timestamp = Timestamp,
+            MessageType = MessageType,
+            Headers = combined,
+            Payload = Payload
+        };
+    }
+
+    /// <inheritdoc/>
+    public ITransportEnvelope WithCorrelation(string? correlationId, string? causationId)
+    {
+        return new TransportEnvelope
+        {
+            MessageId = MessageId,
+            CorrelationId = correlationId ?? CorrelationId,
+            CausationId = causationId ?? CausationId,
+            Timestamp = Timestamp,
+            MessageType = MessageType,
+            Headers = Headers,
+            Payload = Payload
+        };
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TelemetryMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TelemetryMiddleware.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Telemetry;
+
+/// <summary>
+/// Middleware that adds telemetry to message processing.
+/// </summary>
+public sealed class TelemetryMiddleware : Pipeline.IMessageMiddleware
+{
+    /// <inheritdoc/>
+    public async Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = TransportTelemetry.StartProcessActivity(envelope, "consumer");
+        TransportTelemetry.RecordDeliveryCount(activity, context.DeliveryCount);
+
+        try
+        {
+            await next();
+            TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+        }
+        catch (Exception ex)
+        {
+            TransportTelemetry.RecordError(activity, ex);
+            throw;
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TelemetryMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TelemetryMiddleware.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using HoneyDrunk.Transport.Abstractions;
 
 namespace HoneyDrunk.Transport.Telemetry;

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TransportTelemetry.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Telemetry/TransportTelemetry.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics;
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Telemetry;
+
+/// <summary>
+/// Telemetry and observability hooks for transport operations.
+/// </summary>
+public static class TransportTelemetry
+{
+    /// <summary>
+    /// Activity source name for transport telemetry.
+    /// </summary>
+    public const string ActivitySourceName = "HoneyDrunk.Transport";
+
+    /// <summary>
+    /// Activity source for creating spans.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName, "1.0.0");
+
+    /// <summary>
+    /// Creates a span for a publish operation.
+    /// </summary>
+    /// <param name="envelope">The message envelope being published.</param>
+    /// <param name="destination">The destination endpoint.</param>
+    /// <returns>An activity instance if telemetry is enabled; otherwise, null.</returns>
+    public static Activity? StartPublishActivity(ITransportEnvelope envelope, IEndpointAddress destination)
+    {
+        var activity = ActivitySource.StartActivity("publish", ActivityKind.Producer);
+        if (activity != null)
+        {
+            activity.SetTag(Tags.MessageId, envelope.MessageId);
+            activity.SetTag(Tags.MessageType, envelope.MessageType);
+            activity.SetTag(Tags.CorrelationId, envelope.CorrelationId);
+            activity.SetTag(Tags.CausationId, envelope.CausationId);
+            activity.SetTag(Tags.Destination, destination.Address);
+            activity.SetTag(Tags.Operation, "publish");
+            activity.SetTag(Tags.PayloadSize, envelope.Payload.Length);
+        }
+
+        return activity;
+    }
+
+    /// <summary>
+    /// Creates a span for a receive/process operation.
+    /// </summary>
+    /// <param name="envelope">The message envelope being processed.</param>
+    /// <param name="source">The source endpoint name.</param>
+    /// <returns>An activity instance if telemetry is enabled; otherwise, null.</returns>
+    public static Activity? StartProcessActivity(ITransportEnvelope envelope, string source)
+    {
+        var activity = ActivitySource.StartActivity("process", ActivityKind.Consumer);
+        if (activity != null)
+        {
+            activity.SetTag(Tags.MessageId, envelope.MessageId);
+            activity.SetTag(Tags.MessageType, envelope.MessageType);
+            activity.SetTag(Tags.CorrelationId, envelope.CorrelationId);
+            activity.SetTag(Tags.CausationId, envelope.CausationId);
+            activity.SetTag(Tags.Destination, source);
+            activity.SetTag(Tags.Operation, "process");
+            activity.SetTag(Tags.PayloadSize, envelope.Payload.Length);
+        }
+
+        return activity;
+    }
+
+    /// <summary>
+    /// Records the outcome of a message operation.
+    /// </summary>
+    /// <param name="activity">The activity to enrich.</param>
+    /// <param name="result">The processing result.</param>
+    public static void RecordOutcome(Activity? activity, MessageProcessingResult result)
+    {
+        activity?.SetTag(Tags.Outcome, result.ToString().ToLowerInvariant());
+
+        if (result != MessageProcessingResult.Success)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+        }
+    }
+
+    /// <summary>
+    /// Records an error in the activity.
+    /// </summary>
+    /// <param name="activity">The activity to enrich.</param>
+    /// <param name="exception">The exception that occurred.</param>
+    public static void RecordError(Activity? activity, Exception exception)
+    {
+        if (activity != null)
+        {
+            activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+            activity.SetTag(Tags.ErrorType, exception.GetType().FullName);
+            activity.SetTag(Tags.ErrorMessage, exception.Message);
+        }
+    }
+
+    /// <summary>
+    /// Records delivery count.
+    /// </summary>
+    /// <param name="activity">The activity to enrich.</param>
+    /// <param name="deliveryCount">The number of delivery attempts.</param>
+    public static void RecordDeliveryCount(Activity? activity, int deliveryCount)
+    {
+        activity?.SetTag(Tags.DeliveryCount, deliveryCount);
+    }
+
+    /// <summary>
+    /// Enriches an activity with custom tags.
+    /// </summary>
+    /// <param name="activity">The activity to enrich.</param>
+    /// <param name="tags">The custom tags to add.</param>
+    public static void EnrichActivity(Activity? activity, IDictionary<string, object?> tags)
+    {
+        if (activity == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in tags)
+        {
+            activity.SetTag(kvp.Key, kvp.Value);
+        }
+    }
+
+    /// <summary>
+    /// Telemetry tag names.
+    /// </summary>
+    public static class Tags
+    {
+        /// <summary>
+        /// Message identifier tag.
+        /// </summary>
+        public const string MessageId = "messaging.message.id";
+
+        /// <summary>
+        /// Message type tag.
+        /// </summary>
+        public const string MessageType = "messaging.message.type";
+
+        /// <summary>
+        /// Correlation identifier tag.
+        /// </summary>
+        public const string CorrelationId = "messaging.correlation.id";
+
+        /// <summary>
+        /// Causation identifier tag.
+        /// </summary>
+        public const string CausationId = "messaging.causation.id";
+
+        /// <summary>
+        /// Destination endpoint tag.
+        /// </summary>
+        public const string Destination = "messaging.destination";
+
+        /// <summary>
+        /// Operation type tag.
+        /// </summary>
+        public const string Operation = "messaging.operation";
+
+        /// <summary>
+        /// Delivery count tag.
+        /// </summary>
+        public const string DeliveryCount = "messaging.delivery.count";
+
+        /// <summary>
+        /// Payload size tag.
+        /// </summary>
+        public const string PayloadSize = "messaging.payload.size";
+
+        /// <summary>
+        /// Outcome tag.
+        /// </summary>
+        public const string Outcome = "messaging.outcome";
+
+        /// <summary>
+        /// Error type tag.
+        /// </summary>
+        public const string ErrorType = "error.type";
+
+        /// <summary>
+        /// Error message tag.
+        /// </summary>
+        public const string ErrorMessage = "error.message";
+    }
+}

--- a/HoneyDrunk.Transport/docs/FILE_GUIDE.md
+++ b/HoneyDrunk.Transport/docs/FILE_GUIDE.md
@@ -1,0 +1,1217 @@
+﻿# 📦 HoneyDrunk.Transport - Complete File Guide
+
+## Overview
+
+**Think of this library as a postal service for your application**
+
+Just like how the postal service lets you send letters without worrying about trucks, planes, or delivery routes, this library lets applications send messages without worrying about the underlying messaging technology.
+
+---
+
+## 🎯 HoneyDrunk.Transport (Core Project)
+
+*The main postal service headquarters with all the rules and tools*
+
+### 📋 Abstractions (Contracts/Interfaces)
+
+*These define "what" things should do, not "how" they do it*
+
+#### ITransportEnvelope.cs
+- **What it is:** The "envelope" that wraps around every message
+- **Real-world analogy:** Like a physical envelope with an address, return address, tracking number, and the letter inside
+- **What it contains:** Message ID, who sent it, what type of message, and the actual content
+- **How it's used:** Every message sent or received is wrapped in an envelope; you interact with it through `EnvelopeFactory.Create()`
+- **Why it matters:** Provides distributed tracing (correlation IDs), message routing (MessageType), and metadata (Headers) without coupling to transport specifics
+- **When to use:** You rarely construct this directly - use `EnvelopeFactory` instead. Access it in middleware or when inspecting messages
+- **Example:**
+  ```csharp
+  // Reading envelope properties in a handler
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      var envelope = context.Envelope;
+      _logger.LogInformation("Processing message {MessageId} with correlation {CorrelationId}", 
+          envelope.MessageId, envelope.CorrelationId);
+      // ... handle message
+  }
+  ```
+
+#### ITransportPublisher.cs
+- **What it is:** The "post office" that sends messages
+- **Real-world analogy:** The counter where you drop off your letters
+- **What it does:** Takes your message and sends it to the right destination
+- **How it's used:** Injected into your services to publish messages; abstracts the underlying broker (Azure Service Bus, RabbitMQ, etc.)
+- **Why it matters:** Decouples your application code from specific messaging infrastructure - swap transports without changing business logic
+- **When to use:** Anytime you need to send a message to another service or component
+- **Example:**
+  ```csharp
+  public class OrderService(ITransportPublisher publisher, EnvelopeFactory factory)
+  {
+      public async Task CreateOrderAsync(Order order, CancellationToken ct)
+      {
+          // Save order to database
+          await _repository.SaveAsync(order, ct);
+          
+          // Publish event
+          var message = new OrderCreated(order.Id, order.CustomerId);
+          var envelope = factory.Create(message, "orders");
+          await publisher.PublishAsync(envelope, ct);
+      }
+  ```
+  
+#### ITransportConsumer.cs
+- **What it is:** The "mailbox" that receives messages
+- **Real-world analogy:** Your home mailbox where letters arrive
+- **What it does:** Listens for incoming messages and processes them
+- **How it's used:** Registered by transport implementations (Azure Service Bus, InMemory) during startup; runs as background service
+- **Why it matters:** Handles message polling/listening and invokes the pipeline for processing
+- **When to use:** Implemented by transport providers, not typically used directly in application code
+- **Example:**
+  ```csharp
+  // Transport implementations use this
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options => /* ... */)
+      .WithTopicSubscription("my-subscription"); // Configures consumer
+  ```
+
+#### IMessageHandler.cs
+- **What it is:** The "mail handler" for specific types of messages
+- **Real-world analogy:** Like having different people handle bills vs. birthday cards
+- **What it does:** Defines how to process a specific type of message when it arrives
+- **How it's used:** Implement `IMessageHandler<TMessage>` for each message type you want to handle
+- **Why it matters:** Type-safe message handling with automatic deserialization and routing
+- **When to use:** Create one handler per message type that your service needs to process
+- **Example:**
+  ```csharp
+  public class OrderCreatedHandler(ILogger<OrderCreatedHandler> logger) : IMessageHandler<OrderCreated>
+  {
+      public async Task<MessageProcessingResult> HandleAsync(
+          OrderCreated message, 
+          MessageContext context, 
+          CancellationToken ct)
+      {
+          logger.LogInformation("Order {OrderId} created by customer {CustomerId}", 
+              message.OrderId, message.CustomerId);
+          
+          // Process the order
+          await ProcessOrderAsync(message, ct);
+          
+          return MessageProcessingResult.Success;
+      }
+  }
+  
+  // Register in DI
+  services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+  ```
+
+#### IMessageSerializer.cs
+- **What it is:** The "translator" for messages
+- **Real-world analogy:** Converting your spoken words into written text
+- **What it does:** Converts objects into bytes (for sending) and bytes back into objects (for receiving)
+- **How it's used:** Automatically invoked by the publisher/consumer to serialize/deserialize message payloads
+- **Why it matters:** Allows pluggable serialization (JSON, Protobuf, MessagePack) without changing message handling code
+- **When to use:** Use the default `JsonMessageSerializer` or implement custom for different formats (e.g., Protobuf for performance)
+- **Example:**
+  ```csharp
+  // Using default JSON serializer (automatic)
+  services.AddHoneyDrunkTransportCore(); // Registers JsonMessageSerializer
+  
+  // Custom serializer
+  public class ProtobufSerializer : IMessageSerializer
+  {
+      public ReadOnlyMemory<byte> Serialize<T>(T message) where T : class
+      {
+          // Protobuf serialization logic
+      }
+      
+      public T Deserialize<T>(ReadOnlyMemory<byte> data) where T : class
+      {
+          // Protobuf deserialization logic
+      }
+  }
+  
+  // Register custom
+  services.AddSingleton<IMessageSerializer, ProtobufSerializer>();
+  ```
+
+#### ITransportTransaction.cs
+- **What it is:** The "tracking system" for messages
+- **Real-world analogy:** Like certified mail with tracking and confirmation
+- **What it does:** Ensures messages are processed reliably with commit/rollback capabilities
+- **How it's used:** Available in `MessageContext.Transaction` - commit on success, rollback on failure
+- **Why it matters:** Enables reliable message processing - uncommitted messages return to queue for retry
+- **When to use:** Transports that support transactions (Azure Service Bus sessions); automatic handling by pipeline
+- **Example:**
+  ```csharp
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      try
+      {
+          await ProcessOrderAsync(message, ct);
+          await context.Transaction.CommitAsync(ct); // Mark as processed
+          return MessageProcessingResult.Success;
+      }
+      catch (Exception ex)
+      {
+          await context.Transaction.RollbackAsync(ct); // Return to queue
+          return MessageProcessingResult.Retry;
+      }
+  }
+  ```
+
+#### NoOpTransportTransaction.cs
+- **What it is:** A "fake" transaction for when you don't need tracking
+- **Real-world analogy:** Like regular mail without tracking
+- **What it does:** Does nothing, but satisfies the requirement to have a transaction
+- **How it's used:** Default transaction for non-transactional transports (InMemory, standard queues)
+- **Why it matters:** Allows transaction-aware code to work with non-transactional transports
+- **When to use:** Automatically used by transports without transaction support - you don't typically use this directly
+
+#### IEndpointAddress.cs / EndpointAddress.cs
+- **What it is:** The "mailing address" for messages
+- **Real-world analogy:** Like "123 Main St, City, State, ZIP"
+- **What it does:** Identifies where messages should go
+- **How it's used:** Passed to `PublishAsync()` to specify destination topic/queue
+- **Why it matters:** Type-safe routing without hardcoding queue names throughout code
+- **When to use:** When publishing to specific destinations or configuring consumers
+- **Example:**
+  ```csharp
+  var destination = new EndpointAddress("orders.created");
+  var envelope = factory.Create(message, destination);
+  await publisher.PublishAsync(envelope, ct);
+  
+  // Or use string overload (converts to EndpointAddress internally)
+  var envelope2 = factory.Create(message, "orders.created");
+  ```
+
+#### IMessageReceiver.cs
+- **What it is:** The "mail carrier" that delivers to handlers
+- **Real-world analogy:** The postal worker who puts mail in your mailbox
+- **What it does:** Receives messages and routes them to the right handler
+- **How it's used:** Internal component used by consumers to dispatch messages through the pipeline
+- **Why it matters:** Coordinates handler resolution, pipeline execution, and error handling
+- **When to use:** Implemented internally - not typically used directly in application code
+
+#### MessageContext.cs
+- **What it is:** The "delivery slip" with extra information
+- **Real-world analogy:** Like the metadata on a package (weight, date, sender notes)
+- **What it does:** Carries extra information about the message during processing
+- **How it's used:** Passed to handlers and middleware; access envelope, transaction, cancellation token, custom properties
+- **Why it matters:** Provides context for decision-making (retry attempts, tracing info, custom metadata)
+- **When to use:** Access in handlers/middleware to read envelope metadata or store custom state
+- **Example:**
+  ```csharp
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      // Access envelope
+      var messageId = context.Envelope.MessageId;
+      
+      // Store custom state for downstream middleware/handlers
+      context.Properties["ProcessedBy"] = "OrderService";
+      
+      // Access transaction
+      await context.Transaction.CommitAsync(ct);
+      
+      return MessageProcessingResult.Success;
+  }
+  ```
+
+#### MessageProcessingResult.cs
+- **What it is:** The "delivery status report"
+- **Real-world analogy:** "Delivered successfully" vs. "Address unknown - return to sender"
+- **What it does:** Tells the system what happened: Success, Retry, or DeadLetter (failed)
+- **How it's used:** Return from handlers to indicate outcome; determines if message is completed, retried, or moved to DLQ
+- **Why it matters:** Controls message lifecycle and retry behavior at the handler level
+- **When to use:** Return appropriate result from every handler based on processing outcome
+- **Example:**
+  ```csharp
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      try
+      {
+          await ProcessOrderAsync(message, ct);
+          return MessageProcessingResult.Success; // Remove from queue
+      }
+      catch (TransientException ex) // Database timeout, network issue
+      {
+          _logger.LogWarning(ex, "Transient error, will retry");
+          return MessageProcessingResult.Retry; // Return to queue for retry
+      }
+      catch (PoisonMessageException ex) // Invalid data, can't be processed
+      {
+          _logger.LogError(ex, "Poison message, moving to dead letter");
+          return MessageProcessingResult.DeadLetter; // Move to DLQ, no retry
+      }
+  }
+  ```
+
+#### MessageHandler.cs
+- **What it is:** A base class for message handlers
+- **Real-world analogy:** A template for how to handle different types of mail
+- **What it does:** Provides common functionality for all message handlers
+- **How it's used:** Optionally inherit from this instead of implementing `IMessageHandler<T>` directly for shared logic
+- **Why it matters:** Reduces boilerplate for common handler patterns (logging, error handling)
+- **When to use:** When you want shared behavior across handlers (e.g., automatic error logging)
+- **Example:**
+  ```csharp
+  public abstract class LoggingMessageHandler<T>(ILogger logger) : MessageHandler<T> where T : class
+  {
+      protected override async Task<MessageProcessingResult> HandleAsync(T message, MessageContext context, CancellationToken ct)
+      {
+          logger.LogInformation("Handling {MessageType}", typeof(T).Name);
+          try
+          {
+              var result = await HandleCoreAsync(message, context, ct);
+              logger.LogInformation("Handled {MessageType} with result {Result}", typeof(T).Name, result);
+              return result;
+          }
+          catch (Exception ex)
+          {
+              logger.LogError(ex, "Error handling {MessageType}", typeof(T).Name);
+              throw;
+          }
+      }
+      
+      protected abstract Task<MessageProcessingResult> HandleCoreAsync(T message, MessageContext context, CancellationToken ct);
+  }
+  ```
+
+---
+
+### 🔧 Primitives (Building Blocks)
+
+*Basic pieces that everything else uses*
+
+#### TransportEnvelope.cs
+- **What it is:** The actual implementation of the envelope
+- **Real-world analogy:** The physical envelope with all its properties filled in
+- **What it does:** Stores message ID, type, headers, payload, and correlation info
+- **How it's used:** Created by `EnvelopeFactory`; immutable with `With*()` methods for modifications
+- **Why it matters:** Immutable design prevents accidental mutations; rich metadata supports observability
+- **When to use:** Access properties in handlers/middleware; create modified copies with `WithHeaders()` or `WithCorrelation()`
+- **Example:**
+  ```csharp
+  // Add custom headers to envelope
+  var originalEnvelope = factory.Create(message, "orders");
+  var enrichedEnvelope = originalEnvelope.WithHeaders(new Dictionary<string, string>
+  {
+      ["TenantId"] = "tenant-123",
+      ["Priority"] = "high"
+  });
+  await publisher.PublishAsync(enrichedEnvelope, ct);
+  
+  // Read headers in handler
+  if (context.Envelope.Headers.TryGetValue("TenantId", out var tenantId))
+  {
+      _logger.LogInformation("Processing for tenant {TenantId}", tenantId);
+  }
+  ```
+
+#### EnvelopeFactory.cs
+- **What it is:** The "envelope maker"
+- **Real-world analogy:** Like a machine that pre-prints envelopes with tracking numbers
+- **What it does:** Creates new envelopes with auto-generated IDs and timestamps
+- **How it's used:** Inject and call `Create()` to wrap messages; depends on `IIdGenerator` and `IClock` from Kernel
+- **Why it matters:** Ensures consistent ID generation and timestamping; testable via Kernel abstractions
+- **When to use:** Always use this to create envelopes - never construct `TransportEnvelope` directly
+- **Example:**
+  ```csharp
+  public class OrderService(EnvelopeFactory factory, ITransportPublisher publisher)
+  {
+      public async Task PublishOrderCreatedAsync(Order order, CancellationToken ct)
+      {
+          var message = new OrderCreated(order.Id, order.CustomerId);
+          
+          // Factory generates unique MessageId and Timestamp
+          var envelope = factory.Create(message, "orders.created");
+          
+          // Optional: set correlation for request tracing
+          var correlatedEnvelope = envelope.WithCorrelation(
+              correlationId: _contextAccessor.CorrelationId,
+              causationId: _contextAccessor.RequestId
+          );
+          
+          await publisher.PublishAsync(correlatedEnvelope, ct);
+      }
+  }
+  ```
+
+---
+
+### ⚙️ Configuration (Settings)
+
+*All the knobs and switches to control behavior*
+
+#### TransportCoreOptions.cs
+- **What it is:** The main settings panel
+- **Real-world analogy:** The control panel for your postal service
+- **What it does:** Enables/disables telemetry, logging, correlation tracking
+- **How it's used:** Configure via `IOptions<TransportCoreOptions>` or builder pattern
+- **Why it matters:** Controls built-in middleware (correlation, telemetry, logging) without code changes
+- **When to use:** Configure during startup to enable/disable features globally
+- **Example:**
+  ```csharp
+  services.AddHoneyDrunkTransportCore(options =>
+  {
+      options.EnableTelemetry = true;  // OpenTelemetry integration
+      options.EnableLogging = true;    // Structured logging
+      options.EnableCorrelation = true; // Correlation ID propagation
+  });
+  ```
+
+#### TransportOptions.cs
+- **What it is:** General transport settings
+- **Real-world analogy:** Basic settings like "how long to keep messages"
+- **What it does:** Configuration for transport-specific behaviors
+- **How it's used:** Extended by specific transport implementations (Azure Service Bus, etc.)
+- **Why it matters:** Provides common configuration baseline for all transports
+- **When to use:** Base for transport-specific options classes
+
+#### RetryOptions.cs
+- **What it is:** The "retry policy" settings
+- **Real-world analogy:** "Try to deliver 3 times, wait 1 second, then 2, then 4..."
+- **What it does:** Controls how many times to retry failed messages and how long to wait
+- **How it's used:** Configure via builder `.WithRetry()` or options binding
+- **Why it matters:** Handles transient failures (network blips, temporary outages) without manual intervention
+- **When to use:** Always configure retry for production - prevents message loss during temporary failures
+- **Example:**
+  ```csharp
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options => /* ... */)
+      .WithRetry(retry =>
+      {
+          retry.MaxAttempts = 5;
+          retry.InitialDelay = TimeSpan.FromSeconds(1);
+          retry.BackoffStrategy = BackoffStrategy.Exponential; // 1s, 2s, 4s, 8s, 16s
+          retry.MaxDelay = TimeSpan.FromMinutes(1); // Cap exponential growth
+      });
+  ```
+
+#### BackoffStrategy.cs
+- **What it is:** The "wait time calculator" strategies
+- **Real-world analogy:** Fixed wait, or increasing wait times (1 sec, 2 sec, 4 sec...)
+- **What it does:** Defines: Fixed, Linear, or Exponential backoff
+- **How it's used:** Set in `RetryOptions.BackoffStrategy`
+- **Why it matters:** Controls retry timing - exponential prevents overwhelming failing services
+- **When to use:** 
+  - **Fixed**: Predictable retry timing (testing, simple scenarios)
+  - **Linear**: Gradual increase (moderate load)
+  - **Exponential**: Rapid backoff (production, avoid thundering herd)
+- **Example:**
+  ```csharp
+  // Fixed: 1s, 1s, 1s, 1s, 1s
+  retry.BackoffStrategy = BackoffStrategy.Fixed;
+  
+  // Linear: 1s, 2s, 3s, 4s, 5s
+  retry.BackoffStrategy = BackoffStrategy.Linear;
+  
+  // Exponential: 1s, 2s, 4s, 8s, 16s (best for production)
+  retry.BackoffStrategy = BackoffStrategy.Exponential;
+  ```
+
+#### IErrorHandlingStrategy.cs
+- **What it is:** The "error response plan"
+- **Real-world analogy:** "What do we do when mail can't be delivered?"
+- **What it does:** Decides whether to retry, dead-letter, or ignore errors
+- **How it's used:** Implement custom error handling logic based on exception type/context
+- **Why it matters:** Allows sophisticated error handling (e.g., retry transient, DLQ permanent errors)
+- **When to use:** Implement custom when default retry logic isn't sufficient
+- **Example:**
+  ```csharp
+  public class CustomErrorStrategy : IErrorHandlingStrategy
+  {
+      public ErrorHandlingDecision Decide(Exception exception, MessageContext context, int attemptCount)
+      {
+          return exception switch
+          {
+              SqlException { Number: -2 } => // Timeout
+                  new ErrorHandlingDecision(ErrorHandlingAction.Retry, TimeSpan.FromSeconds(5)),
+              
+              ValidationException => // Bad data
+                  new ErrorHandlingDecision(ErrorHandlingAction.DeadLetter),
+              
+              _ => attemptCount < 3 
+                  ? new ErrorHandlingDecision(ErrorHandlingAction.Retry, TimeSpan.FromSeconds(attemptCount * 2))
+                  : new ErrorHandlingDecision(ErrorHandlingAction.DeadLetter)
+          };
+      }
+  }
+  
+  services.AddSingleton<IErrorHandlingStrategy, CustomErrorStrategy>();
+  ```
+
+#### ErrorHandlingAction.cs
+- **What it is:** The possible error actions
+- **Real-world analogy:** "Retry", "Return to sender", or "Destroy"
+- **What it does:** Enum defining possible error handling actions
+- **How it's used:** Returned by `IErrorHandlingStrategy` to indicate desired action
+- **Why it matters:** Type-safe error handling decisions
+- **When to use:** Use in custom error handling strategies
+
+#### ErrorHandlingDecision.cs
+- **What it is:** The decision object for errors
+- **Real-world analogy:** A delivery slip saying what to do with undeliverable mail
+- **What it does:** Contains the action to take and optional delay
+- **How it's used:** Returned by `IErrorHandlingStrategy.Decide()`
+- **Why it matters:** Couples action with delay for time-based retry strategies
+- **When to use:** Return from custom error handling strategies
+
+---
+
+### 🔄 Pipeline (Processing Chain)
+
+*The assembly line that processes messages*
+
+#### IMessagePipeline.cs / MessagePipeline.cs
+- **What it is:** The message processing assembly line
+- **Real-world analogy:** Like a factory conveyor belt where each station does something
+- **What it does:** Runs messages through middleware, then to handlers
+- **How it's used:** Automatically invoked by consumers; middleware registered via DI wraps handlers in onion pattern
+- **Why it matters:** Provides cross-cutting concerns (logging, telemetry, retry) without modifying handlers
+- **When to use:** Register custom middleware during startup; pipeline execution is automatic
+- **Example:**
+  ```csharp
+  // Pipeline execution order (automatic):
+  // Correlation → Telemetry → Logging → CustomMiddleware1 → CustomMiddleware2 → Handler
+  
+  // Register custom middleware
+  services.AddMessageMiddleware<AuthorizationMiddleware>();
+  services.AddMessageMiddleware<ValidationMiddleware>();
+  
+  // Middleware wraps in reverse registration order (LIFO)
+  ```
+
+#### IMessageMiddleware.cs / MessageMiddleware.cs
+- **What it is:** One station on the assembly line
+- **Real-world analogy:** Like quality control stations on a factory line
+- **What it does:** Intercepts messages before they reach handlers (logging, validation, etc.)
+- **How it's used:** Implement `IMessageMiddleware` and register with `AddMessageMiddleware<T>()`
+- **Why it matters:** DRY principle - implement cross-cutting concerns once instead of in every handler
+- **When to use:** For logic that applies to multiple message types (auth, validation, enrichment)
+- **Example:**
+  ```csharp
+  public class TenantResolutionMiddleware(ITenantResolver resolver) : IMessageMiddleware
+  {
+      public async Task InvokeAsync(
+          ITransportEnvelope envelope,
+          MessageContext context,
+          Func<Task> next,
+          CancellationToken ct)
+      {
+          // Extract tenant from headers
+          if (envelope.Headers.TryGetValue("TenantId", out var tenantId))
+          {
+              var tenant = await resolver.ResolveAsync(tenantId, ct);
+              context.Properties["Tenant"] = tenant;
+          }
+          
+          // Continue pipeline
+          await next();
+      }
+  }
+  
+  // Register
+  services.AddMessageMiddleware<TenantResolutionMiddleware>();
+  ```
+
+#### MessageHandlerException.cs
+- **What it is:** A special error for message handling problems
+- **Real-world analogy:** A "delivery failed" notice with reason
+- **What it does:** Wraps exceptions with a processing result
+- **How it's used:** Throw from handlers to control error handling without try/catch in pipeline
+- **Why it matters:** Allows handlers to signal retry/dead-letter intent via exceptions
+- **When to use:** When you want to throw an exception but control the processing result
+- **Example:**
+  ```csharp
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      if (message.OrderId <= 0)
+      {
+          // Throw with explicit dead-letter intent
+          throw new MessageHandlerException(
+              "Invalid OrderId - cannot be zero or negative",
+              MessageProcessingResult.DeadLetter);
+      }
+      
+      try
+      {
+          await ProcessOrderAsync(message, ct);
+          return MessageProcessingResult.Success;
+      }
+      catch (DbException ex) when (ex.IsTransient)
+      {
+          // Throw with retry intent
+          throw new MessageHandlerException("Database timeout", ex, MessageProcessingResult.Retry);
+      }
+  }
+  ```
+
+#### Pipeline/Middleware (Built-in Assembly Line Stations)
+
+**CorrelationMiddleware.cs**
+- **What it is:** The "tracking number manager"
+- **Real-world analogy:** Stamps tracking numbers on packages
+- **What it does:** Adds correlation IDs to track messages across systems
+- **How it's used:** Automatically registered when `TransportCoreOptions.EnableCorrelation = true`
+- **Why it matters:** Enables distributed tracing across service boundaries
+- **When to use:** Enable in production for request tracing and debugging
+- **Example:**
+  ```csharp
+  // Correlation flow:
+  // 1. Service A publishes with CorrelationId "abc-123"
+  // 2. Service B receives message, CorrelationMiddleware extracts "abc-123"
+  // 3. Service B logs with "abc-123", all logs correlated
+  // 4. Service B publishes new message with same CorrelationId
+  // 5. Entire request chain traceable via "abc-123"
+  
+  // Access in handler
+  var correlationId = context.Envelope.CorrelationId;
+  _logger.LogInformation("Processing order in correlation {CorrelationId}", correlationId);
+  ```
+
+**LoggingMiddleware.cs**
+- **What it is:** The "activity logger"
+- **Real-world analogy:** Security camera recording all deliveries
+- **What it does:** Logs when messages arrive, succeed, or fail
+- **How it's used:** Automatically registered when `TransportCoreOptions.EnableLogging = true`
+- **Why it matters:** Automatic structured logging for all messages without handler changes
+- **When to use:** Enable in production for observability and troubleshooting
+- **Example:**
+  ```csharp
+  // Automatic logs (no code needed):
+  // [INFO] Received message OrderCreated with ID abc-123
+  // [INFO] Successfully processed OrderCreated with ID abc-123 in 45ms
+  // [ERROR] Failed to process OrderCreated with ID abc-123: Database timeout
+  
+  services.AddHoneyDrunkTransportCore(options =>
+  {
+      options.EnableLogging = true; // Enables LoggingMiddleware
+  });
+  ```
+
+**RetryMiddleware.cs**
+- **What it is:** The "retry coordinator"
+- **Real-world analogy:** Automatically re-attempts failed deliveries
+- **What it does:** Catches failures and retries messages based on policy
+- **How it's used:** Automatically registered when retry configuration is present
+- **Why it matters:** Resilience against transient failures without manual retry logic
+- **When to use:** Always configure for production - handles network blips, temporary outages
+- **Example:**
+  ```csharp
+  // Retry happens automatically based on MessageProcessingResult
+  public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+  {
+      try
+      {
+          await ProcessOrderAsync(message, ct);
+          return MessageProcessingResult.Success; // No retry
+      }
+      catch (TimeoutException)
+      {
+          return MessageProcessingResult.Retry; // RetryMiddleware handles backoff
+      }
+  }
+  
+  // Configure retry policy
+  services.AddHoneyDrunkTransportCore()
+      .WithRetry(retry =>
+      {
+          retry.MaxAttempts = 3;
+          retry.BackoffStrategy = BackoffStrategy.Exponential;
+      });
+  ```
+
+---
+
+### 📊 Telemetry (Monitoring)
+
+*The dashboard that shows what's happening*
+
+#### TransportTelemetry.cs
+- **What it is:** The monitoring system
+- **Real-world analogy:** Like UPS tracking showing where packages are
+- **What it does:** Records metrics, traces, and events for observability
+- **How it's used:** Static helper for creating OpenTelemetry activities; automatically called by telemetry middleware
+- **Why it matters:** Integrates with APM tools (Application Insights, Jaeger, Zipkin) for distributed tracing
+- **When to use:** Enable via `TransportCoreOptions.EnableTelemetry = true`; automatic in middleware/consumers
+- **Example:**
+  ```csharp
+  // Automatic telemetry when enabled:
+  // - Activity spans for publish/consume operations
+  // - Metrics: message count, processing duration, error rate
+  // - Traces: distributed tracing across services
+  
+  services.AddHoneyDrunkTransportCore(options =>
+  {
+      options.EnableTelemetry = true; // Integrates with OpenTelemetry
+  });
+  
+  // In Application Insights:
+  // ├─ transport.publish (45ms)
+  // │  └─ transport.consume (120ms)
+  // │     ├─ transport.middleware.correlation (2ms)
+  // │     ├─ transport.middleware.telemetry (1ms)
+  // │     └─ transport.handler.OrderCreated (115ms)
+  ```
+
+#### TelemetryMiddleware.cs
+- **What it is:** The telemetry station in the pipeline
+- **Real-world analogy:** The scanner that beeps when packages pass through
+- **What it does:** Automatically records telemetry for every message
+- **How it's used:** Automatically registered when `TransportCoreOptions.EnableTelemetry = true`
+- **Why it matters:** Zero-code instrumentation for all message processing
+- **When to use:** Enable in production for APM integration
+
+---
+
+### 📤 Outbox (Transactional Messaging)
+
+*The "guarantee delivery" system*
+
+#### IOutboxStore.cs
+- **What it is:** The database for storing messages before sending
+- **Real-world analogy:** A safe where you store important letters until the post office opens
+- **What it does:** Saves messages in your database as part of a transaction
+- **How it's used:** Implement against your database (EF Core, Dapper, etc.); save messages in same transaction as business logic
+- **Why it matters:** Guarantees exactly-once message delivery even if publish fails after database commit
+- **When to use:** Critical workflows where message loss is unacceptable (payments, orders, account changes)
+- **Example:**
+  ```csharp
+  // Entity Framework implementation
+  public class EfCoreOutboxStore(ApplicationDbContext db) : IOutboxStore
+  {
+      public async Task SaveAsync(IOutboxMessage message, CancellationToken ct)
+      {
+          await db.OutboxMessages.AddAsync(new OutboxMessageEntity
+          {
+              MessageId = message.MessageId,
+              Payload = message.Payload.ToArray(),
+              // ... map other properties
+          }, ct);
+          // Don't call SaveChangesAsync - parent transaction handles it
+      }
+      
+      public async Task<IEnumerable<IOutboxMessage>> LoadPendingAsync(int batchSize, CancellationToken ct)
+      {
+          return await db.OutboxMessages
+              .Where(m => m.State == OutboxMessageState.Pending)
+              .Take(batchSize)
+              .ToListAsync(ct);
+      }
+      
+      // ... other methods
+  }
+  
+  // Usage in service
+  public class OrderService(ApplicationDbContext db, IOutboxStore outbox, EnvelopeFactory factory)
+  {
+      public async Task CreateOrderAsync(Order order, CancellationToken ct)
+      {
+          using var transaction = await db.Database.BeginTransactionAsync(ct);
+          
+          // Save order
+          db.Orders.Add(order);
+          
+          // Save message to outbox (same transaction)
+          var message = new OrderCreated(order.Id, order.CustomerId);
+          var envelope = factory.Create(message, "orders.created");
+          await outbox.SaveAsync(new OutboxMessage(envelope), ct);
+          
+          await db.SaveChangesAsync(ct);
+          await transaction.CommitAsync(ct);
+          
+          // Background dispatcher will publish later
+      }
+  }
+  ```
+
+#### IOutboxDispatcher.cs
+- **What it is:** The background worker that sends stored messages
+- **Real-world analogy:** A postal worker who checks the safe and mails everything
+- **What it does:** Polls the store and publishes pending messages
+- **How it's used:** Run as background service (IHostedService); polls store at intervals
+- **Why it matters:** Completes the outbox pattern by ensuring messages eventually get published
+- **When to use:** Required when using outbox pattern; typically one instance per application
+- **Example:**
+  ```csharp
+  public class OutboxDispatcherService(
+      IOutboxStore store,
+      ITransportPublisher publisher,
+      ILogger<OutboxDispatcherService> logger) : BackgroundService
+  {
+      protected override async Task ExecuteAsync(CancellationToken ct)
+      {
+          while (!ct.IsCancellationRequested)
+          {
+              try
+              {
+                  var pending = await store.LoadPendingAsync(100, ct);
+                  
+                  foreach (var message in pending)
+                  {
+                      await publisher.PublishAsync(message.Envelope, ct);
+                      await store.MarkDispatchedAsync(message.MessageId, ct);
+                  }
+              }
+              catch (Exception ex)
+              {
+                  logger.LogError(ex, "Error dispatching outbox messages");
+              }
+              
+              await Task.Delay(TimeSpan.FromSeconds(5), ct); // Poll interval
+          }
+      }
+  }
+  
+  // Register
+  services.AddHostedService<OutboxDispatcherService>();
+  ```
+
+#### IOutboxMessage.cs / OutboxMessage.cs
+- **What it is:** A message stored in the outbox
+- **Real-world analogy:** A letter in the safe with a sticky note about when to send it
+- **What it does:** Wraps a message with state (pending, dispatched, failed)
+- **How it's used:** Created when saving to outbox; tracks lifecycle through states
+- **Why it matters:** Tracks message state for reliable delivery and failure handling
+- **When to use:** Created automatically when using outbox pattern
+
+#### OutboxMessageState.cs
+- **What it is:** The state of a stored message
+- **Real-world analogy:** "Waiting to send", "Sent", "Failed", "Poisoned (give up)"
+- **What it does:** Enum tracking message lifecycle in the outbox
+- **How it's used:** Updated by dispatcher as messages are processed
+- **Why it matters:** Prevents infinite retry loops (Poisoned state after max attempts)
+- **When to use:** Track in your outbox store implementation
+- **Example:**
+  ```csharp
+  public enum OutboxMessageState
+  {
+      Pending,    // Waiting to be dispatched
+      Dispatched, // Successfully published
+      Failed,     // Temporary failure, will retry
+      Poisoned    // Permanent failure after max retries exceeded
+  }
+  
+  // State transitions:
+  // Pending → Dispatched (success)
+  // Pending → Failed → Pending (retry)
+  // Pending → Failed → Poisoned (max retries exceeded)
+  ```
+
+---
+
+### 🔌 DependencyInjection (Setup Helpers)
+
+*The toolbox for setting up the postal service*
+
+#### ServiceCollectionExtensions.cs
+- **What it is:** The "setup wizard"
+- **Real-world analogy:** Like a guided setup for installing software
+- **What it does:** Provides easy methods to configure the transport system
+- **How it's used:** Call extension methods on `IServiceCollection` during startup
+- **Why it matters:** Fluent API makes configuration discoverable and type-safe
+- **When to use:** Every application using HoneyDrunk.Transport starts here
+- **Example:**
+  ```csharp
+  // Program.cs or Startup.cs
+  services.AddHoneyDrunkTransportCore(options =>
+  {
+      options.EnableTelemetry = true;
+      options.EnableLogging = true;
+      options.EnableCorrelation = true;
+  })
+  .AddHoneyDrunkServiceBusTransport(options =>
+  {
+      options.ConnectionString = configuration["AzureServiceBus:ConnectionString"];
+      options.TopicName = "orders";
+  })
+  .WithTopicSubscription("order-processor")
+  .WithRetry(retry =>
+  {
+      retry.MaxAttempts = 5;
+      retry.BackoffStrategy = BackoffStrategy.Exponential;
+  });
+  
+  // Register handlers
+  services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+  services.AddMessageHandler<OrderCancelled, OrderCancelledHandler>();
+  ```
+
+#### ITransportBuilder.cs / TransportBuilder.cs
+- **What it is:** The "configuration builder"
+- **Real-world analogy:** A form you fill out step-by-step to configure your postal service
+- **What it does:** Fluent API for chaining configuration calls
+- **How it's used:** Returned by `AddHoneyDrunkTransportCore()` for method chaining
+- **Why it matters:** Enables fluent configuration pattern
+- **When to use:** Automatic - returned by setup methods
+
+#### DelegateMessageHandler.cs
+- **What it is:** A quick way to handle messages with a function
+- **Real-world analogy:** "Just tell me what to do when this type of mail arrives"
+- **What it does:** Wraps a simple function as a message handler
+- **How it's used:** Use `AddMessageHandler<T>()` overload with lambda/function
+- **Why it matters:** Quick prototyping without creating full handler classes
+- **When to use:** Simple handlers, prototyping, or when handler logic is trivial
+- **Example:**
+  ```csharp
+  // Delegate handler (no class needed)
+  services.AddMessageHandler<OrderCreated>(async (message, context, ct) =>
+  {
+      _logger.LogInformation("Order {OrderId} created", message.OrderId);
+      await ProcessOrderAsync(message, ct);
+      return MessageProcessingResult.Success;
+  });
+  
+  // vs. Full handler class
+  public class OrderCreatedHandler : IMessageHandler<OrderCreated>
+  {
+      public async Task<MessageProcessingResult> HandleAsync(/* ... */) { /* ... */ }
+  }
+  services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+  ```
+
+#### DelegateMessageMiddleware.cs
+- **What it is:** A quick way to add middleware with a function
+- **Real-world analogy:** "Add this step to the assembly line"
+- **What it does:** Wraps a simple function as middleware
+- **How it's used:** Use `AddMessageMiddleware()` with lambda/function
+- **Why it matters:** Quick middleware without creating full classes
+- **When to use:** Simple cross-cutting concerns or prototyping
+- **Example:**
+  ```csharp
+  // Delegate middleware (no class needed)
+  services.AddMessageMiddleware(async (envelope, context, next, ct) =>
+  {
+      var sw = Stopwatch.StartNew();
+      await next();
+      _logger.LogInformation("Processing took {ElapsedMs}ms", sw.ElapsedMilliseconds);
+  });
+  ```
+
+#### NoOpMiddleware.cs
+- **What it is:** A middleware that does nothing
+- **Real-world analogy:** An empty station on the assembly line
+- **What it does:** Placeholder middleware when you need one but it doesn't do anything
+- **How it's used:** Internal/testing - you typically won't use this directly
+- **Why it matters:** Satisfies middleware requirements in tests or optional configurations
+- **When to use:** Testing or when conditional middleware is disabled
+
+#### JsonMessageSerializer.cs
+- **What it is:** JSON-based message translator
+- **Real-world analogy:** Converts messages to/from JSON format
+- **What it does:** Default serializer using System.Text.Json
+- **How it's used:** Automatically registered; override with custom serializer if needed
+- **Why it matters:** Human-readable format, widely compatible, good default choice
+- **When to use:** Default for most scenarios; replace with Protobuf/MessagePack for performance-critical systems
+- **Example:**
+  ```csharp
+  // Default (automatic)
+  services.AddHoneyDrunkTransportCore(); // Uses JsonMessageSerializer
+  
+  // Custom JSON options
+  services.AddSingleton<IMessageSerializer>(sp =>
+      new JsonMessageSerializer(new JsonSerializerOptions
+      {
+          PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+          WriteIndented = false
+      }));
+  ```
+
+---
+
+### 🧠 Context (Application State)
+
+*System for carrying information through the pipeline*
+
+#### IKernelContextFactory.cs / KernelContextFactory.cs
+- **What it is:** Factory for creating execution contexts
+- **Real-world analogy:** Like a form that gets passed along with each package
+- **What it does:** Creates context objects that carry state through message processing
+- **How it's used:** Internal component creating `MessageContext` instances
+- **Why it matters:** Integrates with HoneyDrunk.Kernel for consistent context propagation
+- **When to use:** Used internally - not typically interacted with directly
+
+---
+
+## 🧪 HoneyDrunk.Transport.InMemory
+
+*The "toy postal service" for testing*
+
+### InMemoryBroker.cs
+- **What it is:** A fake message broker that runs in memory
+- **Real-world analogy:** Like a toy postal system for testing - mail goes in one end, comes out the other
+- **What it does:** Manages queues and subscriptions in memory without external services
+- **How it's used:** Registered via `AddHoneyDrunkInMemoryTransport()`; runs in same process
+- **Why it matters:** Fast integration tests without Azure Service Bus or other infrastructure
+- **When to use:** Unit/integration tests, local development, CI/CD pipelines
+- **Example:**
+  ```csharp
+  // Test setup
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkInMemoryTransport(); // No connection strings needed
+  
+  // Test can publish and consume in-process
+  [Fact]
+  public async Task ProcessesOrderCreatedMessage()
+  {
+      await _publisher.PublishAsync(envelope, ct);
+      await Task.Delay(100); // Give consumer time to process
+      
+      // Assert handler was called
+      _mockHandler.Verify(h => h.HandleAsync(It.IsAny<OrderCreated>(), It.IsAny<MessageContext>(), It.IsAny<CancellationToken>()));
+  }
+  ```
+
+### InMemoryTransportPublisher.cs
+- **What it is:** The "post office" for the in-memory system
+- **Real-world analogy:** The send counter at the toy post office
+- **What it does:** Publishes messages to the in-memory broker
+- **How it's used:** Injected as `ITransportPublisher`; identical API to real transports
+- **Why it matters:** Test code is identical to production code
+- **When to use:** Automatically used when InMemory transport is registered
+
+### InMemoryTransportConsumer.cs
+- **What it is:** The "mailbox" for the in-memory system
+- **Real-world analogy:** The receive station at the toy post office
+- **What it does:** Consumes messages from the in-memory broker
+- **How it's used:** Runs as background service, processes messages through pipeline
+- **Why it matters:** Full pipeline execution in tests (middleware, handlers, etc.)
+- **When to use:** Automatically started when InMemory transport is registered
+
+### DependencyInjection/ServiceCollectionExtensions.cs
+- **What it is:** Setup wizard for in-memory transport
+- **Real-world analogy:** "Click here to use the toy postal system"
+- **What it does:** Registers in-memory transport with your application
+- **How it's used:** Call `AddHoneyDrunkInMemoryTransport()` in test startup
+- **Why it matters:** One-line switch from real transport to in-memory for tests
+- **When to use:** Test projects, local development
+- **Example:**
+  ```csharp
+  // Production (Startup.cs)
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options => /* ... */);
+  
+  // Tests (TestStartup.cs)
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkInMemoryTransport(); // Drop-in replacement
+  ```
+
+---
+
+## ☁️ HoneyDrunk.Transport.AzureServiceBus
+
+*The "real postal service" using Microsoft Azure*
+
+### ServiceBusTransportPublisher.cs
+- **What it is:** The Azure Service Bus sender
+- **Real-world analogy:** The interface to FedEx/UPS for sending packages
+- **What it does:** Publishes messages to real Azure Service Bus topics/queues
+- **How it's used:** Injected as `ITransportPublisher`; converts envelopes to ServiceBusMessage
+- **Why it matters:** Production-grade message delivery with Azure's reliability guarantees
+- **When to use:** Production deployments requiring durable messaging
+- **Example:**
+  ```csharp
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options =>
+      {
+          options.ConnectionString = configuration["AzureServiceBus:ConnectionString"];
+          options.TopicName = "orders";
+      });
+  
+  // Publisher uses Azure Service Bus automatically
+  await _publisher.PublishAsync(envelope, ct); // Sends to Azure
+  ```
+
+### ServiceBusTransportConsumer.cs
+- **What it is:** The Azure Service Bus receiver
+- **Real-world analogy:** The interface that receives packages from FedEx/UPS
+- **What it does:** Listens to Azure Service Bus and processes incoming messages
+- **How it's used:** Runs as background service; supports queues, topics, sessions
+- **Why it matters:** Reliable message reception with automatic lock renewal and dead-lettering
+- **When to use:** Production deployments consuming from Azure Service Bus
+- **Example:**
+  ```csharp
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options => /* ... */)
+      .WithTopicSubscription("order-processor") // Consumer listens to subscription
+      .WithSessions(); // Enable session support if needed
+  ```
+
+### Configuration/AzureServiceBusOptions.cs
+- **What it is:** Settings specific to Azure Service Bus
+- **Real-world analogy:** Your FedEx account settings (connection string, retry policy)
+- **What it does:** Configures connection strings, topic names, subscriptions, sessions
+- **How it's used:** Configure via builder or IOptions binding
+- **Why it matters:** Centralizes Azure-specific settings
+- **When to use:** Configure during startup for Azure deployments
+- **Example:**
+  ```csharp
+  // appsettings.json
+  {
+    "AzureServiceBus": {
+      "ConnectionString": "Endpoint=sb://...",
+      "TopicName": "orders",
+      "SubscriptionName": "order-processor",
+      "EnableSessions": false,
+      "MaxConcurrentCalls": 10,
+      "PrefetchCount": 100
+    }
+  }
+  
+  // Startup
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(
+          configuration.GetSection("AzureServiceBus"));
+  ```
+
+### Mapping/EnvelopeMapper.cs
+- **What it is:** The "format converter"
+- **Real-world analogy:** Converts your internal envelope format to Azure's package format
+- **What it does:** Maps between TransportEnvelope and Azure ServiceBusMessage
+- **How it's used:** Internal component used by publisher/consumer
+- **Why it matters:** Bridges library abstraction with Azure's native message format
+- **When to use:** Used internally - not typically interacted with directly
+- **Example:**
+  ```csharp
+  // Internal mapping:
+  // TransportEnvelope.MessageId → ServiceBusMessage.MessageId
+  // TransportEnvelope.CorrelationId → ServiceBusMessage.CorrelationId
+  // TransportEnvelope.Headers → ServiceBusMessage.ApplicationProperties
+  // TransportEnvelope.Payload → ServiceBusMessage.Body
+  ```
+
+### DependencyInjection/ServiceCollectionExtensions.cs
+- **What it is:** Setup wizard for Azure Service Bus
+- **Real-world analogy:** "Connect to Azure" configuration wizard
+- **What it does:** Registers Azure Service Bus transport with your application
+- **How it's used:** Call `AddHoneyDrunkServiceBusTransport()` in startup
+- **Why it matters:** Fluent API for Azure-specific configuration
+- **When to use:** Production deployments using Azure Service Bus
+- **Example:**
+  ```csharp
+  services.AddHoneyDrunkTransportCore()
+      .AddHoneyDrunkServiceBusTransport(options =>
+      {
+          options.ConnectionString = configuration["AzureServiceBus:ConnectionString"];
+          options.TopicName = "orders";
+      })
+      .WithTopicSubscription("order-processor")
+      .WithSessions() // Enable sessions
+      .WithRetry(retry =>
+      {
+          retry.MaxAttempts = 5;
+          retry.BackoffStrategy = BackoffStrategy.Exponential;
+      });
+  ```
+
+---
+
+## 🎯 Summary: The Big Picture
+
+### What problem does this solve?
+
+Applications need to send messages to each other, but each messaging system (Azure Service Bus, RabbitMQ, Kafka, etc.) works differently. This library provides one consistent way to send and receive messages, and you can swap out the underlying technology without changing your code.
+
+### How to explain it to a non-technical person:
+
+> "Imagine you write letters, but you don't want to care whether they're sent by USPS, FedEx, or carrier pigeon. This library is like having one mailbox where you drop letters, and it figures out which delivery service to use. You can switch from one delivery service to another without rewriting your letters."
+
+### How to explain it to a developer:
+
+> "It's a transport-agnostic messaging abstraction layer with a middleware pipeline pattern (like ASP.NET Core). Write your message handlers once, then plug in Azure Service Bus, RabbitMQ, or in-memory for testing. Includes retry policies, correlation tracking, telemetry, and transactional outbox pattern out of the box."
+
+---
+
+## 📚 Quick Reference
+
+### Core Concepts
+
+| Concept | Description | Analogy |
+|---------|-------------|---------|
+| **Envelope** | Message wrapper with metadata | Physical envelope with address |
+| **Publisher** | Sends messages | Post office counter |
+| **Consumer** | Receives messages | Mailbox |
+| **Handler** | Processes specific message types | Mail sorter |
+| **Middleware** | Processing pipeline steps | Assembly line stations |
+| **Serializer** | Converts objects to/from bytes | Translator |
+| **Outbox** | Transactional message store | Safe for important mail |
+
+### Message Flow
+
+```
+1. Create Message → 2. Wrap in Envelope → 3. Serialize → 4. Publish
+                                                              ↓
+5. Consumer Receives ← 6. Deserialize ← 7. Pipeline (Middleware) ← 8. Handler
+```
+
+### Middleware Pipeline Order
+
+```
+Message → Correlation → Telemetry → Logging → Custom → Retry → Handler
+```
+
+### Common Usage Patterns
+
+#### Basic Publish/Subscribe
+```csharp
+// Publish
+var message = new OrderCreated(orderId, customerId);
+var envelope = factory.Create(message, "orders.created");
+await publisher.PublishAsync(envelope, ct);
+
+// Subscribe (handler)
+public class OrderCreatedHandler : IMessageHandler<OrderCreated>
+{
+    public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+    {
+        // Process message
+        return MessageProcessingResult.Success;
+    }
+}
+```
+
+#### With Retry Logic
+```csharp
+services.AddHoneyDrunkTransportCore()
+    .AddHoneyDrunkServiceBusTransport(options => /* ... */)
+    .WithRetry(retry =>
+    {
+        retry.MaxAttempts = 5;
+        retry.BackoffStrategy = BackoffStrategy.Exponential;
+    });
+```
+
+#### With Transactional Outbox
+```csharp
+// In service
+using var transaction = await db.Database.BeginTransactionAsync(ct);
+db.Orders.Add(order);
+await outbox.SaveAsync(new OutboxMessage(envelope), ct);
+await db.SaveChangesAsync(ct);
+await transaction.CommitAsync(ct);
+
+// Background dispatcher publishes later
+services.AddHostedService<OutboxDispatcherService>();
+```
+
+#### Testing with InMemory
+```csharp
+// Test setup
+services.AddHoneyDrunkTransportCore()
+    .AddHoneyDrunkInMemoryTransport(); // No connection strings needed
+  
+// Test can publish and consume in-process
+[Fact]
+public async Task ProcessesOrderCreatedMessage()
+{
+    await _publisher.PublishAsync(envelope, ct);
+    await Task.Delay(100); // Give consumer time to process
+    
+    // Assert handler was called
+    _mockHandler.Verify(h => h.HandleAsync(It.IsAny<OrderCreated>(), It.IsAny<MessageContext>(), It.IsAny<CancellationToken>()));
+}
+```
+
+---
+
+*Last Updated: 2025-11-11*
+*Version: 0.1.0*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,522 @@
 # HoneyDrunk.Transport
-Reliable messaging and outbox infrastructure for the Hive. Transport unifies brokers, queues, and event buses under one contract ensuring delivery, order, and idempotence. It powers communication between Nodes—Data, Pulse, Vault, and beyond—so every message finds its way.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/download/dotnet/10.0)
+
+> **Reliable messaging and outbox infrastructure for the Hive** - Transport unifies brokers, queues, and event buses under one contract ensuring delivery, order, and idempotence. It powers communication between Nodes—Data, Pulse, Vault, and beyond—so every message finds its way.
+
+**Signal Quote:** *"Every message finds its way."*
+
+---
+
+## 📦 What Is This?
+
+HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive"). It provides a transport-agnostic abstraction layer over different message brokers with built-in resilience, observability, and exactly-once semantics:
+
+- ✅ **Transport Abstraction** - Unified interface for Azure Service Bus, RabbitMQ, Kafka, in-memory, and more
+- ✅ **Middleware Pipeline** - Onion-style processing with correlation, telemetry, logging, and retry
+- ✅ **Envelope Pattern** - Immutable message wrapping with correlation/causation tracking
+- ✅ **Transactional Outbox** - Exactly-once processing with database transactions
+- ✅ **Kernel Integration** - Uses `IClock`, `IIdGenerator`, `IKernelContext` for deterministic, testable messaging
+- ✅ **Framework Integration** - Extends Microsoft.Extensions, integrates seamlessly with ASP.NET Core
+
+---
+
+## 🚀 Quick Start
+
+### Installation
+
+```xml
+<ItemGroup>
+  <!-- Core Transport -->
+  <PackageReference Include="HoneyDrunk.Transport" Version="0.1.0" />
+  
+  <!-- Azure Service Bus Provider -->
+  <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.1.0" />
+  
+  <!-- In-Memory Provider (for testing) -->
+  <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.1.0" />
+</ItemGroup>
+```
+
+### Register Transport Services
+
+```csharp
+using HoneyDrunk.Transport.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register Transport core (includes Kernel defaults)
+builder.Services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableTelemetry = true;
+    options.EnableLogging = true;
+    options.EnableCorrelation = true;
+});
+
+// Add Azure Service Bus transport
+builder.Services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
+    options.EntityType = ServiceBusEntityType.Queue;
+    options.Address = "my-queue";
+    options.AutoComplete = true;
+});
+
+// Register message handlers
+builder.Services.AddMessageHandler<OrderCreatedEvent, OrderCreatedHandler>();
+
+var app = builder.Build();
+app.Run();
+```
+
+---
+
+## 🎯 Features
+
+### 🔍 Core Components
+
+| Component | Purpose | Key Types |
+|-----------|---------|-----------|
+| **Transport Abstraction** | Unified publisher/consumer interface | `ITransportPublisher`, `ITransportConsumer` |
+| **Message Pipeline** | Middleware execution engine | `IMessagePipeline`, `IMessageMiddleware` |
+| **Envelope System** | Immutable message wrapping | `ITransportEnvelope`, `EnvelopeFactory` |
+| **Kernel Context** | Correlation/causation tracking | `IKernelContextFactory`, `KernelContext` |
+| **Serialization** | Pluggable message serialization | `IMessageSerializer`, `JsonMessageSerializer` |
+| **Outbox Pattern** | Transactional outbox support | `IOutboxStore`, `IOutboxDispatcher` |
+
+### 🔗 Kernel Integration
+
+HoneyDrunk.Transport **extends** HoneyDrunk.Kernel with messaging primitives:
+
+| Kernel Service | How Transport Uses It |
+|----------------|----------------------|
+| `IIdGenerator` | Message ID generation (ULID) |
+| `IClock` | Deterministic message timestamps |
+| `IKernelContext` | Correlation/causation propagation |
+| `IMetricsCollector` | Message processing metrics |
+| `ILogger<T>` | Structured logging throughout |
+
+### 🚀 Available Transports
+
+| Transport | Package | Status |
+|-----------|---------|--------|
+| **Azure Service Bus** | `HoneyDrunk.Transport.AzureServiceBus` | ✅ Available |
+| **In-Memory** | `HoneyDrunk.Transport.InMemory` | ✅ Available (Testing) |
+| **RabbitMQ** | `HoneyDrunk.Transport.RabbitMQ` | 🚧 Planned |
+| **Kafka** | `HoneyDrunk.Transport.Kafka` | 🚧 Planned |
+
+---
+
+## 📖 Usage Examples
+
+### Publishing Messages
+
+```csharp
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Primitives;
+
+public class OrderService(
+    ITransportPublisher publisher,
+    EnvelopeFactory envelopeFactory,
+    IMessageSerializer serializer)
+{
+    public async Task CreateOrderAsync(CreateOrderCommand command)
+    {
+        // Create order...
+        
+        // Publish event
+        var @event = new OrderCreatedEvent { OrderId = orderId, Total = total };
+        var payload = serializer.Serialize(@event);
+        var envelope = envelopeFactory.CreateEnvelope<OrderCreatedEvent>(
+            payload,
+            correlationId: command.CorrelationId);
+        
+        await publisher.PublishAsync(
+            envelope,
+            new EndpointAddress("orders-topic"),
+            cancellationToken);
+    }
+}
+```
+
+### Handling Messages
+
+```csharp
+using HoneyDrunk.Transport.Abstractions;
+
+public class OrderCreatedHandler : IMessageHandler<OrderCreatedEvent>
+{
+    private readonly ILogger<OrderCreatedHandler> _logger;
+    
+    public OrderCreatedHandler(ILogger<OrderCreatedHandler> logger)
+    {
+        _logger = logger;
+    }
+    
+    public async Task HandleAsync(
+        OrderCreatedEvent message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        // Access kernel context for correlation tracking
+        if (context.Properties.TryGetValue("KernelContext", out var ctxObj)
+            && ctxObj is IKernelContext kernelContext)
+        {
+            _logger.LogInformation(
+                "Processing order {OrderId} with CorrelationId {CorrelationId}",
+                message.OrderId,
+                kernelContext.CorrelationId);
+        }
+        
+        // Process the event
+        await SendConfirmationEmailAsync(message.OrderId, cancellationToken);
+    }
+}
+```
+
+### Custom Middleware
+
+```csharp
+using HoneyDrunk.Transport.Pipeline;
+
+public class ValidationMiddleware : IMessageMiddleware
+{
+    public async Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken)
+    {
+        // Validate envelope
+        if (string.IsNullOrEmpty(envelope.MessageType))
+        {
+            throw new MessageHandlerException(
+                "MessageType is required",
+                MessageProcessingResult.DeadLetter);
+        }
+        
+        // Continue pipeline
+        await next();
+    }
+}
+
+// Register in DI
+services.AddMessageMiddleware<ValidationMiddleware>();
+```
+
+### Transactional Outbox
+
+```csharp
+using HoneyDrunk.Transport.Outbox;
+
+public class OrderService(IOutboxStore outboxStore, IDbContext dbContext)
+{
+    public async Task CreateOrderAsync(CreateOrderCommand command)
+    {
+        await using var transaction = await dbContext.BeginTransactionAsync();
+        
+        try
+        {
+            // Save order to database
+            var order = new Order { /* ... */ };
+            await dbContext.Orders.AddAsync(order);
+            
+            // Save message to outbox (same transaction)
+            var envelope = CreateOrderCreatedEnvelope(order);
+            await outboxStore.SaveAsync(
+                envelope,
+                new EndpointAddress("orders-topic"),
+                cancellationToken);
+            
+            await transaction.CommitAsync();
+            
+            // Background dispatcher will publish from outbox
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+}
+```
+
+---
+
+## 🧪 Testing & Validation
+
+### In-Memory Transport for Tests
+
+```csharp
+using HoneyDrunk.Transport.InMemory;
+using Xunit;
+
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task CreateOrder_PublishesOrderCreatedEvent()
+    {
+        // Arrange
+        var broker = new InMemoryBroker();
+        var publisher = new InMemoryTransportPublisher(broker, logger);
+        var service = new OrderService(publisher, /* ... */);
+        
+        var messagesReceived = new List<ITransportEnvelope>();
+        broker.Subscribe("orders-topic", (envelope, ct) =>
+        {
+            messagesReceived.Add(envelope);
+            return Task.CompletedTask;
+        });
+        
+        // Act
+        await service.CreateOrderAsync(new CreateOrderCommand { /* ... */ });
+        
+        // Assert
+        Assert.Single(messagesReceived);
+        Assert.Equal("OrderCreatedEvent", messagesReceived[0].MessageType);
+    }
+}
+```
+
+### Testing with Fixed Time
+
+```csharp
+using HoneyDrunk.Kernel.Abstractions.Time;
+
+public class EnvelopeFactoryTests
+{
+    [Fact]
+    public void CreateEnvelope_UsesFixedTimestamp()
+    {
+        // Arrange
+        var fixedTime = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        var clock = new FixedClock(fixedTime);
+        var idGenerator = new TestIdGenerator("test-id");
+        var factory = new EnvelopeFactory(idGenerator, clock);
+        
+        // Act
+        var envelope = factory.CreateEnvelope<TestMessage>(payload);
+        
+        // Assert
+        Assert.Equal(fixedTime, envelope.Timestamp);
+        Assert.Equal("test-id", envelope.MessageId);
+    }
+}
+```
+
+---
+
+## 🛠️ Configuration
+
+### Transport Core Options
+
+```csharp
+builder.Services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EndpointName = "my-service";
+    options.Address = "my-queue";
+    options.EnableTelemetry = true;
+    options.EnableLogging = true;
+    options.EnableCorrelation = true;
+    options.MaxConcurrency = 10;
+    options.PrefetchCount = 20;
+});
+```
+
+### Azure Service Bus Options
+
+```csharp
+builder.Services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    // Connection
+    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
+    options.ConnectionString = config["ServiceBus:ConnectionString"];
+    
+    // Entity
+    options.EntityType = ServiceBusEntityType.Topic;
+    options.Address = "orders-topic";
+    options.SubscriptionName = "order-processor";
+    
+    // Processing
+    options.AutoComplete = true;
+    options.SessionEnabled = false;
+    options.MaxConcurrency = 10;
+    options.PrefetchCount = 20;
+    options.MessageLockDuration = TimeSpan.FromMinutes(5);
+    
+    // Retry
+    options.ServiceBusRetry.Mode = ServiceBusRetryMode.Exponential;
+    options.ServiceBusRetry.MaxRetries = 3;
+    options.ServiceBusRetry.Delay = TimeSpan.FromSeconds(0.8);
+    options.ServiceBusRetry.MaxDelay = TimeSpan.FromMinutes(1);
+    
+    // Dead Letter
+    options.EnableDeadLetterQueue = true;
+    options.MaxDeliveryCount = 10;
+});
+```
+
+### Retry Middleware
+
+```csharp
+builder.Services.AddMessageMiddleware(sp => 
+    new RetryMiddleware(
+        sp.GetRequiredService<ILogger<RetryMiddleware>>(),
+        maxAttempts: 3));
+```
+
+---
+
+## 🧱 Architecture
+
+### Repository Layout
+
+```
+HoneyDrunk.Transport/
+ ├── HoneyDrunk.Transport/                    # Core abstractions & pipeline
+ │   ├── Abstractions/                        # Contracts & interfaces
+ │   ├── Pipeline/                            # Middleware execution engine
+ │   ├── Configuration/                       # Options & settings
+ │   ├── Context/                             # Kernel context integration
+ │   ├── Primitives/                          # Envelope & factory
+ │   ├── Outbox/                              # Transactional outbox
+ │   └── DependencyInjection/                 # DI registration
+ ├── HoneyDrunk.Transport.AzureServiceBus/    # Azure Service Bus provider
+ ├── HoneyDrunk.Transport.InMemory/           # In-memory provider
+ ├── HoneyDrunk.Transport.Tests/              # Test project
+ ├── HoneyDrunk.Transport.slnx
+ ├── .editorconfig
+ └── .github/workflows/
+     ├── validate-pr.yml
+     └── publish.yml
+```
+
+### Design Philosophy
+
+- **Transport Agnostic** – One interface, many brokers
+- **Middleware First** – Composable, testable processing pipeline
+- **Kernel Integrated** – Built on HoneyDrunk.Kernel primitives
+- **Exactly-Once** – Transactional outbox for guaranteed delivery
+- **Observable** – Telemetry, metrics, and distributed tracing built-in
+
+### Middleware Pipeline
+
+Messages flow through middleware in this order:
+
+1. **CorrelationMiddleware** – Creates `IKernelContext` from envelope
+2. **TelemetryMiddleware** – Starts distributed trace activity
+3. **LoggingMiddleware** – Logs message processing lifecycle
+4. **RetryMiddleware** – Enforces retry limits
+5. **Custom Middleware** – Your application middleware
+6. **Message Handler** – Final handler invocation
+
+### Relationships
+
+**Upstream Dependencies:**
+- HoneyDrunk.Kernel (ID generation, time, context)
+- HoneyDrunk.Standards (analyzers, conventions)
+
+**Downstream Consumers:**
+- HoneyDrunk.Data (outbox implementation)
+- HoneyDrunk.Web.Rest (REST APIs with messaging)
+- Service applications (order service, payment service, etc.)
+
+---
+
+## ⚙️ Build & Release
+
+### CI/CD Integration
+
+The package is validated and published automatically:
+
+```yaml
+# Validate on PR
+- push → build + test
+- pull_request → validate formatting and analyzers
+
+# Publish on tag
+- tag v* → build + test + pack + publish to NuGet
+```
+
+### Local Development
+
+```sh
+# Clone repository
+git clone https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport
+cd HoneyDrunk.Transport
+
+# Restore dependencies
+dotnet restore
+
+# Build solution
+dotnet build
+
+# Run tests
+dotnet test HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+
+# Pack packages
+dotnet pack -c Release -o ./artifacts
+```
+
+---
+
+## 📋 Testing Policy
+
+- All tests live in `HoneyDrunk.Transport.Tests` — **none** in runtime projects
+- Use `InMemoryBroker` for integration tests
+- Tests **must** use `IClock` and `IIdGenerator` for deterministic runs
+- CI gate: build fails if tests fail; coverage threshold optional
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome! Please:
+
+1. Read [.github/copilot-instructions.md](.github/copilot-instructions.md) for coding standards
+2. Open an issue for discussion before major changes
+3. Ensure all tests pass locally
+4. Update documentation for new features
+
+---
+
+## 📄 License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+## 🐝 About HoneyDrunk Studios
+
+HoneyDrunk.Transport is part of the **Hive** ecosystem - a collection of tools, libraries, and standards for building high-quality .NET applications.
+
+**Other Projects:**
+- 🚀 [HoneyDrunk.Kernel](https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel) - Foundational primitives
+- 🚀 [HoneyDrunk.Standards](https://github.com/HoneyDrunkStudios/HoneyDrunk.Standards) - Build-transitive analyzers
+- 🚧 HoneyDrunk.Data *(coming soon)* - Database abstractions
+- 🚧 HoneyDrunk.Auth *(coming soon)* - Authentication/authorization
+
+---
+
+## 📞 Support
+
+- **Questions:** Open a [discussion](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/discussions)
+- **Bugs:** File an [issue](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/issues)
+- **Feature Requests:** Open an [issue](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/issues) with the `enhancement` label
+
+---
+
+## 🧃 Motto
+
+**"Every message finds its way."**
+
+---
+
+<div align="center">
+
+**Built with 🍯 by HoneyDrunk Studios**
+
+[GitHub](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport) • [NuGet](https://www.nuget.org/packages/HoneyDrunk.Transport) • [Issues](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/issues)
+
+</div>


### PR DESCRIPTION
Introduced a robust messaging framework with support for Azure Service Bus and in-memory transport. Key features include:

- `ServiceBusTransportConsumer` and `ServiceBusTransportPublisher` for consuming and publishing messages via Azure Service Bus.
- `AzureServiceBusOptions` for configuring connection strings, namespaces, retry policies, and entity types (Queue/Topic).
- `InMemoryBroker`, `InMemoryTransportConsumer`, and `InMemoryTransportPublisher` for local development/testing.
- `MessagePipeline` and middleware components for extensible message processing (`CorrelationMiddleware`, `RetryMiddleware`, `LoggingMiddleware`, `TelemetryMiddleware`).
- `TransportTelemetry` for observability with activity spans.
- `RetryOptions` and `BackoffStrategy` for configurable retry behavior (fixed, linear, exponential).
- Transactional outbox pattern support with `OutboxMessage`, `IOutboxStore`, and `IOutboxDispatcher`.

Enhanced dependency injection extensions for seamless integration and added abstractions (`ITransportEnvelope`, `ITransportConsumer`, `ITransportPublisher`, `ITransportTransaction`) for transport- agnostic message handling.

BREAKING CHANGE: Updated project files to include new dependencies (`Azure.Identity`, `Azure.Messaging.ServiceBus`, etc.) and enabled XML documentation file generation. Existing transport integrations may require updates to align with the new abstractions.