### PR TITLE
feat(storagequeue): add Azure Storage Queue transport

### DIFF
--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/AzureServiceBusOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/AzureServiceBusOptions.cs
@@ -8,105 +8,42 @@ namespace HoneyDrunk.Transport.AzureServiceBus.Configuration;
 public sealed class AzureServiceBusOptions : TransportOptions
 {
     /// <summary>
-    /// Fully qualified namespace (e.g., "mynamespace.servicebus.windows.net").
+    /// Gets or sets the fully qualified namespace (e.g., "mynamespace.servicebus.windows.net").
     /// </summary>
     public string FullyQualifiedNamespace { get; set; } = string.Empty;
 
     /// <summary>
-    /// Connection string (alternative to FullyQualifiedNamespace with managed identity).
+    /// Gets or sets the connection string (alternative to FullyQualifiedNamespace with managed identity).
     /// </summary>
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Entity type: Queue or Topic.
+    /// Gets or sets the entity type: Queue or Topic.
     /// </summary>
     public ServiceBusEntityType EntityType { get; set; } = ServiceBusEntityType.Queue;
 
     /// <summary>
-    /// Subscription name (required for Topic entity type).
+    /// Gets or sets the subscription name (required for Topic entity type).
     /// </summary>
     public string? SubscriptionName { get; set; }
 
     /// <summary>
-    /// Maximum wait time for receiving messages.
+    /// Gets or sets the maximum wait time for receiving messages.
     /// </summary>
     public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// Service Bus retry options.
+    /// Gets or sets the Service Bus retry options.
     /// </summary>
     public ServiceBusRetryOptions ServiceBusRetry { get; set; } = new();
 
     /// <summary>
-    /// Whether to use sub-queue (dead letter queue).
+    /// Gets or sets a value indicating whether to use sub-queue (dead letter queue).
     /// </summary>
     public bool EnableDeadLetterQueue { get; set; } = true;
 
     /// <summary>
-    /// Maximum delivery count before moving to dead letter queue.
+    /// Gets or sets the maximum delivery count before moving to dead letter queue.
     /// </summary>
     public int MaxDeliveryCount { get; set; } = 10;
-}
-
-/// <summary>
-/// Entity type for Azure Service Bus.
-/// </summary>
-public enum ServiceBusEntityType
-{
-    /// <summary>
-    /// Queue entity type.
-    /// </summary>
-    Queue,
-    
-    /// <summary>
-    /// Topic entity type.
-    /// </summary>
-    Topic
-}
-
-/// <summary>
-/// Service Bus specific retry configuration.
-/// </summary>
-public sealed class ServiceBusRetryOptions
-{
-    /// <summary>
-    /// Retry mode for Service Bus operations.
-    /// </summary>
-    public ServiceBusRetryMode Mode { get; set; } = ServiceBusRetryMode.Exponential;
-
-    /// <summary>
-    /// Maximum number of retry attempts.
-    /// </summary>
-    public int MaxRetries { get; set; } = 3;
-
-    /// <summary>
-    /// Delay between retry attempts.
-    /// </summary>
-    public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(0.8);
-
-    /// <summary>
-    /// Maximum delay between retries.
-    /// </summary>
-    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(1);
-
-    /// <summary>
-    /// Timeout for Service Bus operations.
-    /// </summary>
-    public TimeSpan TryTimeout { get; set; } = TimeSpan.FromMinutes(1);
-}
-
-/// <summary>
-/// Retry mode for Service Bus.
-/// </summary>
-public enum ServiceBusRetryMode
-{
-    /// <summary>
-    /// Fixed delay between retries.
-    /// </summary>
-    Fixed,
-    
-    /// <summary>
-    /// Exponential backoff between retries.
-    /// </summary>
-    Exponential
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusEntityType.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusEntityType.cs
@@ -1,0 +1,17 @@
+namespace HoneyDrunk.Transport.AzureServiceBus.Configuration;
+
+/// <summary>
+/// Entity type for Azure Service Bus.
+/// </summary>
+public enum ServiceBusEntityType
+{
+    /// <summary>
+    /// Queue entity type.
+    /// </summary>
+    Queue,
+
+    /// <summary>
+    /// Topic entity type.
+    /// </summary>
+    Topic
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusRetryMode.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusRetryMode.cs
@@ -1,0 +1,17 @@
+namespace HoneyDrunk.Transport.AzureServiceBus.Configuration;
+
+/// <summary>
+/// Retry mode for Service Bus.
+/// </summary>
+public enum ServiceBusRetryMode
+{
+    /// <summary>
+    /// Fixed delay between retries.
+    /// </summary>
+    Fixed,
+
+    /// <summary>
+    /// Exponential backoff between retries.
+    /// </summary>
+    Exponential
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusRetryOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Configuration/ServiceBusRetryOptions.cs
@@ -1,0 +1,32 @@
+namespace HoneyDrunk.Transport.AzureServiceBus.Configuration;
+
+/// <summary>
+/// Service Bus specific retry configuration.
+/// </summary>
+public sealed class ServiceBusRetryOptions
+{
+    /// <summary>
+    /// Gets or sets the retry mode for Service Bus operations.
+    /// </summary>
+    public ServiceBusRetryMode Mode { get; set; } = ServiceBusRetryMode.Exponential;
+
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts.
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the delay between retry attempts.
+    /// </summary>
+    public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(0.8);
+
+    /// <summary>
+    /// Gets or sets the maximum delay between retries.
+    /// </summary>
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets or sets the timeout for Service Bus operations.
+    /// </summary>
+    public TimeSpan TryTimeout { get; set; } = TimeSpan.FromMinutes(1);
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/DependencyInjection/ServiceCollectionExtensions.cs
@@ -16,6 +16,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the HoneyDrunk Azure Service Bus transport implementation.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configuration action for Azure Service Bus options.</param>
+    /// <returns>A transport builder for additional configuration.</returns>
     public static ITransportBuilder AddHoneyDrunkServiceBusTransport(
         this IServiceCollection services,
         Action<AzureServiceBusOptions> configure)
@@ -80,6 +83,11 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds Azure Service Bus transport with connection string.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Azure Service Bus connection string.</param>
+    /// <param name="queueOrTopicName">The queue or topic name.</param>
+    /// <param name="configure">Optional configuration action for additional settings.</param>
+    /// <returns>A transport builder for additional configuration.</returns>
     public static ITransportBuilder AddHoneyDrunkServiceBusTransport(
         this IServiceCollection services,
         string connectionString,
@@ -98,6 +106,11 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds Azure Service Bus transport with managed identity.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="fullyQualifiedNamespace">The fully qualified Service Bus namespace.</param>
+    /// <param name="queueOrTopicName">The queue or topic name.</param>
+    /// <param name="configure">Optional configuration action for additional settings.</param>
+    /// <returns>A transport builder for additional configuration.</returns>
     public static ITransportBuilder AddHoneyDrunkServiceBusTransportWithManagedIdentity(
         this IServiceCollection services,
         string fullyQualifiedNamespace,
@@ -116,6 +129,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Configures the transport for a topic with subscription.
     /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="subscriptionName">The subscription name.</param>
+    /// <returns>The transport builder for additional configuration.</returns>
     public static ITransportBuilder WithTopicSubscription(
         this ITransportBuilder builder,
         string subscriptionName)
@@ -132,6 +148,8 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Enables session support for ordered message processing.
     /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <returns>The transport builder for additional configuration.</returns>
     public static ITransportBuilder WithSessions(this ITransportBuilder builder)
     {
         builder.Services.Configure<AzureServiceBusOptions>(options =>
@@ -145,6 +163,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Configures retry behavior for the transport.
     /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="configure">Configuration action for retry options.</param>
+    /// <returns>The transport builder for additional configuration.</returns>
     public static ITransportBuilder WithRetry(
         this ITransportBuilder builder,
         Action<Configuration.ServiceBusRetryOptions> configure)

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -46,10 +46,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Exceptions\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -32,6 +32,10 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
@@ -39,6 +43,14 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Exceptions\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Mapping/ServiceBusTransportTransaction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/Mapping/ServiceBusTransportTransaction.cs
@@ -1,0 +1,33 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.AzureServiceBus.Mapping;
+
+/// <summary>
+/// Service Bus specific transaction context.
+/// </summary>
+internal sealed class ServiceBusTransportTransaction(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) : ITransportTransaction
+{
+    private readonly Azure.Messaging.ServiceBus.ServiceBusReceivedMessage _message = message;
+
+    public string TransactionId { get; } = message.MessageId;
+
+    public IReadOnlyDictionary<string, object> Context => new Dictionary<string, object>
+    {
+        ["ServiceBusMessage"] = _message,
+        ["LockToken"] = _message.LockToken,
+        ["SequenceNumber"] = _message.SequenceNumber,
+        ["EnqueuedTime"] = _message.EnqueuedTime
+    };
+
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        // Completion is handled by the processor
+        return Task.CompletedTask;
+    }
+
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        // Abandonment is handled by the processor
+        return Task.CompletedTask;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/DependencyInjection/ServiceCollectionExtensions.cs
@@ -14,6 +14,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the HoneyDrunk in-memory transport implementation.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration action for transport options.</param>
+    /// <returns>A transport builder for additional configuration.</returns>
     public static ITransportBuilder AddHoneyDrunkInMemoryTransport(
         this IServiceCollection services,
         Action<TransportOptions>? configure = null)
@@ -40,6 +43,11 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds the HoneyDrunk in-memory transport with specific endpoint configuration.
     /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="endpointName">The endpoint name.</param>
+    /// <param name="address">The endpoint address.</param>
+    /// <param name="configure">Optional configuration action for additional settings.</param>
+    /// <returns>A transport builder for additional configuration.</returns>
     public static ITransportBuilder AddHoneyDrunkInMemoryTransport(
         this IServiceCollection services,
         string endpointName,
@@ -57,6 +65,8 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Extension to start the in-memory consumer from the builder.
     /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <returns>The transport builder for additional configuration.</returns>
     public static ITransportBuilder WithConsumer(this ITransportBuilder builder)
     {
         // Consumer is already registered; this is for fluent API completeness

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -30,11 +30,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
   <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/InMemoryTransportConsumer.cs
@@ -159,7 +159,7 @@ public sealed class InMemoryTransportConsumer(
         {
             await _broker.ConsumeAsync(
                 _options.Value.Address,
-                async (envelope, ct) => await ProcessMessageAsync(envelope, ct),
+                ProcessMessageAsync,
                 cancellationToken);
         }
         catch (OperationCanceledException)

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Configuration/StorageQueueOptions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Configuration/StorageQueueOptions.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel.DataAnnotations;
+using HoneyDrunk.Transport.Configuration;
+
+namespace HoneyDrunk.Transport.StorageQueue.Configuration;
+
+/// <summary>
+/// Configuration options for Azure Storage Queue transport.
+/// </summary>
+public sealed class StorageQueueOptions : TransportOptions
+{
+    /// <summary>
+    /// Gets or sets the connection string for Azure Storage Queue.
+    /// </summary>
+    /// <remarks>
+    /// Required if <see cref="AccountEndpoint"/> is not specified.
+    /// </remarks>
+    [Required(ErrorMessage = "ConnectionString or AccountEndpoint must be configured")]
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the storage account endpoint URI (for managed identity).
+    /// </summary>
+    /// <remarks>
+    /// TODO: Add TokenCredential support for managed identity authentication.
+    /// </remarks>
+    public Uri? AccountEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the queue name.
+    /// </summary>
+    [Required(ErrorMessage = "QueueName is required")]
+    public string QueueName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to create the queue if it doesn't exist.
+    /// </summary>
+    public bool CreateIfNotExists { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to base64-encode message payloads.
+    /// </summary>
+    /// <remarks>
+    /// Azure Storage Queues support base64 encoding for binary data.
+    /// Default is true to handle arbitrary byte payloads safely.
+    /// </remarks>
+    public bool Base64EncodePayload { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the message time-to-live (TTL).
+    /// </summary>
+    /// <remarks>
+    /// Null means use the service default (7 days).
+    /// </remarks>
+    public TimeSpan? MessageTimeToLive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visibility timeout for received messages.
+    /// </summary>
+    /// <remarks>
+    /// Duration a message remains invisible after being retrieved.
+    /// Default is 30 seconds.
+    /// </remarks>
+    public TimeSpan VisibilityTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the maximum number of messages to retrieve per receive call.
+    /// </summary>
+    /// <remarks>
+    /// Valid range: 1-32 (Azure Storage Queue limit).
+    /// Default is 16 for balanced throughput.
+    /// </remarks>
+    [Range(1, 32, ErrorMessage = "PrefetchMaxMessages must be between 1 and 32")]
+    public int PrefetchMaxMessages { get; set; } = 16;
+
+    /// <summary>
+    /// Gets or sets the maximum dequeue count before a message is considered poison.
+    /// </summary>
+    /// <remarks>
+    /// After this many delivery attempts, the message moves to the poison queue.
+    /// Default is 5.
+    /// </remarks>
+    [Range(1, 100, ErrorMessage = "MaxDequeueCount must be between 1 and 100")]
+    public int MaxDequeueCount { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the poison queue name.
+    /// </summary>
+    /// <remarks>
+    /// If null, defaults to "{QueueName}-poison".
+    /// </remarks>
+    public string? PoisonQueueName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether telemetry is enabled.
+    /// </summary>
+    public bool EnableTelemetry { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether logging is enabled.
+    /// </summary>
+    public bool EnableLogging { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether correlation tracking is enabled.
+    /// </summary>
+    public bool EnableCorrelation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the polling interval when the queue is empty.
+    /// </summary>
+    /// <remarks>
+    /// Default is 1 second. Uses exponential backoff with jitter.
+    /// </remarks>
+    public TimeSpan EmptyQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets the maximum polling interval during idle periods.
+    /// </summary>
+    /// <remarks>
+    /// Used for exponential backoff when queue is consistently empty.
+    /// Default is 5 seconds.
+    /// </remarks>
+    public TimeSpan MaxPollingInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets the effective poison queue name.
+    /// </summary>
+    internal string GetPoisonQueueName() => PoisonQueueName ?? $"{QueueName}-poison";
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,259 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.DependencyInjection;
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using HoneyDrunk.Transport.StorageQueue.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace HoneyDrunk.Transport.StorageQueue.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering Azure Storage Queue transport services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the HoneyDrunk Azure Storage Queue transport implementation.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configuration action for Storage Queue options.</param>
+    /// <returns>A transport builder for fluent configuration.</returns>
+    public static ITransportBuilder AddHoneyDrunkTransportStorageQueue(
+        this IServiceCollection services,
+        Action<StorageQueueOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Ensure core transport services are registered
+        var builder = services.AddHoneyDrunkTransportCore();
+
+        // Configure options
+        services.Configure(configure);
+
+        // Validate options on startup
+        services.AddOptions<StorageQueueOptions>()
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        // Register queue client factory
+        services.TryAddSingleton<QueueClientFactory>();
+
+        // Register publisher and consumer
+        services.TryAddSingleton<ITransportPublisher, StorageQueueSender>();
+        services.TryAddSingleton<ITransportConsumer, StorageQueueProcessor>();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds Azure Storage Queue transport with connection string and queue name.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The Azure Storage connection string.</param>
+    /// <param name="queueName">The queue name.</param>
+    /// <param name="configure">Optional additional configuration.</param>
+    /// <returns>A transport builder for fluent configuration.</returns>
+    public static ITransportBuilder AddHoneyDrunkTransportStorageQueue(
+        this IServiceCollection services,
+        string connectionString,
+        string queueName,
+        Action<StorageQueueOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+
+        return services.AddHoneyDrunkTransportStorageQueue(options =>
+        {
+            options.ConnectionString = connectionString;
+            options.QueueName = queueName;
+            options.Address = queueName;
+            options.EndpointName = queueName;
+            configure?.Invoke(options);
+        });
+    }
+
+    /// <summary>
+    /// Configures the Storage Queue transport to use a specific poison queue name.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="poisonQueueName">The poison queue name.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithPoisonQueue(
+        this ITransportBuilder builder,
+        string poisonQueueName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(poisonQueueName);
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.PoisonQueueName = poisonQueueName;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the maximum dequeue count before messages are moved to poison queue.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="maxDequeueCount">The maximum dequeue count.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithMaxDequeueCount(
+        this ITransportBuilder builder,
+        int maxDequeueCount)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (maxDequeueCount < 1 || maxDequeueCount > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxDequeueCount), "MaxDequeueCount must be between 1 and 100");
+        }
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.MaxDequeueCount = maxDequeueCount;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the visibility timeout for received messages.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="visibilityTimeout">The visibility timeout duration.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithVisibilityTimeout(
+        this ITransportBuilder builder,
+        TimeSpan visibilityTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (visibilityTimeout <= TimeSpan.Zero || visibilityTimeout > TimeSpan.FromDays(7))
+        {
+            throw new ArgumentOutOfRangeException(nameof(visibilityTimeout), "VisibilityTimeout must be between 1 second and 7 days");
+        }
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.VisibilityTimeout = visibilityTimeout;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the message time-to-live.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="timeToLive">The message time-to-live duration.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithMessageTimeToLive(
+        this ITransportBuilder builder,
+        TimeSpan timeToLive)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (timeToLive <= TimeSpan.Zero || timeToLive > TimeSpan.FromDays(7))
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeToLive), "MessageTimeToLive must be between 1 second and 7 days");
+        }
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.MessageTimeToLive = timeToLive;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the prefetch message count for batch retrieval.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="prefetchCount">The number of messages to prefetch (1-32).</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithPrefetchCount(
+        this ITransportBuilder builder,
+        int prefetchCount)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (prefetchCount < 1 || prefetchCount > 32)
+        {
+            throw new ArgumentOutOfRangeException(nameof(prefetchCount), "PrefetchCount must be between 1 and 32");
+        }
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.PrefetchMaxMessages = prefetchCount;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the maximum number of concurrent message processors.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <param name="maxConcurrency">The maximum concurrency level.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithConcurrency(
+        this ITransportBuilder builder,
+        int maxConcurrency)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (maxConcurrency < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxConcurrency), "MaxConcurrency must be at least 1");
+        }
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.MaxConcurrency = maxConcurrency;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Disables base64 encoding for message payloads.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    /// <remarks>
+    /// Use with caution - disabling base64 encoding may cause issues with binary payloads.
+    /// </remarks>
+    public static ITransportBuilder WithoutBase64Encoding(this ITransportBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.Base64EncodePayload = false;
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Disables automatic queue creation.
+    /// </summary>
+    /// <param name="builder">The transport builder.</param>
+    /// <returns>The transport builder for fluent configuration.</returns>
+    public static ITransportBuilder WithoutAutoCreateQueue(this ITransportBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.Configure<StorageQueueOptions>(options =>
+        {
+            options.CreateIfNotExists = false;
+        });
+
+        return builder;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Exceptions/MessageTooLargeException.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Exceptions/MessageTooLargeException.cs
@@ -1,0 +1,68 @@
+namespace HoneyDrunk.Transport.StorageQueue.Exceptions;
+
+/// <summary>
+/// Exception thrown when a message exceeds Azure Storage Queue size limits.
+/// </summary>
+/// <remarks>
+/// Azure Storage Queue messages are limited to approximately 64KB (base64-encoded).
+/// Consider moving large payloads to Blob Storage and sending a pointer/reference.
+/// </remarks>
+public sealed class MessageTooLargeException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageTooLargeException"/> class.
+    /// </summary>
+    public MessageTooLargeException()
+        : base("Message payload exceeds Azure Storage Queue size limit (~64KB)")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public MessageTooLargeException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageTooLargeException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public MessageTooLargeException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageTooLargeException"/> class.
+    /// </summary>
+    /// <param name="messageId">The message identifier.</param>
+    /// <param name="actualSize">The actual message size in bytes.</param>
+    /// <param name="maxSize">The maximum allowed size in bytes.</param>
+    public MessageTooLargeException(string messageId, int actualSize, int maxSize)
+        : base($"Message {messageId} size ({actualSize} bytes) exceeds maximum ({maxSize} bytes). " +
+               "Consider using Blob Storage for large payloads and sending a reference instead.")
+    {
+        MessageId = messageId;
+        ActualSize = actualSize;
+        MaxSize = maxSize;
+    }
+
+    /// <summary>
+    /// Gets the message identifier that exceeded size limits.
+    /// </summary>
+    public string? MessageId { get; }
+
+    /// <summary>
+    /// Gets the actual message size in bytes.
+    /// </summary>
+    public int ActualSize { get; }
+
+    /// <summary>
+    /// Gets the maximum allowed message size in bytes.
+    /// </summary>
+    public int MaxSize { get; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Package Metadata -->
+    <PackageId>HoneyDrunk.Transport.StorageQueue</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>HoneyDrunk Studios</Authors>
+    <Description>Azure Storage Queue transport implementation for HoneyDrunk.Transport. Provides cost-effective, high-volume messaging with automatic poison queue handling and exponential backoff.</Description>
+    <PackageReleaseNotes>v0.1.0: Initial release with Azure Storage Queue support including poison queue pattern, configurable retry policies, batch processing, and thread-safe lifecycle management.</PackageReleaseNotes>
+    <PackageTags>messaging;storage-queue;azure;transport;poison-queue;retry;backoff</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport</PackageProjectUrl>
+
+    <!-- Symbol Package Configuration -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HoneyDrunk.Transport\HoneyDrunk.Transport.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -46,10 +46,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Exceptions\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -43,6 +43,14 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Exceptions\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/PoisonQueueMover.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/PoisonQueueMover.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Transport.StorageQueue.Internal;
+
+/// <summary>
+/// Helper for moving poison messages to a dedicated poison queue.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="PoisonQueueMover"/> class.
+/// </remarks>
+/// <param name="logger">The logger instance.</param>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
+internal sealed class PoisonQueueMover(ILogger logger)
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly ILogger _logger = logger;
+
+    /// <summary>
+    /// Moves a message to the poison queue with error metadata.
+    /// </summary>
+    /// <param name="poisonQueueClient">The poison queue client.</param>
+    /// <param name="message">The original queue message.</param>
+    /// <param name="error">The exception that caused the message to be poisoned.</param>
+    /// <param name="originalDequeueCount">The dequeue count from the original message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task MoveMessageToPoisonQueueAsync(
+        QueueClient poisonQueueClient,
+        QueueMessage message,
+        Exception? error,
+        long originalDequeueCount,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(poisonQueueClient);
+        ArgumentNullException.ThrowIfNull(message);
+
+        try
+        {
+            // Create poison envelope with error metadata
+            var poisonEnvelope = CreatePoisonEnvelope(message, error, originalDequeueCount);
+
+            // Serialize to JSON
+            var poisonMessageText = JsonSerializer.Serialize(poisonEnvelope, SerializerOptions);
+
+            // Send to poison queue
+            await poisonQueueClient.SendMessageAsync(
+                poisonMessageText,
+                cancellationToken: cancellationToken);
+
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "Moved message {MessageId} to poison queue after {DequeueCount} attempts. Error: {ErrorType}",
+                    message.MessageId,
+                    originalDequeueCount,
+                    error?.GetType().Name ?? "Unknown");
+            }
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to move message {MessageId} to poison queue",
+                    message.MessageId);
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates a poison envelope with error metadata.
+    /// </summary>
+    private static PoisonEnvelope CreatePoisonEnvelope(
+        QueueMessage message,
+        Exception? error,
+        long dequeueCount)
+    {
+        return new PoisonEnvelope
+        {
+            OriginalMessageId = message.MessageId,
+            OriginalMessage = message.Body.ToString(),
+            DequeueCount = dequeueCount,
+            FirstFailureTimestamp = message.InsertedOn ?? DateTimeOffset.UtcNow,
+            LastFailureTimestamp = DateTimeOffset.UtcNow,
+            ErrorType = error?.GetType().FullName,
+            ErrorMessage = error?.Message,
+            ErrorStackTrace = error?.StackTrace,
+            Metadata = new Dictionary<string, string>
+            {
+                ["PopReceipt"] = message.PopReceipt ?? string.Empty,
+                ["InsertedOn"] = message.InsertedOn?.ToString("o") ?? string.Empty,
+                ["ExpiresOn"] = message.ExpiresOn?.ToString("o") ?? string.Empty,
+                ["NextVisibleOn"] = message.NextVisibleOn?.ToString("o") ?? string.Empty
+            }
+        };
+    }
+
+    /// <summary>
+    /// Represents a message that has been moved to the poison queue.
+    /// </summary>
+    private sealed class PoisonEnvelope
+    {
+        public required string OriginalMessageId { get; init; }
+
+        public required string OriginalMessage { get; init; }
+
+        public long DequeueCount { get; init; }
+
+        public DateTimeOffset FirstFailureTimestamp { get; init; }
+
+        public DateTimeOffset LastFailureTimestamp { get; init; }
+
+        public string? ErrorType { get; init; }
+
+        public string? ErrorMessage { get; init; }
+
+        public string? ErrorStackTrace { get; init; }
+
+        public Dictionary<string, string>? Metadata { get; init; }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/PoisonQueueMover.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/PoisonQueueMover.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Extensions.Logging;
@@ -111,22 +112,31 @@ internal sealed class PoisonQueueMover(ILogger logger)
     /// </summary>
     private sealed class PoisonEnvelope
     {
+        [JsonPropertyName("originalMessageId")]
         public required string OriginalMessageId { get; init; }
 
+        [JsonPropertyName("originalMessage")]
         public required string OriginalMessage { get; init; }
 
+        [JsonPropertyName("dequeueCount")]
         public long DequeueCount { get; init; }
 
+        [JsonPropertyName("firstFailureTimestamp")]
         public DateTimeOffset FirstFailureTimestamp { get; init; }
 
+        [JsonPropertyName("lastFailureTimestamp")]
         public DateTimeOffset LastFailureTimestamp { get; init; }
 
+        [JsonPropertyName("errorType")]
         public string? ErrorType { get; init; }
 
+        [JsonPropertyName("errorMessage")]
         public string? ErrorMessage { get; init; }
 
+        [JsonPropertyName("errorStackTrace")]
         public string? ErrorStackTrace { get; init; }
 
+        [JsonPropertyName("metadata")]
         public Dictionary<string, string>? Metadata { get; init; }
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/QueueClientFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/QueueClientFactory.cs
@@ -1,0 +1,162 @@
+using System.Diagnostics.CodeAnalysis;
+using Azure.Storage.Queues;
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.StorageQueue.Internal;
+
+/// <summary>
+/// Factory for creating and managing queue clients.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="QueueClientFactory"/> class.
+/// </remarks>
+/// <param name="options">The storage queue configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
+internal sealed class QueueClientFactory(
+    IOptions<StorageQueueOptions> options,
+    ILogger<QueueClientFactory> logger) : IDisposable
+{
+    private readonly StorageQueueOptions _options = options.Value;
+    private readonly ILogger<QueueClientFactory> _logger = logger;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private QueueClient? _primaryQueueClient;
+    private QueueClient? _poisonQueueClient;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets or creates the primary queue client.
+    /// </summary>
+    public async Task<QueueClient> GetOrCreatePrimaryQueueClientAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_primaryQueueClient != null)
+        {
+            return _primaryQueueClient;
+        }
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_primaryQueueClient != null)
+            {
+                return _primaryQueueClient;
+            }
+
+            _primaryQueueClient = CreateQueueClient(_options.QueueName);
+
+            if (_options.CreateIfNotExists)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Creating queue {QueueName} if not exists", _options.QueueName);
+                }
+
+                await _primaryQueueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Queue {QueueName} ready", _options.QueueName);
+                }
+            }
+
+            return _primaryQueueClient;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Gets or creates the poison queue client.
+    /// </summary>
+    public async Task<QueueClient> GetOrCreatePoisonQueueClientAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_poisonQueueClient != null)
+        {
+            return _poisonQueueClient;
+        }
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_poisonQueueClient != null)
+            {
+                return _poisonQueueClient;
+            }
+
+            var poisonQueueName = _options.GetPoisonQueueName();
+            _poisonQueueClient = CreateQueueClient(poisonQueueName);
+
+            if (_options.CreateIfNotExists)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Creating poison queue {QueueName} if not exists", poisonQueueName);
+                }
+
+                await _poisonQueueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Poison queue {QueueName} ready", poisonQueueName);
+                }
+            }
+
+            return _poisonQueueClient;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Disposes resources used by the factory.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, true))
+        {
+            return;
+        }
+
+        _initLock.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a queue client for the specified queue name.
+    /// </summary>
+    private QueueClient CreateQueueClient(string queueName)
+    {
+        if (!string.IsNullOrEmpty(_options.ConnectionString))
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Creating queue client for {QueueName} using connection string", queueName);
+            }
+
+            return new QueueClient(_options.ConnectionString, queueName);
+        }
+        else if (_options.AccountEndpoint != null)
+        {
+            throw new NotImplementedException(
+                "TokenCredential authentication is not yet implemented. Please use ConnectionString for now.");
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                "Either ConnectionString or AccountEndpoint must be configured");
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/QueueClientFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/QueueClientFactory.cs
@@ -17,7 +17,7 @@ namespace HoneyDrunk.Transport.StorageQueue.Internal;
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
 internal sealed class QueueClientFactory(
     IOptions<StorageQueueOptions> options,
-    ILogger<QueueClientFactory> logger) : IDisposable
+    ILogger<QueueClientFactory> logger) : IAsyncDisposable
 {
     private readonly StorageQueueOptions _options = options.Value;
     private readonly ILogger<QueueClientFactory> _logger = logger;
@@ -124,7 +124,7 @@ internal sealed class QueueClientFactory(
     /// <summary>
     /// Disposes resources used by the factory.
     /// </summary>
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         // Thread-safe disposal check using Interlocked.Exchange
         // Atomically sets _disposed to true and returns the previous value
@@ -135,7 +135,7 @@ internal sealed class QueueClientFactory(
         }
 
         // Acquire the initialization lock to ensure no concurrent queue client creation
-        _initLock.Wait();
+        await _initLock.WaitAsync();
         try
         {
             // QueueClient instances are not owned by this factory and should not be disposed here

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueEnvelope.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueEnvelope.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace HoneyDrunk.Transport.StorageQueue.Internal;
+
+/// <summary>
+/// Serializable envelope for Azure Storage Queue messages.
+/// </summary>
+/// <remarks>
+/// This class represents the serialized form of a transport envelope that can be
+/// stored in Azure Storage Queue as JSON text.
+/// </remarks>
+internal sealed class StorageQueueEnvelope
+{
+    /// <summary>
+    /// Gets or sets the unique message identifier.
+    /// </summary>
+    [JsonPropertyName("messageId")]
+    public required string MessageId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the correlation identifier for distributed tracing.
+    /// </summary>
+    [JsonPropertyName("correlationId")]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the causation identifier (parent message ID).
+    /// </summary>
+    [JsonPropertyName("causationId")]
+    public string? CausationId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message timestamp (UTC).
+    /// </summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fully qualified message type name.
+    /// </summary>
+    [JsonPropertyName("messageType")]
+    public required string MessageType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content type (e.g., "application/json").
+    /// </summary>
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message headers.
+    /// </summary>
+    [JsonPropertyName("headers")]
+    public Dictionary<string, string> Headers { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the base64-encoded payload.
+    /// </summary>
+    /// <remarks>
+    /// The actual message payload is stored as base64 to safely transmit binary data.
+    /// </remarks>
+    [JsonPropertyName("payload")]
+    public required string PayloadBase64 { get; set; }
+
+    /// <summary>
+    /// Gets or sets metadata about the envelope (version, encoding, etc.).
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, string>? Metadata { get; set; }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueEnvelope.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueEnvelope.cs
@@ -7,7 +7,8 @@ namespace HoneyDrunk.Transport.StorageQueue.Internal;
 /// </summary>
 /// <remarks>
 /// This class represents the serialized form of a transport envelope that can be
-/// stored in Azure Storage Queue as JSON text.
+/// stored in Azure Storage Queue as JSON text. The payload is base64-encoded to
+/// safely transmit binary data in text format.
 /// </remarks>
 internal sealed class StorageQueueEnvelope
 {
@@ -42,12 +43,6 @@ internal sealed class StorageQueueEnvelope
     public required string MessageType { get; set; }
 
     /// <summary>
-    /// Gets or sets the content type (e.g., "application/json").
-    /// </summary>
-    [JsonPropertyName("contentType")]
-    public string? ContentType { get; set; }
-
-    /// <summary>
     /// Gets or sets the message headers.
     /// </summary>
     [JsonPropertyName("headers")]
@@ -57,7 +52,9 @@ internal sealed class StorageQueueEnvelope
     /// Gets or sets the base64-encoded payload.
     /// </summary>
     /// <remarks>
-    /// The actual message payload is stored as base64 to safely transmit binary data.
+    /// The actual message payload is stored as base64 to safely transmit binary data
+    /// in Azure Storage Queue's text-based format. The payload is always JSON-serialized
+    /// by the transport layer before base64 encoding.
     /// </remarks>
     [JsonPropertyName("payload")]
     public required string PayloadBase64 { get; set; }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueProcessor.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueProcessor.cs
@@ -1,0 +1,516 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Azure;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Pipeline;
+using HoneyDrunk.Transport.Primitives;
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using HoneyDrunk.Transport.Telemetry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.StorageQueue.Internal;
+
+/// <summary>
+/// Azure Storage Queue implementation of transport consumer.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="StorageQueueProcessor"/> class.
+/// </remarks>
+/// <param name="queueClientFactory">The queue client factory.</param>
+/// <param name="pipeline">The message processing pipeline.</param>
+/// <param name="options">The storage queue configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
+internal sealed class StorageQueueProcessor(
+    QueueClientFactory queueClientFactory,
+    IMessagePipeline pipeline,
+    IOptions<StorageQueueOptions> options,
+    ILogger<StorageQueueProcessor> logger) : ITransportConsumer, IAsyncDisposable
+{
+    private static readonly JsonSerializerOptions DeserializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly QueueClientFactory _queueClientFactory = queueClientFactory;
+    private readonly IMessagePipeline _pipeline = pipeline;
+    private readonly StorageQueueOptions _options = options.Value;
+    private readonly ILogger<StorageQueueProcessor> _logger = logger;
+    private readonly PoisonQueueMover _poisonMover = new(logger);
+    private readonly SemaphoreSlim _startStopLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private Task? _processingTask;
+    private bool _disposed;
+
+    // Backoff state
+    private TimeSpan _currentPollingInterval;
+    private int _consecutiveEmptyReceives;
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        await _startStopLock.WaitAsync(cancellationToken);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_cts != null)
+            {
+                throw new InvalidOperationException("Consumer is already started");
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Starting Storage Queue consumer for queue {QueueName}",
+                    _options.QueueName);
+            }
+
+            // Initialize backoff state
+            _currentPollingInterval = _options.EmptyQueuePollingInterval;
+            _consecutiveEmptyReceives = 0;
+
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            // Start multiple concurrent consumers based on MaxConcurrency
+            var tasks = new List<Task>();
+            for (int i = 0; i < _options.MaxConcurrency; i++)
+            {
+                var consumerId = i;
+                var task = Task.Run(
+                    async () =>
+                    {
+                        await ConsumeMessagesAsync(consumerId, _cts.Token);
+                    },
+                    _cts.Token);
+                tasks.Add(task);
+            }
+
+            _processingTask = Task.WhenAll(tasks);
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Started {ConsumerCount} concurrent consumers for queue {QueueName}",
+                    _options.MaxConcurrency,
+                    _options.QueueName);
+            }
+        }
+        finally
+        {
+            _startStopLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        await _startStopLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_cts == null)
+            {
+                return;
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Stopping Storage Queue consumer for queue {QueueName}",
+                    _options.QueueName);
+            }
+
+            await _cts.CancelAsync();
+
+            if (_processingTask != null)
+            {
+                try
+                {
+                    await _processingTask;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when stopping
+                }
+            }
+
+            _cts.Dispose();
+            _cts = null;
+            _processingTask = null;
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("Consumer stopped");
+            }
+        }
+        finally
+        {
+            _startStopLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, true))
+        {
+            return;
+        }
+
+        try
+        {
+            await StopAsync();
+        }
+        finally
+        {
+            _startStopLock.Dispose();
+            _queueClientFactory.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Deserializes a Storage Queue message to a transport envelope.
+    /// </summary>
+    private static TransportEnvelope DeserializeEnvelope(QueueMessage message)
+    {
+        var messageText = message.Body.ToString();
+        var queueEnvelope = JsonSerializer.Deserialize<StorageQueueEnvelope>(messageText, DeserializerOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize message {message.MessageId}");
+
+        var payloadBytes = Convert.FromBase64String(queueEnvelope.PayloadBase64);
+
+        return new TransportEnvelope
+        {
+            MessageId = queueEnvelope.MessageId,
+            CorrelationId = queueEnvelope.CorrelationId,
+            CausationId = queueEnvelope.CausationId,
+            Timestamp = queueEnvelope.Timestamp,
+            MessageType = queueEnvelope.MessageType,
+            Headers = new Dictionary<string, string>(queueEnvelope.Headers),
+            Payload = payloadBytes
+        };
+    }
+
+    /// <summary>
+    /// Determines if an Azure Storage error is transient.
+    /// </summary>
+    private static bool IsTransientError(RequestFailedException ex)
+    {
+        // HTTP 5xx errors (server errors) are typically transient
+        return ex.Status >= 500 && ex.Status < 600;
+    }
+
+    /// <summary>
+    /// Background consumer loop for receiving and processing messages.
+    /// </summary>
+    private async Task ConsumeMessagesAsync(int consumerId, CancellationToken cancellationToken)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Consumer {ConsumerId} started for queue {QueueName}",
+                consumerId,
+                _options.QueueName);
+        }
+
+        try
+        {
+            var queueClient = await _queueClientFactory.GetOrCreatePrimaryQueueClientAsync(cancellationToken);
+            var poisonQueueClient = await _queueClientFactory.GetOrCreatePoisonQueueClientAsync(cancellationToken);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Receive messages from queue
+                    var messages = await ReceiveMessagesAsync(queueClient, cancellationToken);
+
+                    if (messages.Length == 0)
+                    {
+                        // Queue is empty, apply exponential backoff
+                        await HandleEmptyQueueAsync(consumerId, cancellationToken);
+                        continue;
+                    }
+
+                    // Reset backoff since we got messages
+                    ResetBackoff();
+
+                    // Process each message
+                    foreach (var message in messages)
+                    {
+                        await ProcessMessageAsync(
+                            queueClient,
+                            poisonQueueClient,
+                            message,
+                            cancellationToken);
+                    }
+                }
+                catch (RequestFailedException ex) when (IsTransientError(ex))
+                {
+                    if (_logger.IsEnabled(LogLevel.Warning))
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Consumer {ConsumerId} encountered transient error, will retry",
+                            consumerId);
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when stopping
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsEnabled(LogLevel.Error))
+                    {
+                        _logger.LogError(
+                            ex,
+                            "Consumer {ConsumerId} encountered unexpected error",
+                            consumerId);
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Consumer {ConsumerId} fatal error",
+                    consumerId);
+            }
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Consumer {ConsumerId} stopped", consumerId);
+        }
+    }
+
+    /// <summary>
+    /// Receives messages from the queue.
+    /// </summary>
+    private async Task<QueueMessage[]> ReceiveMessagesAsync(
+        QueueClient queueClient,
+        CancellationToken cancellationToken)
+    {
+        var response = await queueClient.ReceiveMessagesAsync(
+            maxMessages: _options.PrefetchMaxMessages,
+            visibilityTimeout: _options.VisibilityTimeout,
+            cancellationToken: cancellationToken);
+
+        return response.Value ?? [];
+    }
+
+    /// <summary>
+    /// Processes a single message through the pipeline.
+    /// </summary>
+    private async Task ProcessMessageAsync(
+        QueueClient queueClient,
+        QueueClient poisonQueueClient,
+        QueueMessage message,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Deserialize envelope
+            var envelope = DeserializeEnvelope(message);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Processing message {MessageId} (dequeue count: {DequeueCount})",
+                    envelope.MessageId,
+                    message.DequeueCount);
+            }
+
+            using var activity = _options.EnableTelemetry
+                ? TransportTelemetry.StartProcessActivity(envelope, _options.QueueName)
+                : null;
+
+            TransportTelemetry.RecordDeliveryCount(activity, (int)message.DequeueCount);
+
+            // Create message context
+            var context = new MessageContext
+            {
+                Envelope = envelope,
+                Transaction = NoOpTransportTransaction.Instance,
+                DeliveryCount = (int)message.DequeueCount
+            };
+
+            try
+            {
+                // Process through pipeline
+                var result = await _pipeline.ProcessAsync(envelope, context, cancellationToken);
+
+                if (result == MessageProcessingResult.Success)
+                {
+                    // Delete message from queue
+                    await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+
+                    TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Successfully processed message {MessageId}", envelope.MessageId);
+                    }
+                }
+                else if (result == MessageProcessingResult.DeadLetter)
+                {
+                    // Move to poison queue immediately
+                    await _poisonMover.MoveMessageToPoisonQueueAsync(
+                        poisonQueueClient,
+                        message,
+                        null,
+                        message.DequeueCount,
+                        cancellationToken);
+
+                    // Delete from primary queue
+                    await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+
+                    TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.DeadLetter);
+                }
+                else
+                {
+                    // Retry: Check if max dequeue count exceeded
+                    if (message.DequeueCount >= _options.MaxDequeueCount)
+                    {
+                        if (_logger.IsEnabled(LogLevel.Warning))
+                        {
+                            _logger.LogWarning(
+                                "Message {MessageId} exceeded max dequeue count ({MaxDequeueCount}), moving to poison queue",
+                                envelope.MessageId,
+                                _options.MaxDequeueCount);
+                        }
+
+                        await _poisonMover.MoveMessageToPoisonQueueAsync(
+                            poisonQueueClient,
+                            message,
+                            null,
+                            message.DequeueCount,
+                            cancellationToken);
+
+                        await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+
+                        TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.DeadLetter);
+                    }
+                    else
+                    {
+                        // Message will become visible again after VisibilityTimeout.
+                        // Optionally extend visibility for longer retry delays.
+                        TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Retry);
+
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug(
+                                "Message {MessageId} will be retried (dequeue count: {DequeueCount})",
+                                envelope.MessageId,
+                                message.DequeueCount);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                TransportTelemetry.RecordError(activity, ex);
+                throw;
+            }
+        }
+        catch (Exception processingError)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    processingError,
+                    "Failed to process message {MessageId}",
+                    message.MessageId);
+            }
+
+            // Check if message should be poisoned
+            if (message.DequeueCount >= _options.MaxDequeueCount)
+            {
+                try
+                {
+                    await _poisonMover.MoveMessageToPoisonQueueAsync(
+                        poisonQueueClient,
+                        message,
+                        processingError,
+                        message.DequeueCount,
+                        cancellationToken);
+
+                    await queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt, cancellationToken);
+                }
+                catch (Exception poisonEx)
+                {
+                    if (_logger.IsEnabled(LogLevel.Error))
+                    {
+                        _logger.LogError(
+                            poisonEx,
+                            "Failed to move message {MessageId} to poison queue",
+                            message.MessageId);
+                    }
+                }
+            }
+
+            // Otherwise, message will reappear after visibility timeout for retry
+        }
+    }
+
+    /// <summary>
+    /// Handles empty queue scenario with exponential backoff.
+    /// </summary>
+    private async Task HandleEmptyQueueAsync(int consumerId, CancellationToken cancellationToken)
+    {
+        _consecutiveEmptyReceives++;
+
+        // Apply exponential backoff with jitter
+        if (_consecutiveEmptyReceives > 1)
+        {
+            _currentPollingInterval = TimeSpan.FromMilliseconds(
+                Math.Min(
+                    _currentPollingInterval.TotalMilliseconds * 1.5,
+                    _options.MaxPollingInterval.TotalMilliseconds));
+        }
+
+        // Add jitter (±25%)
+        var jitter = (Random.Shared.NextDouble() * 0.5) - 0.25; // -0.25 to +0.25
+        var delayMs = _currentPollingInterval.TotalMilliseconds * (1 + jitter);
+
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(
+                "Consumer {ConsumerId} queue empty, waiting {DelayMs}ms",
+                consumerId,
+                delayMs);
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken);
+    }
+
+    /// <summary>
+    /// Resets backoff state when messages are received.
+    /// </summary>
+    private void ResetBackoff()
+    {
+        if (_consecutiveEmptyReceives > 0)
+        {
+            _consecutiveEmptyReceives = 0;
+            _currentPollingInterval = _options.EmptyQueuePollingInterval;
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueProcessor.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueProcessor.cs
@@ -542,9 +542,8 @@ internal sealed class StorageQueueProcessor(
     private sealed class ConsumerBackoffState(TimeSpan initialPollingInterval)
     {
         private int _consecutiveEmptyReceives;
-        private TimeSpan _currentPollingInterval = initialPollingInterval;
 
-        public TimeSpan CurrentPollingInterval => _currentPollingInterval;
+        public TimeSpan CurrentPollingInterval { get; private set; } = initialPollingInterval;
 
         /// <summary>
         /// Increments the empty receive counter.
@@ -562,9 +561,9 @@ internal sealed class StorageQueueProcessor(
         {
             if (_consecutiveEmptyReceives > 1)
             {
-                _currentPollingInterval = TimeSpan.FromMilliseconds(
+                CurrentPollingInterval = TimeSpan.FromMilliseconds(
                     Math.Min(
-                        _currentPollingInterval.TotalMilliseconds * 1.5,
+                        CurrentPollingInterval.TotalMilliseconds * 1.5,
                         maxPollingInterval.TotalMilliseconds));
             }
         }
@@ -578,7 +577,7 @@ internal sealed class StorageQueueProcessor(
             if (_consecutiveEmptyReceives > 0)
             {
                 _consecutiveEmptyReceives = 0;
-                _currentPollingInterval = initialPollingInterval;
+                CurrentPollingInterval = initialPollingInterval;
             }
         }
     }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueSender.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/Internal/StorageQueueSender.cs
@@ -1,0 +1,252 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using Azure;
+using Azure.Storage.Queues;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Primitives;
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using HoneyDrunk.Transport.StorageQueue.Exceptions;
+using HoneyDrunk.Transport.Telemetry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.StorageQueue.Internal;
+
+/// <summary>
+/// Azure Storage Queue implementation of transport publisher.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="StorageQueueSender"/> class.
+/// </remarks>
+/// <param name="queueClientFactory">The queue client factory.</param>
+/// <param name="options">The storage queue configuration options.</param>
+/// <param name="logger">The logger instance.</param>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated by dependency injection")]
+internal sealed class StorageQueueSender(
+    QueueClientFactory queueClientFactory,
+    IOptions<StorageQueueOptions> options,
+    ILogger<StorageQueueSender> logger) : ITransportPublisher, IAsyncDisposable
+{
+    // Azure Storage Queue max message size is ~64KB (base64-encoded)
+    private const int MaxMessageSizeBytes = 64 * 1024;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly QueueClientFactory _queueClientFactory = queueClientFactory;
+    private readonly StorageQueueOptions _options = options.Value;
+    private readonly ILogger<StorageQueueSender> _logger = logger;
+    private readonly SemaphoreSlim _sendLock = new(Environment.ProcessorCount, Environment.ProcessorCount);
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public async Task PublishAsync(
+        ITransportEnvelope envelope,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        using var activity = _options.EnableTelemetry
+            ? TransportTelemetry.StartPublishActivity(envelope, destination)
+            : null;
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Publishing message {MessageId} of type {MessageType} to queue {QueueName}",
+                    envelope.MessageId,
+                    envelope.MessageType,
+                    destination.Address);
+            }
+
+            // Serialize envelope to JSON
+            var messageText = SerializeEnvelope(envelope);
+
+            // Validate size
+            var messageSizeBytes = Encoding.UTF8.GetByteCount(messageText);
+            if (messageSizeBytes > MaxMessageSizeBytes)
+            {
+                var ex = new MessageTooLargeException(envelope.MessageId, messageSizeBytes, MaxMessageSizeBytes);
+
+                if (_logger.IsEnabled(LogLevel.Error))
+                {
+                    _logger.LogError(ex, "Message {MessageId} exceeds size limit", envelope.MessageId);
+                }
+
+                TransportTelemetry.RecordError(activity, ex);
+                throw ex;
+            }
+
+            // Get queue client
+            var queueClient = await _queueClientFactory.GetOrCreatePrimaryQueueClientAsync(cancellationToken);
+
+            // Send message
+            await queueClient.SendMessageAsync(
+                messageText,
+                visibilityTimeout: null, // Visible immediately
+                timeToLive: _options.MessageTimeToLive,
+                cancellationToken: cancellationToken);
+
+            TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Successfully published message {MessageId}", envelope.MessageId);
+            }
+        }
+        catch (RequestFailedException ex) when (IsTransientError(ex))
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Transient error publishing message {MessageId}, may be retried",
+                    envelope.MessageId);
+            }
+
+            TransportTelemetry.RecordError(activity, ex);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to publish message {MessageId}",
+                    envelope.MessageId);
+            }
+
+            TransportTelemetry.RecordError(activity, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PublishBatchAsync(
+        IEnumerable<ITransportEnvelope> envelopes,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(envelopes);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        // Storage Queue doesn't support atomic batching, so parallelize sends
+        var envelopeList = envelopes.ToList();
+
+        if (envelopeList.Count == 0)
+        {
+            return;
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Publishing batch of {Count} messages to queue {QueueName}",
+                envelopeList.Count,
+                destination.Address);
+        }
+
+        var exceptions = new List<Exception>();
+
+        await Parallel.ForEachAsync(
+            envelopeList,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Environment.ProcessorCount,
+                CancellationToken = cancellationToken
+            },
+            async (envelope, ct) =>
+            {
+                try
+                {
+                    await _sendLock.WaitAsync(ct);
+                    try
+                    {
+                        await PublishAsync(envelope, destination, ct);
+                    }
+                    finally
+                    {
+                        _sendLock.Release();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (exceptions)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException(
+                $"Failed to publish {exceptions.Count} of {envelopeList.Count} messages",
+                exceptions);
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Successfully published batch of {Count} messages", envelopeList.Count);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, true))
+        {
+            return;
+        }
+
+        _sendLock.Dispose();
+        _queueClientFactory.Dispose();
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Serializes a transport envelope to JSON.
+    /// </summary>
+    private static string SerializeEnvelope(ITransportEnvelope envelope)
+    {
+        var queueEnvelope = new StorageQueueEnvelope
+        {
+            MessageId = envelope.MessageId,
+            CorrelationId = envelope.CorrelationId,
+            CausationId = envelope.CausationId,
+            Timestamp = envelope.Timestamp,
+            MessageType = envelope.MessageType,
+            ContentType = envelope.Headers.TryGetValue("ContentType", out var contentType) ? contentType : null,
+            Headers = new Dictionary<string, string>(envelope.Headers),
+            PayloadBase64 = Convert.ToBase64String(envelope.Payload.ToArray()),
+            Metadata = new Dictionary<string, string>
+            {
+                ["EnvelopeVersion"] = "1.0",
+                ["Transport"] = "StorageQueue"
+            }
+        };
+
+        return JsonSerializer.Serialize(queueEnvelope, SerializerOptions);
+    }
+
+    /// <summary>
+    /// Determines if an Azure Storage error is transient and potentially retryable.
+    /// </summary>
+    private static bool IsTransientError(RequestFailedException ex)
+    {
+        // HTTP 5xx errors (server errors) are typically transient
+        return ex.Status >= 500 && ex.Status < 600;
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
@@ -10,6 +10,7 @@
   </Folder>
   <Project Path="HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj" />
   <Project Path="HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj" />
+  <Project Path="HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj" />
   <Project Path="HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj" />
   <Project Path="HoneyDrunk.Transport/HoneyDrunk.Transport.csproj" />
 </Solution>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Abstractions/NoOpTransportTransaction.cs
@@ -12,18 +12,16 @@ public sealed class NoOpTransportTransaction : ITransportTransaction
 
     private static readonly IReadOnlyDictionary<string, object> EmptyContext = new Dictionary<string, object>();
 
-    private readonly string _transactionId;
-
     /// <summary>
     /// Prevents a default instance of the <see cref="NoOpTransportTransaction"/> class from being created.
     /// </summary>
     private NoOpTransportTransaction()
     {
-        _transactionId = Guid.NewGuid().ToString();
+        TransactionId = Guid.NewGuid().ToString();
     }
 
     /// <inheritdoc/>
-    public string TransactionId => _transactionId;
+    public string TransactionId { get; }
 
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object> Context => EmptyContext;

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.1.1" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -25,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.1.1" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.1.7">
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.1.2" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/docs/FILE_GUIDE.md
+++ b/HoneyDrunk.Transport/docs/FILE_GUIDE.md
@@ -997,221 +997,486 @@ Just like how the postal service lets you send letters without worrying about tr
 
 ---
 
-## ☁️ HoneyDrunk.Transport.AzureServiceBus
+## 🗄️ HoneyDrunk.Transport.StorageQueue
 
-*The "real postal service" using Microsoft Azure*
+*Azure Storage Queue transport for cost-effective, high-volume messaging*
 
-### ServiceBusTransportPublisher.cs
-- **What it is:** The Azure Service Bus sender
-- **Real-world analogy:** The interface to FedEx/UPS for sending packages
-- **What it does:** Publishes messages to real Azure Service Bus topics/queues
-- **How it's used:** Injected as `ITransportPublisher`; converts envelopes to ServiceBusMessage
-- **Why it matters:** Production-grade message delivery with Azure's reliability guarantees
-- **When to use:** Production deployments requiring durable messaging
+### Overview
+
+The Storage Queue transport provides a lightweight, cost-effective messaging solution using Azure Storage Queues. It's ideal for high-volume scenarios where advanced features like sessions, transactions, or pub/sub aren't required.
+
+**Key Characteristics:**
+- ✅ Simple queue-based messaging (no topics/subscriptions)
+- ✅ Cost-effective for high-volume scenarios
+- ✅ Message size limit: ~64KB (after base64 encoding)
+- ✅ At-least-once delivery semantics
+- ✅ Built-in poison queue pattern
+- ✅ Exponential backoff for empty queues
+- ⚠️ No FIFO guarantees beyond basic queue semantics
+- ⚠️ No native dead-letter queue (implemented via poison queue)
+- ⚠️ No built-in duplicate detection
+
+### When to Use Storage Queue vs Service Bus
+
+**Choose Storage Queue when:**
+- Cost optimization is a priority
+- Message volume is very high (millions per day)
+- Simple queue semantics are sufficient
+- Message size < 64KB
+- At-least-once delivery is acceptable
+- No need for pub/sub patterns
+
+**Choose Service Bus when:**
+- Need topics/subscriptions (pub/sub)
+- Require sessions for ordered processing
+- Need transactional receive
+- Message size up to 1MB+ 
+- Dead-letter queue with automatic retry policies
+- Duplicate detection is required
+
+### StorageQueueOptions.cs
+
+- **What it is:** Configuration for Azure Storage Queue transport
+- **Real-world analogy:** Settings for a simpler, more economical postal service
+- **What it does:** Configures connection, queue names, polling, and poison handling
+- **How it's used:** Configure via builder pattern or options binding
+- **Why it matters:** Controls all aspects of Storage Queue behavior
+- **When to use:** During startup when registering Storage Queue transport
 - **Example:**
   ```csharp
-  services.AddHoneyDrunkTransportCore()
-      .AddHoneyDrunkServiceBusTransport(options =>
-      {
-          options.ConnectionString = configuration["AzureServiceBus:ConnectionString"];
-          options.TopicName = "orders";
-      });
-  
-  // Publisher uses Azure Service Bus automatically
-  await _publisher.PublishAsync(envelope, ct); // Sends to Azure
-  ```
-
-### ServiceBusTransportConsumer.cs
-- **What it is:** The Azure Service Bus receiver
-- **Real-world analogy:** The interface that receives packages from FedEx/UPS
-- **What it does:** Listens to Azure Service Bus and processes incoming messages
-- **How it's used:** Runs as background service; supports queues, topics, sessions
-- **Why it matters:** Reliable message reception with automatic lock renewal and dead-lettering
-- **When to use:** Production deployments consuming from Azure Service Bus
-- **Example:**
-  ```csharp
-  services.AddHoneyDrunkTransportCore()
-      .AddHoneyDrunkServiceBusTransport(options => /* ... */)
-      .WithTopicSubscription("order-processor") // Consumer listens to subscription
-      .WithSessions(); // Enable session support if needed
-  ```
-
-### Configuration/AzureServiceBusOptions.cs
-- **What it is:** Settings specific to Azure Service Bus
-- **Real-world analogy:** Your FedEx account settings (connection string, retry policy)
-- **What it does:** Configures connection strings, topic names, subscriptions, sessions
-- **How it's used:** Configure via builder or IOptions binding
-- **Why it matters:** Centralizes Azure-specific settings
-- **When to use:** Configure during startup for Azure deployments
-- **Example:**
-  ```csharp
-  // appsettings.json
+  services.AddHoneyDrunkTransportStorageQueue(options =>
   {
-    "AzureServiceBus": {
-      "ConnectionString": "Endpoint=sb://...",
-      "TopicName": "orders",
-      "SubscriptionName": "order-processor",
-      "EnableSessions": false,
-      "MaxConcurrentCalls": 10,
-      "PrefetchCount": 100
-    }
-  }
-  
-  // Startup
-  services.AddHoneyDrunkTransportCore()
-      .AddHoneyDrunkServiceBusTransport(
-          configuration.GetSection("AzureServiceBus"));
+      // Connection
+      options.ConnectionString = config["StorageQueue:ConnectionString"];
+      options.QueueName = "orders";
+      options.CreateIfNotExists = true;
+      
+      // Message Settings
+      options.Base64EncodePayload = true;  // Handle binary data safely
+      options.MessageTimeToLive = TimeSpan.FromDays(7);
+      options.VisibilityTimeout = TimeSpan.FromSeconds(30);
+      
+      // Processing
+      options.MaxConcurrency = 5;
+      options.PrefetchMaxMessages = 16;  // 1-32 range
+      
+      // Poison Handling
+      options.MaxDequeueCount = 5;  // Move to poison after 5 attempts
+      options.PoisonQueueName = "orders-poison";
+      
+      // Polling (empty queue optimization)
+      options.EmptyQueuePollingInterval = TimeSpan.FromSeconds(1);
+      options.MaxPollingInterval = TimeSpan.FromSeconds(5);
+      
+      // Observability
+      options.EnableTelemetry = true;
+      options.EnableLogging = true;
+      options.EnableCorrelation = true;
+  });
   ```
 
-### Mapping/EnvelopeMapper.cs
-- **What it is:** The "format converter"
-- **Real-world analogy:** Converts your internal envelope format to Azure's package format
-- **What it does:** Maps between TransportEnvelope and Azure ServiceBusMessage
-- **How it's used:** Internal component used by publisher/consumer
-- **Why it matters:** Bridges library abstraction with Azure's native message format
-- **When to use:** Used internally - not typically interacted with directly
-- **Example:**
-  ```csharp
-  // Internal mapping:
-  // TransportEnvelope.MessageId → ServiceBusMessage.MessageId
-  // TransportEnvelope.CorrelationId → ServiceBusMessage.CorrelationId
-  // TransportEnvelope.Headers → ServiceBusMessage.ApplicationProperties
-  // TransportEnvelope.Payload → ServiceBusMessage.Body
-  ```
+**Key Properties:**
+- `ConnectionString` / `AccountEndpoint`: Azure Storage authentication
+- `QueueName`: Primary queue name (required)
+- `PoisonQueueName`: Dead-letter queue name (defaults to `{QueueName}-poison`)
+- `MaxDequeueCount`: Attempts before poisoning (default: 5)
+- `VisibilityTimeout`: Message lock duration (default: 30s)
+- `PrefetchMaxMessages`: Batch size 1-32 (default: 16)
+- `EmptyQueuePollingInterval`: Initial backoff delay (default: 1s)
+- `MaxPollingInterval`: Max backoff delay (default: 5s)
 
-### DependencyInjection/ServiceCollectionExtensions.cs
-- **What it is:** Setup wizard for Azure Service Bus
-- **Real-world analogy:** "Connect to Azure" configuration wizard
-- **What it does:** Registers Azure Service Bus transport with your application
-- **How it's used:** Call `AddHoneyDrunkServiceBusTransport()` in startup
-- **Why it matters:** Fluent API for Azure-specific configuration
-- **When to use:** Production deployments using Azure Service Bus
-- **Example:**
-  ```csharp
-  services.AddHoneyDrunkTransportCore()
-      .AddHoneyDrunkServiceBusTransport(options =>
-      {
-          options.ConnectionString = configuration["AzureServiceBus:ConnectionString"];
-          options.TopicName = "orders";
-      })
-      .WithTopicSubscription("order-processor")
-      .WithSessions() // Enable sessions
-      .WithRetry(retry =>
-      {
-          retry.MaxAttempts = 5;
-          retry.BackoffStrategy = BackoffStrategy.Exponential;
-      });
-  ```
+### StorageQueueSender.cs
 
----
+- **What it is:** Azure Storage Queue publisher implementation
+- **Real-world analogy:** The budget postal counter that handles high volumes
+- **What it does:** Serializes envelopes to JSON and sends to Azure Storage Queue
+- **How it's used:** Injected as `ITransportPublisher`; automatically used when Storage Queue transport is registered
+- **Why it matters:** Provides cost-effective, reliable message publishing
+- **When to use:** Automatically used - no direct interaction needed
+- **Technical Details:**
+  - Serializes `ITransportEnvelope` → `StorageQueueEnvelope` → JSON
+  - Base64-encodes payload for safe text transmission
+  - Validates message size (max ~64KB)
+  - Throws `MessageTooLargeException` if size exceeded
+  - Batch publishing uses parallelized individual sends (non-atomic)
+  - Detects transient errors (HTTP 5xx) for retry
 
-## 🎯 Summary: The Big Picture
-
-### What problem does this solve?
-
-Applications need to send messages to each other, but each messaging system (Azure Service Bus, RabbitMQ, Kafka, etc.) works differently. This library provides one consistent way to send and receive messages, and you can swap out the underlying technology without changing your code.
-
-### How to explain it to a non-technical person:
-
-> "Imagine you write letters, but you don't want to care whether they're sent by USPS, FedEx, or carrier pigeon. This library is like having one mailbox where you drop letters, and it figures out which delivery service to use. You can switch from one delivery service to another without rewriting your letters."
-
-### How to explain it to a developer:
-
-> "It's a transport-agnostic messaging abstraction layer with a middleware pipeline pattern (like ASP.NET Core). Write your message handlers once, then plug in Azure Service Bus, RabbitMQ, or in-memory for testing. Includes retry policies, correlation tracking, telemetry, and transactional outbox pattern out of the box."
-
----
-
-## 📚 Quick Reference
-
-### Core Concepts
-
-| Concept | Description | Analogy |
-|---------|-------------|---------|
-| **Envelope** | Message wrapper with metadata | Physical envelope with address |
-| **Publisher** | Sends messages | Post office counter |
-| **Consumer** | Receives messages | Mailbox |
-| **Handler** | Processes specific message types | Mail sorter |
-| **Middleware** | Processing pipeline steps | Assembly line stations |
-| **Serializer** | Converts objects to/from bytes | Translator |
-| **Outbox** | Transactional message store | Safe for important mail |
-
-### Message Flow
-
-```
-1. Create Message → 2. Wrap in Envelope → 3. Serialize → 4. Publish
-                                                              ↓
-5. Consumer Receives ← 6. Deserialize ← 7. Pipeline (Middleware) ← 8. Handler
-```
-
-### Middleware Pipeline Order
-
-```
-Message → Correlation → Telemetry → Logging → Custom → Retry → Handler
-```
-
-### Common Usage Patterns
-
-#### Basic Publish/Subscribe
+**Example Usage:**
 ```csharp
-// Publish
-var message = new OrderCreated(orderId, customerId);
-var envelope = factory.Create(message, "orders.created");
-await publisher.PublishAsync(envelope, ct);
-
-// Subscribe (handler)
-public class OrderCreatedHandler : IMessageHandler<OrderCreated>
+// Automatic usage through ITransportPublisher
+public class OrderService(ITransportPublisher publisher, EnvelopeFactory factory)
 {
-    public async Task<MessageProcessingResult> HandleAsync(OrderCreated message, MessageContext context, CancellationToken ct)
+    public async Task PublishOrderAsync(Order order, CancellationToken ct)
     {
-        // Process message
+        var message = new OrderCreated(order.Id, order.CustomerId);
+        var envelope = factory.CreateEnvelope<OrderCreated>(
+            serializer.Serialize(message));
+        
+        // Publishes to Storage Queue automatically
+        await publisher.PublishAsync(envelope, new EndpointAddress("orders"), ct);
+    }
+}
+```
+
+**Size Limit Handling:**
+```csharp
+try
+{
+    await publisher.PublishAsync(largeEnvelope, destination, ct);
+}
+catch (MessageTooLargeException ex)
+{
+    // Message exceeds 64KB - consider using Blob Storage + reference
+    _logger.LogError(ex, 
+        "Message {MessageId} is {ActualSize}KB (max: {MaxSize}KB)",
+        ex.MessageId, ex.ActualSize / 1024, ex.MaxSize / 1024);
+    
+    // Alternative: Store payload in Blob Storage
+    var blobUrl = await _blobStorage.UploadAsync(payload);
+    var referenceMessage = new BlobReferenceMessage(blobUrl);
+    await publisher.PublishAsync(CreateEnvelope(referenceMessage), destination, ct);
+}
+```
+
+### StorageQueueProcessor.cs
+
+- **What it is:** Azure Storage Queue consumer implementation
+- **Real-world analogy:** The receiving station that polls for mail and handles bad letters
+- **What it does:** Polls queue, processes messages through pipeline, handles poison messages
+- **How it's used:** Runs as background service; automatically started when transport is registered
+- **Why it matters:** Reliable message consumption with automatic poison handling and backoff
+- **When to use:** Automatically started - no direct interaction needed
+- **Technical Details:**
+  - Concurrent processing based on `MaxConcurrency`
+  - Exponential backoff with jitter when queue is empty
+  - Automatic poison queue handling after `MaxDequeueCount` attempts
+  - Deserializes JSON → `StorageQueueEnvelope` → `TransportEnvelope`
+  - Integrates with message pipeline for middleware/handler execution
+  - Uses visibility timeout for message locking during processing
+
+**Processing Flow:**
+```
+1. Poll queue (batch: PrefetchMaxMessages)
+2. For each message:
+   - Deserialize envelope
+   - Create message context (with DeliveryCount)
+   - Process through pipeline
+   - On Success: Delete message
+   - On DeadLetter: Move to poison queue + delete
+   - On Retry: 
+     - If dequeue count >= MaxDequeueCount: Move to poison + delete
+     - Else: Leave in queue (becomes visible after VisibilityTimeout)
+3. If queue empty: Apply exponential backoff
+4. Repeat
+```
+
+**Backoff Strategy:**
+- Initial delay: `EmptyQueuePollingInterval` (1s)
+- Each empty poll: delay *= 1.5
+- Maximum delay: `MaxPollingInterval` (5s)
+- Jitter: ±25% to prevent thundering herd
+- Reset when messages found
+
+**Example Handler with Retry Control:**
+```csharp
+public class PaymentProcessingHandler : IMessageHandler<ProcessPayment>
+{
+    public async Task<MessageProcessingResult> HandleAsync(
+        ProcessPayment message, 
+        MessageContext context, 
+        CancellationToken ct)
+    {
+        // Check delivery count for monitoring
+        if (context.DeliveryCount > 3)
+        {
+            _logger.LogWarning(
+                "Payment {PaymentId} retry attempt {Attempt}",
+                message.PaymentId, context.DeliveryCount);
+        }
+        
+        try
+        {
+            var result = await _paymentGateway.ProcessAsync(message, ct);
+            
+            if (result.IsSuccess)
+                return MessageProcessingResult.Success;  // Delete from queue
+            
+            if (result.IsTransient)
+                return MessageProcessingResult.Retry;    // Retry with backoff
+            
+            // Permanent error - move to poison immediately
+            return MessageProcessingResult.DeadLetter;
+        }
+        catch (TimeoutException)
+        {
+            return MessageProcessingResult.Retry;  // Transient - retry
+        }
+        catch (ValidationException)
+        {
+            return MessageProcessingResult.DeadLetter;  // Invalid data - poison
+        }
+    }
+}
+```
+
+### PoisonQueueMover.cs
+
+- **What it is:** Helper for moving poison messages with rich error metadata
+- **Real-world analogy:** The undeliverable mail processing center that documents why delivery failed
+- **What it does:** Moves failed messages to poison queue with detailed error information
+- **How it's used:** Internal helper used by `StorageQueueProcessor`
+- **Why it matters:** Preserves failed messages for debugging and manual intervention
+- **When to use:** Automatically invoked when `MaxDequeueCount` is exceeded
+- **Technical Details:**
+  - Creates `PoisonEnvelope` with original message + error metadata
+  - Includes exception type, message, stack trace
+  - Tracks first/last failure timestamps
+  - Records dequeue count history
+  - Preserves Azure Storage metadata (PopReceipt, timestamps)
+
+**Poison Envelope Structure:**
+```json
+{
+  "originalMessageId": "msg-abc-123",
+  "originalMessage": "{...}",  // Full original message JSON
+  "dequeueCount": 5,
+  "firstFailureTimestamp": "2025-01-15T10:00:00Z",
+  "lastFailureTimestamp": "2025-01-15T10:15:00Z",
+  "errorType": "System.TimeoutException",
+  "errorMessage": "Payment gateway timeout after 30s",
+  "errorStackTrace": "at PaymentGateway.ProcessAsync...",
+  "metadata": {
+    "popReceipt": "...",
+    "insertedOn": "2025-01-15T10:00:00Z",
+    "expiresOn": "2025-01-22T10:00:00Z",
+    "nextVisibleOn": "2025-01-15T10:05:00Z"
+  }
+}
+```
+
+**Monitoring Poison Queue:**
+```csharp
+// Check poison queue for failed messages
+var poisonQueueClient = new QueueClient(connectionString, "orders-poison");
+var messages = await poisonQueueClient.ReceiveMessagesAsync(maxMessages: 32);
+
+foreach (var message in messages.Value)
+{
+    var poisonEnvelope = JsonSerializer.Deserialize<PoisonEnvelope>(
+        message.Body.ToString());
+    
+    _logger.LogError(
+        "Poison message {MessageId}: {ErrorType} after {Attempts} attempts",
+        poisonEnvelope.OriginalMessageId,
+        poisonEnvelope.ErrorType,
+        poisonEnvelope.DequeueCount);
+    
+    // Analyze error, fix root cause, then:
+    // Option 1: Replay to main queue
+    // Option 2: Delete if permanently invalid
+}
+```
+
+### QueueClientFactory.cs
+
+- **What it is:** Factory for creating and managing Azure Storage Queue clients
+- **Real-world analogy:** The connection pool manager for postal service locations
+- **What it does:** Thread-safe lazy initialization of primary and poison queue clients
+- **How it's used:** Internal service managing queue client lifecycle
+- **Why it matters:** Ensures single client instances, handles queue creation
+- **When to use:** Used internally - not directly accessed
+- **Technical Details:**
+  - Implements `IDisposable` for proper resource cleanup
+  - Thread-safe initialization using `SemaphoreSlim`
+  - Double-check locking pattern for lazy initialization
+  - Optionally creates queues if they don't exist
+  - Supports connection string authentication (managed identity TODO)
+
+**Initialization Pattern:**
+```csharp
+// First call initializes and creates queue (if CreateIfNotExists = true)
+var queueClient = await factory.GetOrCreatePrimaryQueueClientAsync(ct);
+// Subsequent calls return cached instance (no Azure calls)
+
+var poisonClient = await factory.GetOrCreatePoisonQueueClientAsync(ct);
+```
+
+### StorageQueueEnvelope.cs
+
+- **What it is:** Serializable envelope for Azure Storage Queue messages
+- **Real-world analogy:** The standardized postal format that fits in queue "mailboxes"
+- **What it does:** JSON-serializable representation of `ITransportEnvelope`
+- **How it's used:** Internal DTO for serialization/deserialization
+- **Why it matters:** Bridges binary envelope format with text-based Azure Storage Queue
+- **When to use:** Used internally - not directly accessed
+- **Technical Details:**
+  - All `ITransportEnvelope` properties mapped
+  - Payload stored as Base64-encoded string
+  - Headers preserved as dictionary
+  - Metadata includes envelope version and transport name
+  - Uses camelCase JSON naming for consistency
+
+**Serialization Flow:**
+```
+ITransportEnvelope (in-memory)
+    ↓
+StorageQueueEnvelope (POCO)
+    ↓
+JSON string
+    ↓
+Azure Storage Queue message (text)
+```
+
+### MessageTooLargeException.cs
+
+- **What it is:** Exception for messages exceeding Azure Storage Queue size limit
+- **Real-world analogy:** "Package too large for mailbox" rejection
+- **What it does:** Signals that message exceeds ~64KB limit with actionable guidance
+- **How it's used:** Thrown by `StorageQueueSender` when size validation fails
+- **Why it matters:** Prevents silent failures, provides clear guidance for resolution
+- **When to use:** Catch when publishing large messages, implement fallback strategy
+- **Technical Details:**
+  - Includes `MessageId`, `ActualSize`, `MaxSize` properties
+  - Suggests Blob Storage + reference pattern
+  - Clear, actionable error message
+
+**Handling Large Messages:**
+```csharp
+public async Task PublishLargePayloadAsync(
+    OrderData order, 
+    CancellationToken ct)
+{
+    try
+    {
+        var envelope = CreateEnvelope(order);
+        await _publisher.PublishAsync(envelope, destination, ct);
+    }
+    catch (MessageTooLargeException ex)
+    {
+        _logger.LogWarning(ex, 
+            "Order {OrderId} payload too large ({Size}KB), using Blob reference pattern",
+            order.Id, ex.ActualSize / 1024);
+        
+        // Strategy: Store large data in Blob Storage
+        var blobUri = await _blobStorage.UploadAsync(
+            $"orders/{order.Id}.json",
+            JsonSerializer.Serialize(order),
+            ct);
+        
+        // Send lightweight reference message
+        var reference = new OrderBlobReference(order.Id, blobUri);
+        var refEnvelope = CreateEnvelope(reference);
+        await _publisher.PublishAsync(refEnvelope, destination, ct);
+    }
+}
+
+// Handler retrieves from blob
+public class OrderBlobReferenceHandler(BlobStorageClient blobStorage)
+    : IMessageHandler<OrderBlobReference>
+{
+    public async Task<MessageProcessingResult> HandleAsync(
+        OrderBlobReference message, 
+        MessageContext context, 
+        CancellationToken ct)
+    {
+        var orderJson = await blobStorage.DownloadAsync(message.BlobUri, ct);
+        var order = JsonSerializer.Deserialize<OrderData>(orderJson);
+        
+        await ProcessOrderAsync(order, ct);
         return MessageProcessingResult.Success;
     }
 }
 ```
 
-#### With Retry Logic
-```csharp
-services.AddHoneyDrunkTransportCore()
-    .AddHoneyDrunkServiceBusTransport(options => /* ... */)
-    .WithRetry(retry =>
-    {
-        retry.MaxAttempts = 5;
-        retry.BackoffStrategy = BackoffStrategy.Exponential;
-    });
-```
+#### ServiceCollectionExtensions.cs
 
-#### With Transactional Outbox
-```csharp
-// In service
-using var transaction = await db.Database.BeginTransactionAsync(ct);
-db.Orders.Add(order);
-await outbox.SaveAsync(new OutboxMessage(envelope), ct);
-await db.SaveChangesAsync(ct);
-await transaction.CommitAsync(ct);
-
-// Background dispatcher publishes later
-services.AddHostedService<OutboxDispatcherService>();
-```
-
-#### Testing with InMemory
-```csharp
-// Test setup
-services.AddHoneyDrunkTransportCore()
-    .AddHoneyDrunkInMemoryTransport(); // No connection strings needed
+- **What it is:** Fluent API for registering Storage Queue transport
+- **Real-world analogy:** The enrollment form for the budget postal service
+- **What it does:** Registers all Storage Queue services with dependency injection
+- **How it's used:** Call extension methods during startup
+- **Why it matters:** Provides discoverable, type-safe configuration
+- **When to use:** Application startup/configuration
+- **Example:**
+  ```csharp
+  // Simple registration
+  services.AddHoneyDrunkTransportStorageQueue(
+      connectionString: config["StorageQueue:ConnectionString"]!,
+      queueName: "orders");
   
-// Test can publish and consume in-process
-[Fact]
-public async Task ProcessesOrderCreatedMessage()
+  // Fluent configuration
+  services.AddHoneyDrunkTransportStorageQueue(
+          config["StorageQueue:ConnectionString"]!,
+          "orders")
+      .WithMaxDequeueCount(3)                    // Poison after 3 attempts
+      .WithVisibilityTimeout(TimeSpan.FromMinutes(2))  // 2-minute lock
+      .WithPrefetchCount(32)                     // Max batch size
+      .WithConcurrency(10)                       // 10 concurrent processors
+      .WithPoisonQueue("orders-dlq")             // Custom poison queue name
+      .WithMessageTimeToLive(TimeSpan.FromDays(3));  // Auto-delete after 3 days
+  ```
+
+**Fluent Builder Methods:**
+- `WithPoisonQueue(string)` - Custom poison queue name
+- `WithMaxDequeueCount(int)` - Attempts before poisoning (1-100)
+- `WithVisibilityTimeout(TimeSpan)` - Message lock duration
+- `WithMessageTimeToLive(TimeSpan)` - Message expiration
+- `WithPrefetchCount(int)` - Batch size (1-32)
+- `WithConcurrency(int)` - Concurrent processors
+- `WithoutBase64Encoding()` - Disable payload encoding (use with caution)
+- `WithoutAutoCreateQueue()` - Skip automatic queue creation
+
+**Configuration from IConfiguration:**
+```csharp
+// appsettings.json
 {
-    await _publisher.PublishAsync(envelope, ct);
-    await Task.Delay(100); // Give consumer time to process
-    
-    // Assert handler was called
-    _mockHandler.Verify(h => h.HandleAsync(It.IsAny<OrderCreated>(), It.IsAny<MessageContext>(), It.IsAny<CancellationToken>()));
+  "StorageQueue": {
+    "ConnectionString": "DefaultEndpointsProtocol=https;...",
+    "QueueName": "orders",
+    "MaxDequeueCount": 5,
+    "VisibilityTimeout": "00:00:30",
+    "MaxConcurrency": 10,
+    "PrefetchMaxMessages": 16,
+    "PoisonQueueName": "orders-poison"
+  }
 }
+
+// Startup.cs
+services.AddHoneyDrunkTransportStorageQueue(options =>
+{
+    config.GetSection("StorageQueue").Bind(options);
+});
 ```
 
----
+### Complete Example
 
-*Last Updated: 2025-11-11*
-*Version: 0.1.0*
+**Setup:**
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableTelemetry = true;
+    options.EnableLogging = true;
+    options.EnableCorrelation = true;
+});
+
+builder.Services
+    .AddHoneyDrunkTransportStorageQueue(
+        builder.Configuration["StorageQueue:ConnectionString"]!,
+        "orders")
+    .WithMaxDequeueCount(5)
+    .WithConcurrency(10)
+    .WithPoisonQueue("orders-poison");
+
+// Register handlers
+builder.Services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+builder.Services.AddMessageHandler<OrderCancelled, OrderCancelledHandler>();
+
+var app = builder.Build();
+
+// Start consumer
+var consumer = app.Services.GetRequiredService<ITransportConsumer>();
+await consumer.StartAsync();
+
+app.Run();


### PR DESCRIPTION
Introduce Azure Storage Queue transport implementation with support for poison queue handling, exponential backoff, and observability.

- Add `StorageQueueOptions` for configuration
- Implement `ServiceCollectionExtensions` for DI registration
- Add `MessageTooLargeException` for size limit handling
- Create `PoisonQueueMover` for poison message management
- Add `QueueClientFactory` for thread-safe queue client creation
- Implement `StorageQueueProcessor` for message consumption
- Implement `StorageQueueSender` for message publishing
- Add `StorageQueueEnvelope` for JSON serialization
- Update solution and project files to include new transport
- Enhance documentation with examples and comparisons to Service Bus

Closes #42