### PR TITLE
chore(packaging): include README.md in NuGet packages

### DIFF
--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -33,4 +33,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -36,4 +36,8 @@
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
+  <ItemGroup>
+	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+	
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -39,5 +39,4 @@
   <ItemGroup>
 	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-	
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -37,6 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add README.md to the NuGet packages for AzureServiceBus, InMemory, and Transport projects. The file is included with `Pack="true"` and placed at the root of the package using `PackagePath="\"`. This ensures documentation is available to package consumers.