### PR TITLE
feat(transport): enhance multi-tenancy, durability, and docs

### DIFF
--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -1,19 +1,38 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to HoneyDrunk.Transport.AzureServiceBus will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-12-03
+
+### Breaking Changes
+- **Kernel v0.3.0 Upgrade**: Requires `HoneyDrunk.Kernel.Abstractions` v0.3.0
+- **TenantId/ProjectId**: Envelope now includes `TenantId` and `ProjectId` for multi-tenant support
+- **GridHeaderNames**: Uses Kernel's canonical header names (`X-Causation-Id`, `X-Correlation-Id`, etc.)
+
+### Added
+- **Multi-Tenancy Support**: Full `TenantId` and `ProjectId` propagation via application properties
+- **EndpointAddress Pattern**: Session and partition key support via `EndpointAddress.Create()`
+- **Blob Fallback Configuration**: `BlobFallback` option for large message storage (application-level replay)
+
+### Changed
+- **AzureServiceBusOptions**: Renamed `IsQueue` to `EntityType`, `EnableSessions` to `SessionEnabled`
+- **Documentation**: Complete rewrite of README and docs for consistency
+
+### Fixed
+- **Header Standardization**: All Grid headers now use `GridHeaderNames` constants
+
 ## [0.2.0] - 2025-11-22
 
-### ?? BREAKING CHANGES
+### Breaking Changes
 - **Kernel Integration**: Requires HoneyDrunk.Kernel to be registered via `AddHoneyDrunkCoreNode` before calling `AddHoneyDrunkServiceBusTransport`
 - **Grid Context**: Envelope now includes `NodeId`, `StudioId`, `Environment` fields for Grid-aware context propagation
 
 ### Added
-- ? **Grid Context Support**: Automatic propagation of Kernel Grid context across messages
-- ? **Health Contributors**: Service Bus connectivity health monitoring
+- **Grid Context Support**: Automatic propagation of Kernel Grid context across messages
+- **Health Contributors**: Service Bus connectivity health monitoring
 
 ### Changed
 - **Dependency Updates**: Now depends on `HoneyDrunk.Kernel.Abstractions` v0.2.1

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
@@ -5,15 +5,32 @@ All notable changes to HoneyDrunk.Transport.InMemory will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-12-03
+
+### Breaking Changes
+- **Kernel v0.3.0 Upgrade**: Requires `HoneyDrunk.Kernel.Abstractions` v0.3.0
+- **TenantId/ProjectId**: Envelope now includes `TenantId` and `ProjectId` for multi-tenant support
+
+### Added
+- **Multi-Tenancy Support**: Full `TenantId` and `ProjectId` propagation
+- **TransportRuntimeHost Integration**: InMemoryTransportConsumer works with runtime host as IHostedService
+
+### Changed
+- **Documentation**: Clarified InMemory runs real pipeline (not a mock), added limitations section
+- **Test Patterns**: Examples use `TaskCompletionSource` instead of `Task.Delay`
+
+### Fixed
+- **Terminology**: Changed "Pub/Sub" to "Multi-Observer" for honest semantics
+
 ## [0.2.0] - 2025-11-22
 
-### ?? BREAKING CHANGES
+### Breaking Changes
 - **Kernel Integration**: Requires HoneyDrunk.Kernel to be registered via `AddHoneyDrunkCoreNode` before calling `AddHoneyDrunkInMemoryTransport`
 - **Grid Context**: Envelope now includes `NodeId`, `StudioId`, `Environment` fields for Grid-aware context propagation
 
 ### Added
-- ? **Grid Context Support**: Automatic propagation of Kernel Grid context across messages in test scenarios
-- ? **Full Pipeline Testing**: Test Grid context flow end-to-end
+- **Grid Context Support**: Automatic propagation of Kernel Grid context across messages in test scenarios
+- **Full Pipeline Testing**: Test Grid context flow end-to-end
 
 ### Changed
 - **Dependency Updates**: Now depends on `HoneyDrunk.Kernel.Abstractions` v0.2.1

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -1,19 +1,37 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to HoneyDrunk.Transport.StorageQueue will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-12-03
+
+### Breaking Changes
+- **Kernel v0.3.0 Upgrade**: Requires `HoneyDrunk.Kernel.Abstractions` v0.3.0
+- **TenantId/ProjectId**: JSON envelope schema now includes `tenantId` and `projectId` fields
+- **GridHeaderNames**: Uses Kernel's canonical header names
+
+### Added
+- **Multi-Tenancy Support**: Full `TenantId` and `ProjectId` propagation in JSON envelope
+- **Two-Level Concurrency**: Explicit documentation of `MaxConcurrency` x `BatchProcessingConcurrency` model
+
+### Changed
+- **Documentation**: Clarified 64KB limit applies after Base64 encoding, not raw payload
+- **Concurrency Description**: Clarified "parallel fetch loops" terminology
+
+### Fixed
+- **Header Standardization**: All Grid headers now use `GridHeaderNames` constants
+
 ## [0.2.0] - 2025-11-22
 
-### ?? BREAKING CHANGES
+### Breaking Changes
 - **Kernel Integration**: Requires HoneyDrunk.Kernel to be registered via `AddHoneyDrunkCoreNode` before calling `AddHoneyDrunkTransportStorageQueue`
 - **Grid Context**: Envelope now includes `NodeId`, `StudioId`, `Environment` fields for Grid-aware context propagation
 
 ### Added
-- ? **Grid Context Support**: Automatic propagation of Kernel Grid context across messages
-- ? **Health Contributors**: Storage Queue connectivity and backlog health monitoring
+- **Grid Context Support**: Automatic propagation of Kernel Grid context across messages
+- **Health Contributors**: Storage Queue connectivity and backlog health monitoring
 
 ### Changed
 - **Dependency Updates**: Now depends on `HoneyDrunk.Kernel.Abstractions` v0.2.1

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/README.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/README.md
@@ -7,17 +7,22 @@
 
 ## 📋 What Is This?
 
-**HoneyDrunk.Transport.StorageQueue** provides Azure Storage Queue integration for cost-effective, high-volume messaging. Ideal for simple queue-based scenarios where advanced features like topics, sessions, or transactions aren't required. Includes built-in poison queue handling, exponential backoff, and two-level concurrency control.
+**HoneyDrunk.Transport.StorageQueue** provides Azure Storage Queue integration for cost-effective, high-volume messaging. Ideal for simple queue-based scenarios where advanced features like topics, sessions, or transactions aren't required. Includes built-in poison queue handling, exponential backoff polling, and two-level concurrency control.
+
+This provider is configured via `StorageQueueOptions`, extending the core `TransportOptions` type.
 
 **Key Features:**
 - ✅ **Cost-Effective** - ~10x cheaper than Service Bus
 - ✅ **High Volume** - Millions of messages per day
-- ✅ **Simple Queues** - No topics/subscriptions complexity
+- ✅ **Simple Queues** - Point-to-point messaging
 - ✅ **Poison Queue** - Automatic dead-letter handling
 - ✅ **Exponential Backoff** - Empty queue polling optimization
 - ✅ **Two-Level Concurrency** - MaxConcurrency × BatchProcessingConcurrency
-- ⚠️ **Message Size Limit** - 64KB (base64-encoded)
+- ⚠️ **Message Size Limit** - 64KB (after Base64 encoding)
 - ⚠️ **At-Least-Once** - No duplicate detection
+
+**What Storage Queue Does Not Support:**
+> Storage Queue does not support sessions, transactions, duplicate detection, or pub/sub semantics. For those features, use Azure Service Bus.
 
 **Signal Quote:** *"High volume, low cost, simple semantics."*
 
@@ -30,12 +35,14 @@ Configuration for connection, queues, and concurrency:
 - **ConnectionString** / **AccountEndpoint** - Authentication
 - **QueueName** / **PoisonQueueName** - Queue identifiers
 - **MaxDequeueCount** - Poison threshold (default: 5)
-- **MaxConcurrency** - Number of fetch loops (default: 5)
-- **BatchProcessingConcurrency** - Concurrent messages per batch (default: 1)
+- **MaxConcurrency** - Number of parallel fetch loops (default: 5)
+- **BatchProcessingConcurrency** - Concurrent messages per fetch loop (default: 1)
 - **PrefetchMaxMessages** - Batch size 1-32 (default: 16)
 - **VisibilityTimeout** - Message lock duration (default: 30s)
 
 ### Concurrency Model
+`MaxConcurrency` controls parallel fetch loops. `BatchProcessingConcurrency` controls how many messages each loop may process concurrently.
+
 ```
 Total Concurrent Processing = MaxConcurrency × BatchProcessingConcurrency
 
@@ -45,7 +52,10 @@ Examples:
 ```
 
 ### MessageTooLargeException
-Exception thrown when messages exceed 64KB limit with guidance for Blob Storage fallback pattern.
+Exception thrown when messages exceed the 64KB limit. The 64KB limit applies to the **final Base64-encoded message body**, not the raw payload. For oversized messages, store the payload in Blob Storage and send a reference message.
+
+### Runtime Integration
+Storage Queue integrates with `TransportRuntimeHost`, health contributors, and the standard telemetry middleware for consistent observability across transports.
 
 ---
 
@@ -69,6 +79,11 @@ dotnet add package HoneyDrunk.Transport.StorageQueue
 builder.Services.AddHoneyDrunkCoreNode(nodeDescriptor);
 
 builder.Services
+    .AddHoneyDrunkTransportCore(options =>
+    {
+        options.EnableTelemetry = true;
+        options.EnableLogging = true;
+    })
     .AddHoneyDrunkTransportStorageQueue(
         builder.Configuration["StorageQueue:ConnectionString"]!,
         "orders")
@@ -78,7 +93,7 @@ builder.Services
     .WithPoisonQueue("orders-poison");
 ```
 
-### Handle Oversized Messages
+### Handle Oversized Messages (Application-Level)
 
 ```csharp
 try
@@ -87,10 +102,13 @@ try
 }
 catch (MessageTooLargeException ex)
 {
-    // Fallback: Store in Blob Storage
-    var blobUrl = await _blobStorage.UploadAsync(payload, ct);
+    // Application-level handling: store payload in Blob Storage, send reference
+    var blobUrl = await _blobStorage.UploadAsync(largePayload, ct);
     var referenceMessage = new BlobReferenceMessage(blobUrl);
-    await publisher.PublishAsync(CreateEnvelope(referenceMessage), destination, ct);
+    var referenceEnvelope = factory.CreateEnvelope<BlobReferenceMessage>(
+        serializer.Serialize(referenceMessage));
+    
+    await publisher.PublishAsync(referenceEnvelope, destination, ct);
 }
 ```
 
@@ -109,7 +127,7 @@ catch (MessageTooLargeException ex)
 - ✅ Need topics/subscriptions (pub/sub)
 - ✅ Require sessions for ordered processing
 - ✅ Need transactional receive
-- ✅ Message size up to 1MB+
+- ✅ Message size up to 100MB
 - ✅ Duplicate detection is required
 
 ---
@@ -125,7 +143,7 @@ catch (MessageTooLargeException ex)
 ## 📚 Documentation
 
 - **[Storage Queue Guide](../docs/StorageQueue.md)** - Detailed implementation guide
-- **[Concurrency Guide](../docs/STORAGE_QUEUE_CONCURRENCY.md)** - Two-level concurrency tuning
+- **[Configuration Guide](../docs/Configuration.md)** - StorageQueueOptions reference
 - **[Complete File Guide](../docs/FILE_GUIDE.md)** - Architecture documentation
 
 ---

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.slnx
@@ -21,6 +21,7 @@
     <File Path="docs/Primitives.md" />
     <File Path="docs/StorageQueue.md" />
     <File Path="docs/Testing.md" />
+    <File Path="Runtime.md" />
   </Folder>
   <Folder Name="/Pipelines/">
     <File Path="../.github/workflows/publish.yml" />

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -5,39 +5,40 @@ All notable changes to HoneyDrunk.Transport will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2025-01-28
+## [0.3.0] - 2025-12-03
 
-### ⚠️ BREAKING CHANGES
+### Breaking Changes
 - **Kernel v0.3.0 Upgrade**: Transport now requires HoneyDrunk.Kernel.Abstractions v0.3.0
 - **ITransportEnvelope Changes**: Added `TenantId` and `ProjectId` properties for multi-tenant/multi-project support
 - **WithGridContext Signature**: Added `tenantId` and `projectId` parameters
 - **GridHeaderNames**: Now uses Kernel's canonical header names (`X-Causation-Id`, `X-Correlation-Id`, etc.) instead of hardcoded strings
 
 ### Added
-- ✅ **Multi-Tenancy Support**: Full `TenantId` and `ProjectId` propagation through all transport layers
+- **Multi-Tenancy Support**: Full `TenantId` and `ProjectId` propagation through all transport layers
   - Added `TenantId` and `ProjectId` properties to `ITransportEnvelope`
   - Updated `EnvelopeFactory.CreateEnvelopeWithGridContext()` to map new fields from `IGridContext`
   - Updated `GridContextFactory` to reconstruct `TenantId` and `ProjectId` from envelopes
   - Azure Service Bus: Maps `TenantId`/`ProjectId` using `GridHeaderNames.TenantId` and `GridHeaderNames.ProjectId`
   - Storage Queue: Includes `tenantId` and `projectId` in JSON envelope schema
 
-- ✅ **GridHeaderNames Standardization**: All adapters now use Kernel's canonical header names
+- **GridHeaderNames Standardization**: All adapters now use Kernel's canonical header names
   - Replaced hardcoded `"CausationId"` with `GridHeaderNames.CausationId` (`"X-Causation-Id"`)
   - Replaced hardcoded `"CorrelationId"` with `GridHeaderNames.CorrelationId` (`"X-Correlation-Id"`)
   - Consistent header naming across Azure Service Bus, Storage Queue, and InMemory transports
 
-- ✅ **Documentation**: New comprehensive guides
-  - `docs/Publishing.md` - Complete guide for message publishing APIs (IMessagePublisher and ITransportPublisher)
-  - `docs/KernelV03IntegrationAudit.md` - Integration audit and verification checklist
+- **Documentation**: Comprehensive guide rewrites for consistency across all transports
+  - `docs/AzureServiceBus.md` - Aligned with Configuration.md, EndpointAddress patterns
+  - `docs/Testing.md` - Rewritten with proper unit/integration patterns, no ServiceProvider mutation
+  - All project READMEs updated for NuGet consistency
 
 ### Changed
 - **Dependency Updates**: Now depends on `HoneyDrunk.Kernel.Abstractions` v0.3.0
-- **GridContextFactory**: No longer duplicates `StudioId → TenantId`; uses actual `TenantId` and `ProjectId` from envelopes
+- **GridContextFactory**: No longer duplicates `StudioId -> TenantId`; uses actual `TenantId` and `ProjectId` from envelopes
 - **Azure Service Bus EnvelopeMapper**: Updated reserved properties list to include `TenantId`, `ProjectId`, and all Grid header names
 - **Storage Queue Envelope Schema**: Breaking change - JSON schema now includes `tenantId` and `projectId` fields
 
 ### Fixed
-- ✅ **Context Propagation Fidelity**: Grid context now preserves all fields through message round-trips
+- **Context Propagation Fidelity**: Grid context now preserves all fields through message round-trips
   - Fixed loss of `TenantId` and `ProjectId` in distributed messaging
   - Fixed header name inconsistencies between transport adapters
   - Ensured symmetric field mapping across all transport implementations
@@ -111,7 +112,7 @@ Application Nodes (uses all)
 
 ## [0.2.0] - 2025-11-22
 
-### ⚠️ BREAKING CHANGES
+### Breaking Changes
 - **Kernel Integration**: Transport now requires HoneyDrunk.Kernel to be registered via `AddHoneyDrunkCoreNode` before calling `AddHoneyDrunkTransportCore`
 - **ITransportEnvelope Changes**: Added `NodeId`, `StudioId`, `Environment` properties for Grid-aware context propagation
 - **Method Signature Changes**: 
@@ -120,24 +121,24 @@ Application Nodes (uses all)
 - **MessageContext Changes**: Added `IGridContext` property as first-class member
 
 ### Added
-- ✅ **Grid Context Integration**: Full IGridContext support for distributed context propagation
+- **Grid Context Integration**: Full IGridContext support for distributed context propagation
   - Added `NodeId`, `StudioId`, `Environment` to `ITransportEnvelope`
   - Added `CreateEnvelopeWithGridContext()` method to `EnvelopeFactory`
   - Added `IGridContext` property to `MessageContext`
   - Added `GridContextPropagationMiddleware` for automatic context propagation
 
-- ✅ **Health Contributors**: New health monitoring infrastructure
+- **Health Contributors**: New health monitoring infrastructure
   - `ITransportHealthContributor` - Interface for health checks
   - `TransportHealthResult` - Health check result type
   - `PublisherHealthContributor` - Publisher health monitoring
   - `OutboxHealthContributor` - Outbox backlog monitoring
 
-- ✅ **Metrics Infrastructure**: Metrics collection abstractions
+- **Metrics Infrastructure**: Metrics collection abstractions
   - `ITransportMetrics` - Metrics collection interface
   - `NoOpTransportMetrics` - Default no-op implementation
   - Ready for Kernel `IMetricsCollector` integration
 
-- ✅ **Context Factory**: `IGridContextFactory` and `GridContextFactory` for bridging Transport envelopes to Kernel Grid context
+- **Context Factory**: `IGridContextFactory` and `GridContextFactory` for bridging Transport envelopes to Kernel Grid context
 
 ### Changed
 - **Dependency Updates**: Now depends on `HoneyDrunk.Kernel.Abstractions` v0.2.1

--- a/HoneyDrunk.Transport/docs/Abstractions.md
+++ b/HoneyDrunk.Transport/docs/Abstractions.md
@@ -16,26 +16,39 @@
 - [MessageHandler\<TMessage\>.cs](#messagehandlertmessagecs-1)
 - [MessageContext.cs](#messagecontextcs)
 - [MessageProcessingResult.cs](#messageprocessingresultcs)
+- [MessageProcessingFailure.cs](#messageprocessingfailurecs)
 - [ITransportTransaction.cs](#itransporttransactioncs)
 - [NoOpTransportTransaction.cs](#nooptransporttransactioncs)
+- [ITransportTopology.cs](#itransporttopologycs)
 - [IEndpointAddress.cs](#iendpointaddresscs)
 - [EndpointAddress.cs](#endpointaddresscs)
+- [PublishOptions.cs](#publishoptionscs)
+- [MessagePriority.cs](#messageprioritycs)
 - [IMessageSerializer.cs](#imessageserializercs)
 
 ---
 
 ## Overview
 
-Core interfaces that define the transport abstraction layer. These contracts enable transport-agnostic messaging where applications depend on interfaces rather than specific broker implementations.
+Core interfaces and transport-agnostic types that define the transport abstraction layer. This folder contains both pure interfaces and shared contract types that all transports and handlers rely on. These contracts enable transport-agnostic messaging where applications depend on interfaces rather than specific broker implementations.
 
 **Location:** `HoneyDrunk.Transport/Abstractions/`
 
 **Key Abstractions:**
-- **IMessagePublisher** - Primary application-facing API for publishing typed messages
+- **IMessagePublisher** - Primary application/service-facing API for publishing typed messages with Grid context
 - **ITransportPublisher** - Low-level transport envelope publisher
 - **IMessageHandler<T>** - Interface-based message handler pattern
-- **MessageHandler<T>** - Delegate-based functional handler pattern
+- **MessageHandler<T>** - Delegate type for functional/inline handlers
 - **ITransportTransaction** - Transaction context for message processing
+- **ITransportTopology** - Declares transport adapter capabilities
+
+**Shared Contract Types:**
+- **MessageContext** - Handler context with envelope, transaction, and Grid context
+- **MessageProcessingResult** - Handler return type (Success, Retry, DeadLetter, Abandon)
+- **MessageProcessingFailure** - Structured error metadata for diagnostics
+- **EndpointAddress** - Transport-agnostic endpoint address with typed metadata
+- **PublishOptions** - Publishing customization (TTL, scheduling, priority)
+- **MessagePriority** - Priority enumeration for supported transports
 
 [↑ Back to top](#table-of-contents)
 
@@ -120,7 +133,7 @@ public interface IMessagePublisher
 
 ### Purpose
 
-High-level typed message publisher for application-level messaging. This is the **primary abstraction** for Data and Service layers to publish domain events and commands without coupling to transport-specific envelope structures.
+High-level typed message publisher for application-level messaging. This is the **primary abstraction** for application and service layers to publish domain events and commands without coupling to transport-specific envelope structures.
 
 ### Key Features
 
@@ -168,7 +181,7 @@ public class OrderService(
 ### When to Use
 
 ✅ **Use IMessagePublisher when:**
-- Publishing from application/service/data layers
+- Publishing from application or service layers
 - Working with typed domain events or commands
 - You want automatic Grid context propagation
 - You need a clean, decoupled API
@@ -192,11 +205,13 @@ public interface ITransportPublisher
     Task PublishAsync(
         ITransportEnvelope envelope,
         IEndpointAddress destination,
+        PublishOptions? options = null,
         CancellationToken cancellationToken = default);
     
     Task PublishAsync(
         IEnumerable<ITransportEnvelope> envelopes,
         IEndpointAddress destination,
+        PublishOptions? options = null,
         CancellationToken cancellationToken = default);
 }
 ```
@@ -415,3 +430,616 @@ async Task HandlePaymentProcessed(
 {
     await _paymentService.RecordPaymentAsync(message.PaymentId, ct);
 }
+```
+
+### Benefits
+
+- Lightweight and concise
+- No class boilerplate needed
+- Great for simple handlers
+- Closures for external dependencies
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessageContext.cs
+
+**Handler context with envelope, transaction, and Grid context**
+
+```csharp
+public sealed class MessageContext
+{
+    public required ITransportEnvelope Envelope { get; init; }
+    public IGridContext? GridContext { get; set; }
+    public required ITransportTransaction Transaction { get; init; }
+    public int DeliveryCount { get; init; }
+    public Dictionary<string, object> Properties { get; init; } = [];
+}
+```
+
+### Purpose
+
+Provides handlers with access to message metadata, transaction context, and distributed tracing information. The `GridContext` is populated by `GridContextPropagationMiddleware` from envelope metadata.
+
+### Usage Example
+
+```csharp
+public async Task<MessageProcessingResult> HandleAsync(
+    OrderCreated message,
+    MessageContext context,
+    CancellationToken ct)
+{
+    // Access envelope metadata
+    var messageId = context.Envelope.MessageId;
+    var messageType = context.Envelope.MessageType;
+    
+    // Access Grid context for distributed tracing
+    var correlationId = context.GridContext?.CorrelationId;
+    var nodeId = context.GridContext?.NodeId;
+    var tenantId = context.GridContext?.TenantId;
+    
+    // Check delivery count for retry logic
+    if (context.DeliveryCount > 3)
+    {
+        _logger.LogWarning("Message {MessageId} has been retried {Count} times",
+            messageId, context.DeliveryCount);
+    }
+    
+    // Access middleware-set properties
+    if (context.Properties.TryGetValue("ProcessingStartTime", out var startTime))
+    {
+        // Use processing start time
+    }
+    
+    return MessageProcessingResult.Success;
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessageProcessingResult.cs
+
+**Handler return type enumeration**
+
+```csharp
+public enum MessageProcessingResult
+{
+    Success,
+    Retry,
+    DeadLetter,
+    Abandon
+}
+```
+
+### Purpose
+
+Defines the possible outcomes of message processing. The transport adapter uses this result to determine how to handle the message after processing.
+
+### Values
+
+| Value | Description | Transport Action |
+|-------|-------------|------------------|
+| `Success` | Message processed successfully | Complete/acknowledge the message |
+| `Retry` | Processing failed, retry later | Abandon for redelivery with backoff |
+| `DeadLetter` | Permanent failure, don't retry | Move to dead-letter queue |
+| `Abandon` | Release message back to queue | Abandon without incrementing delivery count |
+
+### Usage Example
+
+```csharp
+public async Task<MessageProcessingResult> HandleAsync(
+    OrderCreated message,
+    MessageContext context,
+    CancellationToken ct)
+{
+    try
+    {
+        await ProcessOrderAsync(message, ct);
+        return MessageProcessingResult.Success;
+    }
+    catch (TransientException ex)
+    {
+        _logger.LogWarning(ex, "Transient failure, will retry");
+        return MessageProcessingResult.Retry;
+    }
+    catch (ValidationException ex)
+    {
+        _logger.LogError(ex, "Validation failed, moving to DLQ");
+        return MessageProcessingResult.DeadLetter;
+    }
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessageProcessingFailure.cs
+
+**Structured error metadata for diagnostics**
+
+> **Contract Note:** Handlers currently return `MessageProcessingResult` as the stable contract. `MessageProcessingFailure` provides richer error metadata used by error handling strategies and telemetry, and may become a first-class handler return type in a future major version.
+
+```csharp
+public sealed class MessageProcessingFailure
+{
+    public required MessageProcessingResult Result { get; init; }
+    public string? Reason { get; init; }
+    public string? Category { get; init; }
+    public Exception? Exception { get; init; }
+    public IReadOnlyDictionary<string, object>? Metadata { get; init; }
+
+    public static MessageProcessingFailure Success();
+    public static MessageProcessingFailure Retry(
+        string reason,
+        Exception? exception = null,
+        string? category = null,
+        IReadOnlyDictionary<string, object>? metadata = null);
+    public static MessageProcessingFailure DeadLetter(
+        string reason,
+        string? category = null,
+        Exception? exception = null,
+        IReadOnlyDictionary<string, object>? metadata = null);
+    public static MessageProcessingFailure FromException(
+        Exception exception,
+        int deliveryCount,
+        int maxRetries = 5);
+}
+```
+
+### Purpose
+
+Provides richer error context than the simple `MessageProcessingResult` enum. Used by error handling strategies and telemetry for diagnostics, categorization, and analytics.
+
+### Key Features
+
+- **Result** - The underlying processing result (Success, Retry, DeadLetter)
+- **Reason** - Human-readable explanation of the failure
+- **Category** - Grouping key for analytics (e.g., "Validation", "Timeout", "DatabaseError")
+- **Exception** - The underlying exception if applicable
+- **Metadata** - Additional diagnostic data
+
+### Usage Example
+
+Example of using `MessageProcessingFailure` in error handling strategies, custom pipelines, or future handler patterns:
+
+```csharp
+public async Task<MessageProcessingFailure> HandleWithFailureAsync(
+    OrderCreated message,
+    MessageContext context,
+    CancellationToken ct)
+{
+    try
+    {
+        await ProcessOrderAsync(message, ct);
+        return MessageProcessingFailure.Success();
+    }
+    catch (TimeoutException ex)
+    {
+        return MessageProcessingFailure.Retry(
+            reason: "Database timeout during order processing",
+            exception: ex,
+            category: "Timeout",
+            metadata: new Dictionary<string, object>
+            {
+                ["OrderId"] = message.OrderId,
+                ["Attempt"] = context.DeliveryCount
+            });
+    }
+    catch (OrderValidationException ex)
+    {
+        return MessageProcessingFailure.DeadLetter(
+            reason: ex.Message,
+            category: "Validation",
+            exception: ex);
+    }
+}
+
+// Or use automatic categorization from exception
+catch (Exception ex)
+{
+    return MessageProcessingFailure.FromException(
+        exception: ex,
+        deliveryCount: context.DeliveryCount,
+        maxRetries: 5);
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ITransportTransaction.cs
+
+**Transaction context for message processing**
+
+```csharp
+public interface ITransportTransaction
+{
+    string TransactionId { get; }
+    IReadOnlyDictionary<string, object> Context { get; }
+    Task CommitAsync(CancellationToken cancellationToken = default);
+    Task RollbackAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### Purpose
+
+Abstracts transport-specific transaction semantics. Allows middleware and handlers to participate in message acknowledgment decisions.
+
+### Usage Example
+
+```csharp
+// Transport implementations create transactions:
+public class ServiceBusTransportTransaction : ITransportTransaction
+{
+    private readonly ProcessMessageEventArgs _args;
+    
+    public string TransactionId { get; }
+    public IReadOnlyDictionary<string, object> Context { get; }
+    
+    public async Task CommitAsync(CancellationToken ct)
+    {
+        await _args.CompleteMessageAsync(_args.Message, ct);
+    }
+    
+    public async Task RollbackAsync(CancellationToken ct)
+    {
+        await _args.AbandonMessageAsync(_args.Message, cancellationToken: ct);
+    }
+}
+
+// Handlers can access the transaction via MessageContext:
+public async Task<MessageProcessingResult> HandleAsync(
+    OrderCreated message,
+    MessageContext context,
+    CancellationToken ct)
+{
+    // Transaction is available for advanced scenarios
+    var txId = context.Transaction.TransactionId;
+    
+    // Processing...
+    return MessageProcessingResult.Success;
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## NoOpTransportTransaction.cs
+
+**Transport-agnostic no-op transaction implementation**
+
+```csharp
+public sealed class NoOpTransportTransaction : ITransportTransaction
+{
+    public static readonly ITransportTransaction Instance = new NoOpTransportTransaction();
+    
+    public string TransactionId { get; }
+    public IReadOnlyDictionary<string, object> Context => EmptyContext;
+    
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+    
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}
+```
+
+### Purpose
+
+Default transaction implementation for transports that don't support transactions (e.g., InMemory transport) or for testing scenarios.
+
+### Usage Example
+
+```csharp
+// Use in tests
+var context = new MessageContext
+{
+    Envelope = testEnvelope,
+    Transaction = NoOpTransportTransaction.Instance,
+    DeliveryCount = 1
+};
+
+// InMemory transport uses this by default
+var result = await handler.HandleAsync(message, context, ct);
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ITransportTopology.cs
+
+**Declares transport adapter capabilities**
+
+```csharp
+public interface ITransportTopology
+{
+    string Name { get; }
+    bool SupportsTopics { get; }
+    bool SupportsSubscriptions { get; }
+    bool SupportsSessions { get; }
+    bool SupportsOrdering { get; }
+    bool SupportsScheduledMessages { get; }
+    bool SupportsBatching { get; }
+    bool SupportsTransactions { get; }
+    bool SupportsDeadLetterQueue { get; }
+    bool SupportsPriority { get; }
+    long? MaxMessageSize { get; }
+}
+```
+
+### Purpose
+
+Declares what features a transport adapter supports. Used for runtime validation and feature detection to prevent silent failures when using unsupported features.
+
+### Implementations
+
+| Transport | Topics | Sessions | Ordering | Scheduled | Transactions | DLQ | Priority | Max Size |
+|-----------|--------|----------|----------|-----------|--------------|-----|----------|----------|
+| **ServiceBus** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 256KB/100MB |
+| **StorageQueue** | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | 64KB |
+| **InMemory** | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | null |
+
+### Usage Example
+
+```csharp
+public class TopologyAwarePublisher(
+    ITransportPublisher publisher,
+    ITransportTopology topology,
+    EnvelopeFactory envelopeFactory)
+{
+    public async Task PublishWithSessionAsync<T>(
+        ITransportEnvelope envelope,
+        string sessionId,
+        CancellationToken ct)
+    {
+        if (!topology.SupportsSessions)
+        {
+            throw new NotSupportedException(
+                $"Transport '{topology.Name}' does not support sessions");
+        }
+        
+        var destination = EndpointAddress.Create(
+            name: "orders",
+            address: "orders",
+            sessionId: sessionId);
+        
+        await publisher.PublishAsync(envelope, destination, options: null, ct);
+    }
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## IEndpointAddress.cs
+
+**Logical transport endpoint address contract**
+
+```csharp
+public interface IEndpointAddress
+{
+    string Name { get; }
+    string Address { get; }
+    string? SessionId { get; }
+    string? PartitionKey { get; }
+    DateTimeOffset? ScheduledEnqueueTime { get; }
+    TimeSpan? TimeToLive { get; }
+    IReadOnlyDictionary<string, string> AdditionalProperties { get; }
+}
+```
+
+### Purpose
+
+Represents a logical transport endpoint with typed metadata. Provides a clean API for specifying destination addresses with optional routing metadata.
+
+### Properties
+
+| Property | Description | Used By |
+|----------|-------------|---------|
+| `Name` | Logical endpoint name | All transports |
+| `Address` | Physical address (queue/topic name) | All transports |
+| `SessionId` | Session for ordered processing | ServiceBus |
+| `PartitionKey` | Partition for ordering within partition | ServiceBus |
+| `ScheduledEnqueueTime` | Delayed delivery time | ServiceBus, StorageQueue |
+| `TimeToLive` | Message expiration | ServiceBus, StorageQueue |
+| `AdditionalProperties` | Adapter-specific extensions | Varies |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## EndpointAddress.cs
+
+**Transport-agnostic endpoint address implementation**
+
+```csharp
+public sealed class EndpointAddress : IEndpointAddress
+{
+    public string Name { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public string? SessionId { get; init; }
+    public string? PartitionKey { get; init; }
+    public DateTimeOffset? ScheduledEnqueueTime { get; init; }
+    public TimeSpan? TimeToLive { get; init; }
+    public IReadOnlyDictionary<string, string> AdditionalProperties { get; init; }
+
+    public static IEndpointAddress Create(string name, string address);
+    public static IEndpointAddress Create(
+        string name,
+        string address,
+        string? sessionId = null,
+        string? partitionKey = null,
+        DateTimeOffset? scheduledEnqueueTime = null,
+        TimeSpan? timeToLive = null,
+        IDictionary<string, string>? additionalProperties = null);
+}
+```
+
+### Usage Example
+
+```csharp
+// Simple endpoint
+var simple = EndpointAddress.Create("orders", "orders-queue");
+
+// Session-based ordering
+var sessionBased = EndpointAddress.Create(
+    name: "orders",
+    address: "orders-topic",
+    sessionId: customerId.ToString());
+
+// Scheduled delivery with TTL
+var scheduled = EndpointAddress.Create(
+    name: "reminders",
+    address: "reminders-queue",
+    scheduledEnqueueTime: DateTimeOffset.UtcNow.AddHours(24),
+    timeToLive: TimeSpan.FromDays(7));
+
+// Partitioned with custom properties
+var partitioned = EndpointAddress.Create(
+    name: "events",
+    address: "events-topic",
+    partitionKey: region,
+    additionalProperties: new Dictionary<string, string>
+    {
+        ["ContentType"] = "application/json"
+    });
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## PublishOptions.cs
+
+**Publishing customization options**
+
+```csharp
+public sealed class PublishOptions
+{
+    public TimeSpan? TimeToLive { get; init; }
+    public DateTimeOffset? ScheduledEnqueueTime { get; init; }
+    public string? PartitionKey { get; init; }
+    public string? SessionId { get; init; }
+    public MessagePriority Priority { get; init; } = MessagePriority.Normal;
+    public IReadOnlyDictionary<string, object>? AdditionalOptions { get; init; }
+}
+```
+
+### Purpose
+
+Allows customization of message delivery behavior at publish time. Not all properties are supported by all transport adapters - check `ITransportTopology` for capabilities.
+
+### Usage Example
+
+```csharp
+var options = new PublishOptions
+{
+    TimeToLive = TimeSpan.FromHours(24),
+    ScheduledEnqueueTime = DateTimeOffset.UtcNow.AddMinutes(30),
+    SessionId = customerId.ToString(),
+    Priority = MessagePriority.High
+};
+
+await publisher.PublishAsync(envelope, destination, options, ct);
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessagePriority.cs
+
+**Priority enumeration for supported transports**
+
+```csharp
+public enum MessagePriority
+{
+    Low = 0,
+    Normal = 1,
+    High = 2
+}
+```
+
+### Purpose
+
+Defines message priority levels for transport adapters that support prioritization. Higher priority messages are processed before lower priority messages.
+
+### Note
+
+Not all transports support message priority. Check `ITransportTopology.SupportsPriority` before relying on this feature.
+
+### Usage Example
+
+```csharp
+var options = new PublishOptions
+{
+    Priority = MessagePriority.High
+};
+
+// Critical order - process first
+await publisher.PublishAsync(
+    urgentOrderEnvelope,
+    destination,
+    options,
+    ct);
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## IMessageSerializer.cs
+
+**Serialization contract for message payloads**
+
+```csharp
+public interface IMessageSerializer
+{
+    string ContentType { get; }
+    ReadOnlyMemory<byte> Serialize<TMessage>(TMessage message) where TMessage : class;
+    TMessage Deserialize<TMessage>(ReadOnlyMemory<byte> payload) where TMessage : class;
+    object Deserialize(ReadOnlyMemory<byte> payload, Type messageType);
+}
+```
+
+### Purpose
+
+Abstracts message serialization/deserialization. The default implementation uses `System.Text.Json`, but custom serializers can be registered for other formats.
+
+### Usage Example
+
+```csharp
+// Default JSON serializer is registered automatically
+services.AddHoneyDrunkTransportCore();
+
+// Custom serializer registration
+services.AddSingleton<IMessageSerializer, MessagePackSerializer>();
+
+// Using the serializer
+public class EnvelopeBuilder(IMessageSerializer serializer)
+{
+    public ITransportEnvelope CreateEnvelope<T>(T message) where T : class
+    {
+        var payload = serializer.Serialize(message);
+        return new TransportEnvelope
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            MessageType = typeof(T).FullName!,
+            Payload = payload,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+    }
+}
+```
+
+---
+
+[← Back to File Guide](FILE_GUIDE.md) | [↑ Back to top](#table-of-contents)

--- a/HoneyDrunk.Transport/docs/Configuration.md
+++ b/HoneyDrunk.Transport/docs/Configuration.md
@@ -7,24 +7,49 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [TransportCoreOptions.cs](#transportcoreoptionscs)
-- [RetryOptions.cs](#retryoptionscs)
-- [BackoffStrategy.cs](#backoffstrategycs)
-- [IErrorHandlingStrategy.cs](#ierrorhandlingstrategycs)
-- [ErrorHandlingAction.cs](#errorhandlingactioncs)
-- [ErrorHandlingDecision.cs](#errorhandlingdecisioncs)
+- **Core Transport** (`HoneyDrunk.Transport/Configuration/`)
+  - [TransportCoreOptions.cs](#transportcoreoptionscs)
+  - [TransportOptions.cs](#transportoptionscs)
+  - [RetryOptions.cs](#retryoptionscs)
+  - [BackoffStrategy.cs](#backoffstrategycs)
+  - [IErrorHandlingStrategy.cs](#ierrorhandlingstrategycs)
+  - [ErrorHandlingAction.cs](#errorhandlingactioncs)
+  - [ErrorHandlingDecision.cs](#errorhandlingdecisioncs)
+  - [DefaultErrorHandlingStrategy.cs](#defaulterrorhandlingstrategycs)
+  - [ConfigurableErrorHandlingStrategy.cs](#configurableerrorhandlingstrategycs)
+  - [ExceptionTypeMapStrategy.cs](#exceptiontypemapstrategycs)
+- **Azure Service Bus** (`HoneyDrunk.Transport.AzureServiceBus/Configuration/`)
+  - [AzureServiceBusOptions.cs](#azureservicebusoptionscs)
+  - [ServiceBusRetryOptions.cs](#servicebusretryoptionscs)
+  - [ServiceBusRetryMode.cs](#servicebusretrymodecs)
+  - [ServiceBusEntityType.cs](#servicebusentitytypecs)
+  - [BlobFallbackOptions.cs](#blobfallbackoptionscs)
+- **Azure Storage Queue** (`HoneyDrunk.Transport.StorageQueue/Configuration/`)
+  - [StorageQueueOptions.cs](#storagequeueoptions)
 
 ---
 
 ## Overview
 
-Configuration classes for controlling transport behavior including retry policies, backoff strategies, and error handling.
+Configuration classes for controlling transport behavior including retry policies, backoff strategies, error handling, and transport-specific options.
 
-**Location:** `HoneyDrunk.Transport/Configuration/`
+**Locations:**
+
+- Core: `HoneyDrunk.Transport/Configuration/`
+- Azure Service Bus: `HoneyDrunk.Transport.AzureServiceBus/Configuration/`
+- Azure Storage Queue: `HoneyDrunk.Transport.StorageQueue/Configuration/`
+
+---
+
+# Core Transport Configuration
+
+> **Mental Model:** Core options (`TransportCoreOptions`) control cross-cutting behavior of the transport pipeline (logging, telemetry, correlation). Adapter options (`AzureServiceBusOptions`, `StorageQueueOptions`) control connection, concurrency, and broker-specific behavior.
 
 ---
 
 ## TransportCoreOptions.cs
+
+Cross-cutting behavioral flags for the transport infrastructure.
 
 ```csharp
 public sealed class TransportCoreOptions
@@ -50,7 +75,69 @@ services.AddHoneyDrunkTransportCore(options =>
 
 ---
 
+## TransportOptions.cs
+
+Base configuration for any transport endpoint. Transport-specific options (Azure Service Bus, Storage Queue) extend this class.
+
+```csharp
+public class TransportOptions
+{
+    public string EndpointName { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public int MaxConcurrency { get; set; } = 1;
+    public int PrefetchCount { get; set; }
+    public RetryOptions Retry { get; set; } = new();
+    public TimeSpan MessageLockDuration { get; set; } = TimeSpan.FromMinutes(5);
+    public bool AutoComplete { get; set; } = true;
+    public bool SessionEnabled { get; set; }
+    public Dictionary<string, string> Properties { get; } = [];
+}
+```
+
+### Property Details
+
+| Property | Description |
+|----------|-------------|
+| `EndpointName` | Logical name for the endpoint (used in logging/telemetry) |
+| `Address` | Physical address (queue name, topic name, etc.) |
+| `MaxConcurrency` | Maximum concurrent message processors |
+| `PrefetchCount` | Prefetch count for message retrieval optimization |
+| `Retry` | Nested retry configuration |
+| `MessageLockDuration` | How long the message is locked/invisible during processing |
+| `AutoComplete` | Whether to automatically complete messages on success |
+| `SessionEnabled` | Whether to use sessions for ordered processing |
+| `Properties` | Additional transport-specific key-value properties |
+
+### Usage Example
+
+```csharp
+// TransportOptions is typically configured through transport-specific options
+services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    // Base TransportOptions properties
+    options.EndpointName = "OrderProcessor";
+    options.Address = "orders-queue";
+    options.MaxConcurrency = 10;
+    options.PrefetchCount = 20;
+    options.MessageLockDuration = TimeSpan.FromMinutes(3);
+    options.AutoComplete = true;
+    options.SessionEnabled = false;
+    
+    // Retry configuration
+    options.Retry.MaxAttempts = 3;
+    options.Retry.BackoffStrategy = BackoffStrategy.Exponential;
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
 ## RetryOptions.cs
+
+Application-level retry configuration for the transport pipeline.
+
+> **Note:** `RetryOptions` controls application-level retry behavior in the transport pipeline. `ServiceBusRetryOptions` controls SDK-level retries for Azure Service Bus operations. These are separate concerns.
 
 ```csharp
 public sealed class RetryOptions
@@ -110,42 +197,60 @@ retry.BackoffStrategy = BackoffStrategy.Exponential;
 
 ## IErrorHandlingStrategy.cs
 
+Contract for error handling strategies that decide how to handle message processing failures.
+
+> **Design Note:** Error handling strategies receive only the exception and delivery count—they do not see the full `MessageContext`. This keeps strategies focused on exception classification and retry policy, not message content.
+
 ```csharp
 public interface IErrorHandlingStrategy
 {
-    ErrorHandlingDecision Decide(
+    Task<ErrorHandlingDecision> HandleErrorAsync(
         Exception exception,
-        MessageContext context,
-        int attemptCount);
+        int deliveryCount,
+        CancellationToken cancellationToken = default);
 }
 ```
+
+### Method Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `exception` | The exception that occurred during processing |
+| `deliveryCount` | How many times this message has been delivered/retried |
+| `cancellationToken` | Cancellation token for the operation |
+
+### Implementation Notes
+
+- Must be thread-safe (multiple messages may fail concurrently)
+- Should return quickly (avoid blocking I/O in decision logic)
+- Use `deliveryCount` to implement retry limits
+- Return `ErrorHandlingDecision.DeadLetter()` for permanent failures
 
 ### Usage Example
 
 ```csharp
 public class CustomErrorStrategy : IErrorHandlingStrategy
 {
-    public ErrorHandlingDecision Decide(
+    public Task<ErrorHandlingDecision> HandleErrorAsync(
         Exception exception,
-        MessageContext context,
-        int attemptCount)
+        int deliveryCount,
+        CancellationToken cancellationToken = default)
     {
-        return exception switch
+        // Permanent failure - dead letter immediately
+        if (exception is ValidationException)
         {
-            SqlException { Number: -2 } => // Timeout
-                new ErrorHandlingDecision(
-                    ErrorHandlingAction.Retry,
-                    TimeSpan.FromSeconds(5)),
-            
-            ValidationException => // Invalid data
-                new ErrorHandlingDecision(ErrorHandlingAction.DeadLetter),
-            
-            _ => attemptCount < 3
-                ? new ErrorHandlingDecision(
-                    ErrorHandlingAction.Retry,
-                    TimeSpan.FromSeconds(attemptCount * 2))
-                : new ErrorHandlingDecision(ErrorHandlingAction.DeadLetter)
-        };
+            return Task.FromResult(ErrorHandlingDecision.DeadLetter("Invalid message"));
+        }
+        
+        // Max retries exceeded
+        if (deliveryCount >= 5)
+        {
+            return Task.FromResult(ErrorHandlingDecision.DeadLetter("Max retries exceeded"));
+        }
+        
+        // Transient failure - retry with backoff
+        var delay = TimeSpan.FromSeconds(Math.Pow(2, deliveryCount - 1));
+        return Task.FromResult(ErrorHandlingDecision.Retry(delay));
     }
 }
 
@@ -158,14 +263,24 @@ services.AddSingleton<IErrorHandlingStrategy, CustomErrorStrategy>();
 
 ## ErrorHandlingAction.cs
 
+Enum defining the possible actions when handling a message processing error.
+
 ```csharp
 public enum ErrorHandlingAction
 {
     Retry,        // Retry with delay
     DeadLetter,   // Move to DLQ
-    Ignore        // Discard message
+    Abandon       // Return to queue (no delay)
 }
 ```
+
+### When to Use Each
+
+| Action | Use When |
+|--------|----------|
+| `Retry` | Transient failures (network, timeout, rate limiting) |
+| `DeadLetter` | Permanent failures (validation, bad data, business rule violations) |
+| `Abandon` | Return the message to the queue immediately without applying backoff. Use rarely; most scenarios should prefer `Retry` with a delay. |
 
 [↑ Back to top](#table-of-contents)
 
@@ -173,17 +288,291 @@ public enum ErrorHandlingAction
 
 ## ErrorHandlingDecision.cs
 
+Immutable record representing the outcome of an error handling decision, including the action to take and optional metadata.
+
+> **Pipeline Integration:** The message pipeline converts `ErrorHandlingDecision.Action` into a `MessageProcessingResult` that the transport adapter uses to complete, abandon, retry, or dead-letter the message. Handlers return `MessageProcessingResult` directly; `ErrorHandlingDecision` is used by `IErrorHandlingStrategy` implementations.
+
 ```csharp
-public sealed class ErrorHandlingDecision
+public sealed record ErrorHandlingDecision
 {
     public ErrorHandlingAction Action { get; }
-    public TimeSpan? Delay { get; }
+    public TimeSpan? RetryDelay { get; }
+    public string? Reason { get; }
     
-    public ErrorHandlingDecision(ErrorHandlingAction action, TimeSpan? delay = null)
+    // Factory methods
+    public static ErrorHandlingDecision Retry(TimeSpan delay, string? reason = null);
+    public static ErrorHandlingDecision DeadLetter(string? reason = null);
+    public static ErrorHandlingDecision Abandon(string? reason = null);
+}
+```
+
+### Factory Methods
+
+| Method | Description |
+|--------|-------------|
+| `Retry(delay, reason)` | Retry after the specified delay |
+| `DeadLetter(reason)` | Move to dead-letter queue with reason |
+| `Abandon(reason)` | Return to queue for immediate retry |
+
+### Usage Example
+
+```csharp
+// Retry with exponential backoff
+ErrorHandlingDecision.Retry(
+    TimeSpan.FromSeconds(Math.Pow(2, deliveryCount)),
+    "Transient network failure");
+
+// Dead letter with diagnostic reason
+ErrorHandlingDecision.DeadLetter("Message failed schema validation");
+
+// Abandon (use rarely)
+ErrorHandlingDecision.Abandon("Temporary resource lock contention");
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## DefaultErrorHandlingStrategy.cs
+
+Production-ready error handling strategy with built-in classification rules. Automatically classifies exceptions as transient or permanent and applies appropriate backoff.
+
+```csharp
+public sealed class DefaultErrorHandlingStrategy : IErrorHandlingStrategy
+{
+    public DefaultErrorHandlingStrategy(ILogger<DefaultErrorHandlingStrategy> logger);
+    
+    public Task<ErrorHandlingDecision> HandleErrorAsync(
+        Exception exception,
+        int deliveryCount,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Classification Rules
+
+| Classification | Exception Types | Behavior |
+|----------------|-----------------|----------|
+| **Transient** | `TimeoutException`, `TaskCanceledException`, `OperationCanceledException`, `IOException`, `SocketException` | Retry with exponential backoff (1s → 30s max) |
+| **Permanent** | `ArgumentException`, `InvalidOperationException`, `NotImplementedException` | Dead-letter immediately |
+| **Unknown** | All others | Retry with linear backoff, dead-letter after 5 attempts |
+
+### Usage Example
+
+```csharp
+// Register as the default strategy
+services.AddSingleton<IErrorHandlingStrategy, DefaultErrorHandlingStrategy>();
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ConfigurableErrorHandlingStrategy.cs
+
+Fluent API for building custom error handling rules. Allows mapping specific exception types to retry or dead-letter actions.
+
+```csharp
+public sealed class ConfigurableErrorHandlingStrategy : IErrorHandlingStrategy
+{
+    public ConfigurableErrorHandlingStrategy(int maxDeliveryCount = 5);
+    
+    // Fluent configuration
+    public ConfigurableErrorHandlingStrategy RetryOn<TException>(TimeSpan? retryDelay = null)
+        where TException : Exception;
+    
+    public ConfigurableErrorHandlingStrategy DeadLetterOn<TException>()
+        where TException : Exception;
+    
+    public Task<ErrorHandlingDecision> HandleErrorAsync(
+        Exception exception,
+        int deliveryCount,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Behavior
+
+1. If `deliveryCount >= maxDeliveryCount`, always dead-letter
+2. Check exact exception type match first
+3. Check base exception type match
+4. Default: retry unknown exceptions with exponential backoff
+
+### Usage Example
+
+```csharp
+var strategy = new ConfigurableErrorHandlingStrategy(maxDeliveryCount: 5)
+    .RetryOn<TimeoutException>(TimeSpan.FromSeconds(5))
+    .RetryOn<HttpRequestException>(TimeSpan.FromSeconds(10))
+    .DeadLetterOn<ValidationException>()
+    .DeadLetterOn<ArgumentNullException>();
+
+services.AddSingleton<IErrorHandlingStrategy>(strategy);
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ExceptionTypeMapStrategy.cs
+
+Dictionary-based error handling strategy with builder pattern. Maps exception types to `ErrorHandlingAction` values.
+
+```csharp
+public sealed class ExceptionTypeMapStrategy : IErrorHandlingStrategy
+{
+    public ExceptionTypeMapStrategy(
+        Dictionary<Type, ErrorHandlingAction> typeMap,
+        int maxDeliveryCount = 5,
+        ErrorHandlingAction defaultAction = ErrorHandlingAction.Retry);
+    
+    public static Builder CreateBuilder();
+    
+    public Task<ErrorHandlingDecision> HandleErrorAsync(
+        Exception exception,
+        int deliveryCount,
+        CancellationToken cancellationToken = default);
+    
+    // Nested builder class
+    public sealed class Builder
     {
-        Action = action;
-        Delay = delay;
+        public Builder MapToRetry<TException>() where TException : Exception;
+        public Builder MapToDeadLetter<TException>() where TException : Exception;
+        public Builder WithMaxDeliveryCount(int maxDeliveryCount);
+        public Builder WithDefaultAction(ErrorHandlingAction defaultAction);
+        public ExceptionTypeMapStrategy Build();
     }
+}
+```
+
+### Usage Example
+
+```csharp
+var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+    .MapToRetry<TimeoutException>()
+    .MapToRetry<HttpRequestException>()
+    .MapToDeadLetter<ValidationException>()
+    .MapToDeadLetter<ArgumentException>()
+    .WithMaxDeliveryCount(10)
+    .WithDefaultAction(ErrorHandlingAction.Retry)
+    .Build();
+
+services.AddSingleton<IErrorHandlingStrategy>(strategy);
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+# Azure Service Bus Configuration
+
+---
+
+## AzureServiceBusOptions.cs
+
+Configuration options for Azure Service Bus transport. Extends `TransportOptions` with Service Bus-specific settings.
+
+```csharp
+public sealed class AzureServiceBusOptions : TransportOptions
+{
+    public string FullyQualifiedNamespace { get; set; } = string.Empty;
+    public string? ConnectionString { get; set; }
+    public ServiceBusEntityType EntityType { get; set; } = ServiceBusEntityType.Queue;
+    public string? SubscriptionName { get; set; }
+    public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(60);
+    public ServiceBusRetryOptions ServiceBusRetry { get; set; } = new();
+    public bool EnableDeadLetterQueue { get; set; } = true;
+    public int MaxDeliveryCount { get; set; } = 10;
+    public BlobFallbackOptions BlobFallback { get; set; } = new();
+}
+```
+
+### Authentication Options
+
+| Option | Description |
+|--------|-------------|
+| `FullyQualifiedNamespace` | For managed identity (e.g., `mynamespace.servicebus.windows.net`) |
+| `ConnectionString` | Alternative to managed identity |
+
+### Usage Example
+
+```csharp
+// Using managed identity (recommended for production)
+services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
+    options.Address = "orders-queue";
+    options.EntityType = ServiceBusEntityType.Queue;
+    options.MaxConcurrency = 10;
+    options.MaxDeliveryCount = 5;
+    options.MaxWaitTime = TimeSpan.FromSeconds(30);
+});
+
+// Using Topic/Subscription
+services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
+    options.Address = "orders-topic";
+    options.EntityType = ServiceBusEntityType.Topic;
+    options.SubscriptionName = "order-processor";
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ServiceBusRetryOptions.cs
+
+Service Bus-specific retry configuration for SDK-level operations.
+
+```csharp
+public sealed class ServiceBusRetryOptions
+{
+    public ServiceBusRetryMode Mode { get; set; } = ServiceBusRetryMode.Exponential;
+    public int MaxRetries { get; set; } = 3;
+    public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(0.8);
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(1);
+    public TimeSpan TryTimeout { get; set; } = TimeSpan.FromMinutes(1);
+}
+```
+
+### Property Details
+
+| Property | Description |
+|----------|-------------|
+| `Mode` | `Fixed` or `Exponential` retry mode |
+| `MaxRetries` | Maximum number of SDK-level retry attempts |
+| `Delay` | Initial delay between retries |
+| `MaxDelay` | Maximum delay between retries |
+| `TryTimeout` | Timeout for each SDK operation attempt |
+
+### Usage Example
+
+```csharp
+services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.ServiceBusRetry.Mode = ServiceBusRetryMode.Exponential;
+    options.ServiceBusRetry.MaxRetries = 5;
+    options.ServiceBusRetry.Delay = TimeSpan.FromSeconds(1);
+    options.ServiceBusRetry.MaxDelay = TimeSpan.FromSeconds(30);
+    options.ServiceBusRetry.TryTimeout = TimeSpan.FromSeconds(60);
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## ServiceBusRetryMode.cs
+
+Retry mode for Service Bus SDK operations.
+
+```csharp
+public enum ServiceBusRetryMode
+{
+    Fixed,       // Fixed delay between retries
+    Exponential  // Exponential backoff between retries
 }
 ```
 
@@ -191,4 +580,178 @@ public sealed class ErrorHandlingDecision
 
 ---
 
-[← Back to File Guide](FILE_GUIDE.md) | [↑ Back to top](#table-of-contents)
+## ServiceBusEntityType.cs
+
+Entity type for Azure Service Bus messaging.
+
+```csharp
+public enum ServiceBusEntityType
+{
+    Queue,  // Point-to-point messaging
+    Topic   // Publish-subscribe messaging
+}
+```
+
+### When to Use Each
+
+| Type | Use Case |
+|------|----------|
+| `Queue` | Single consumer, guaranteed delivery, work distribution |
+| `Topic` | Multiple subscribers, event broadcasting, fan-out patterns |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## BlobFallbackOptions.cs
+
+Options for Blob Storage fallback when publishing to Service Bus fails. Enables durability by persisting failed messages to Blob Storage for later replay.
+
+> **When Used:** Blob fallback is used by the Service Bus publisher when messages exceed size limits or when transient publish failures exceed the configured retry policy. This is a *publish-side* durability mechanism, not a consume-side feature.
+
+```csharp
+public sealed class BlobFallbackOptions
+{
+    public bool Enabled { get; set; }
+    public string? ConnectionString { get; set; }
+    public string? AccountUrl { get; set; }
+    public string ContainerName { get; set; } = "transport-fallback";
+    public string? BlobPrefix { get; set; }
+    public TimeSpan? TimeToLive { get; set; }
+}
+```
+
+### Property Details
+
+| Property | Description |
+|----------|-------------|
+| `Enabled` | Whether Blob fallback is enabled |
+| `ConnectionString` | Blob Storage connection string |
+| `AccountUrl` | Blob service URL for managed identity (e.g., `https://account.blob.core.windows.net`) |
+| `ContainerName` | Container for storing fallback messages |
+| `BlobPrefix` | Optional folder prefix for organizing blobs |
+| `TimeToLive` | Informational TTL (external lifecycle policy use) |
+
+### Usage Example
+
+```csharp
+services.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
+    options.Address = "critical-messages";
+    
+    // Enable Blob fallback for durability
+    options.BlobFallback.Enabled = true;
+    options.BlobFallback.AccountUrl = "https://myaccount.blob.core.windows.net";
+    options.BlobFallback.ContainerName = "servicebus-fallback";
+    options.BlobFallback.BlobPrefix = "failed-messages/";
+    options.BlobFallback.TimeToLive = TimeSpan.FromDays(7);
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+# Azure Storage Queue Configuration
+
+---
+
+## StorageQueueOptions.cs
+
+Configuration options for Azure Storage Queue transport. Extends `TransportOptions` with Storage Queue-specific settings and implements `IValidatableObject` for configuration validation.
+
+```csharp
+public sealed class StorageQueueOptions : TransportOptions, IValidatableObject
+{
+    // Authentication
+    public string? ConnectionString { get; set; }
+    public Uri? AccountEndpoint { get; set; }
+    
+    // Queue settings
+    [Required] public string QueueName { get; set; } = string.Empty;
+    public bool CreateIfNotExists { get; set; } = true;
+    public string? PoisonQueueName { get; set; }
+    
+    // Message settings
+    public TimeSpan? MessageTimeToLive { get; set; }
+    public TimeSpan VisibilityTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    [Range(1, 100)] public int MaxDequeueCount { get; set; } = 5;
+    
+    // Performance tuning
+    [Range(1, 32)] public int PrefetchMaxMessages { get; set; } = 16;
+    [Range(1, 128)] public int? MaxBatchPublishConcurrency { get; set; }
+    [Range(1, 32)] public int BatchProcessingConcurrency { get; set; } = 1;
+    
+    // Polling
+    public TimeSpan EmptyQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(1);
+    public TimeSpan MaxPollingInterval { get; set; } = TimeSpan.FromSeconds(5);
+    
+    // Observability
+    public bool EnableTelemetry { get; set; } = true;
+    public bool EnableLogging { get; set; } = true;
+    public bool EnableCorrelation { get; set; } = true;
+    
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext);
+}
+```
+
+### Concurrency Model
+
+Storage Queue uses a two-level concurrency model:
+
+- **MaxConcurrency**: Number of concurrent fetch loops (inherited from `TransportOptions`)
+- **BatchProcessingConcurrency**: Concurrent messages processed per fetch loop
+
+> **Effective concurrency = MaxConcurrency × BatchProcessingConcurrency**
+
+**Example:** `MaxConcurrency=5, BatchProcessingConcurrency=4` = 20 concurrent messages.
+
+### Validation Rules
+
+The `Validate` method enforces:
+
+- Either `ConnectionString` or `AccountEndpoint` must be set
+- `MaxConcurrency` ≤ 100
+- `BatchProcessingConcurrency` ≤ `PrefetchMaxMessages`
+- `EmptyQueuePollingInterval` ≤ `MaxPollingInterval`
+- `VisibilityTimeout` between 1 second and 7 days
+- `MessageTimeToLive` between 1 second and 7 days (if specified)
+
+### Usage Example
+
+```csharp
+services.AddHoneyDrunkStorageQueueTransport(options =>
+{
+    // Authentication (choose one)
+    options.ConnectionString = "DefaultEndpointsProtocol=https;AccountName=...";
+    // OR
+    options.AccountEndpoint = new Uri("https://myaccount.queue.core.windows.net");
+    
+    // Queue settings
+    options.QueueName = "orders-queue";
+    options.CreateIfNotExists = true;
+    options.PoisonQueueName = "orders-poison";  // Default: "{QueueName}-poison"
+    
+    // Message settings
+    options.VisibilityTimeout = TimeSpan.FromMinutes(5);
+    options.MessageTimeToLive = TimeSpan.FromDays(1);
+    options.MaxDequeueCount = 5;
+    
+    // Performance (high throughput)
+    options.MaxConcurrency = 10;
+    options.PrefetchMaxMessages = 32;
+    options.BatchProcessingConcurrency = 4;  // 10 × 4 = 40 concurrent
+    options.MaxBatchPublishConcurrency = 32;
+    
+    // Polling (aggressive for low latency)
+    options.EmptyQueuePollingInterval = TimeSpan.FromMilliseconds(500);
+    options.MaxPollingInterval = TimeSpan.FromSeconds(2);
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Back to File Guide](FILE_GUIDE.md) | [Azure Service Bus](AzureServiceBus.md) | [Storage Queue](StorageQueue.md) | [↑ Back to top](#table-of-contents)

--- a/HoneyDrunk.Transport/docs/Context.md
+++ b/HoneyDrunk.Transport/docs/Context.md
@@ -16,13 +16,25 @@
 
 ## Overview
 
-Grid context integration for distributed context propagation across Node boundaries. Bridges Transport envelopes to Kernel's IGridContext.
+Grid context integration for distributed context propagation across Node boundaries. Bridges Transport envelopes to Kernel's `IGridContext`.
 
 **Location:** `HoneyDrunk.Transport/Context/`
+
+> **Key Concept:** Transport does not create a new concept of Grid context. It maps message envelopes into Kernel's existing `IGridContext` so handlers always run inside a coherent Grid scope.
+
+### Layering
+
+| Layer | Owns | Source |
+|-------|------|--------|
+| **Kernel** | `IGridContext` interface, node identity abstractions | — |
+| **Transport** | `IGridContextFactory`, `TransportGridContext` | Envelope metadata |
+| **Envelope** | Operation lineage (CorrelationId, CausationId, TenantId, ProjectId) | Publishing node |
 
 ---
 
 ## IGridContextFactory.cs
+
+> **Note:** This interface is defined in `HoneyDrunk.Transport.Context`, but conceptually it is the transport-specific bridge into Kernel's `IGridContext`. Application code almost never calls this directly—it is infrastructure plumbing between Kernel and Transport.
 
 ```csharp
 public interface IGridContextFactory
@@ -33,46 +45,80 @@ public interface IGridContextFactory
 }
 ```
 
-### Usage Example
+### Purpose
 
-```csharp
-// Used internally by GridContextPropagationMiddleware
-// Not typically called directly in application code
-```
+`IGridContextFactory` is the bridge from a transport envelope into Kernel's `IGridContext`. Transport calls this factory from `GridContextPropagationMiddleware` so handlers always see a fully-hydrated Grid context.
+
+### When It's Called
+
+1. Consumer receives message from broker
+2. `GridContextPropagationMiddleware` invokes `IGridContextFactory.CreateFromEnvelope()`
+3. Resulting `IGridContext` is set on `MessageContext.GridContext`
+4. Handler accesses context through `MessageContext`
 
 ---
 
 ## GridContextFactory.cs
 
+Default implementation that extracts Grid metadata from transport envelopes.
+
 ```csharp
-public sealed class GridContextFactory(TimeProvider timeProvider) 
-    : IGridContextFactory
+public sealed class GridContextFactory : IGridContextFactory
 {
+    private readonly TimeProvider _timeProvider;
+
+    public GridContextFactory(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
     public IGridContext CreateFromEnvelope(
         ITransportEnvelope envelope,
         CancellationToken cancellationToken)
     {
         var correlationId = envelope.CorrelationId ?? envelope.MessageId;
         var causationId = envelope.CausationId ?? envelope.MessageId;
-        
+
         var baggage = envelope.Headers != null
             ? new Dictionary<string, string>(envelope.Headers)
-            : new Dictionary<string, string>();
-        
+            : [];
+
         return new TransportGridContext(
-            correlationId,
-            causationId,
-            envelope.NodeId ?? string.Empty,
-            envelope.StudioId ?? string.Empty,
-            envelope.Environment ?? string.Empty,
-            baggage,
-            _timeProvider.GetUtcNow(),
-            cancellationToken);
+            correlationId: correlationId,
+            causationId: causationId,
+            nodeId: envelope.NodeId ?? string.Empty,
+            studioId: envelope.StudioId ?? string.Empty,
+            tenantId: envelope.TenantId,
+            projectId: envelope.ProjectId,
+            environment: envelope.Environment ?? string.Empty,
+            baggage: baggage,
+            createdAtUtc: _timeProvider.GetUtcNow(),
+            cancellation: cancellationToken);
     }
 }
 ```
 
-### Usage Example
+### Mapping Behavior
+
+| Property | Source | Fallback |
+|----------|--------|----------|
+| `CorrelationId` | `envelope.CorrelationId` | `envelope.MessageId` |
+| `CausationId` | `envelope.CausationId` | `envelope.MessageId` |
+| `NodeId` | `envelope.NodeId` | `string.Empty` |
+| `StudioId` | `envelope.StudioId` | `string.Empty` |
+| `TenantId` | `envelope.TenantId` | `null` |
+| `ProjectId` | `envelope.ProjectId` | `null` |
+| `Environment` | `envelope.Environment` | `string.Empty` |
+| `Baggage` | `envelope.Headers` | Empty dictionary |
+
+> **Design Note:** Currently, `NodeId` is taken from the envelope (the **source node** that published the message). If your application needs to distinguish between source node and current node, consider:
+> - Adding an `INodeIdentity` abstraction in Kernel that provides the current node's identity
+> - Storing `envelope.NodeId` as `SourceNodeId` in baggage
+> - Using `INodeIdentity.NodeId` for `GridContext.NodeId`
+>
+> This is a v2 consideration for cleaner layering.
+
+### Registration
 
 ```csharp
 // Registered automatically
@@ -83,7 +129,7 @@ services.AddHoneyDrunkTransportCore();  // Registers GridContextFactory
 
 ## TransportGridContext.cs
 
-Lightweight IGridContext implementation for Transport layer.
+Lightweight `IGridContext` implementation for the Transport consumer side.
 
 ```csharp
 internal sealed class TransportGridContext : IGridContext
@@ -92,16 +138,35 @@ internal sealed class TransportGridContext : IGridContext
     public string? CausationId { get; }
     public string NodeId { get; }
     public string StudioId { get; }
+    public string? TenantId { get; }
+    public string? ProjectId { get; }
     public string Environment { get; }
     public IReadOnlyDictionary<string, string> Baggage { get; }
     public CancellationToken Cancellation { get; }
     public DateTimeOffset CreatedAtUtc { get; }
-    
+
     public IDisposable BeginScope() => new NoOpScope();
     public IGridContext CreateChildContext(string? nodeId = null);
     public IGridContext WithBaggage(string key, string value);
 }
 ```
+
+### Role in the Grid
+
+`TransportGridContext` is a lightweight `IGridContext` implementation used only on the **consumer side** of messaging. Kernel still owns the primary Grid context types; Transport creates a projected context for handlers based on:
+
+- **Envelope metadata**: CorrelationId, CausationId, TenantId, ProjectId, NodeId (source), StudioId, Environment
+- **Envelope headers**: Copied into Baggage
+
+> **Note:** This is not "the global Grid context implementation"—it is a projection that lives at the messaging edge. Applications that have Kernel available should prefer Kernel's full `GridContext` implementation for non-messaging scenarios.
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `BeginScope()` | Returns a no-op scope (lightweight implementation) |
+| `CreateChildContext(nodeId?)` | Creates child context with current CorrelationId as CausationId |
+| `WithBaggage(key, value)` | Returns new context with additional baggage entry |
 
 ### Usage Example
 
@@ -117,9 +182,10 @@ public async Task<MessageProcessingResult> HandleAsync(
     var gridContext = context.GridContext;
     
     _logger.LogInformation(
-        "Processing in Node {NodeId} with correlation {CorrelationId}",
-        gridContext?.NodeId,
-        gridContext?.CorrelationId);
+        "Processing order from Node {SourceNodeId} for Tenant {TenantId}, Project {ProjectId}",
+        gridContext?.NodeId,      // Source node that published the message
+        gridContext?.TenantId,
+        gridContext?.ProjectId);
     
     // Create child context for downstream operation
     var childContext = gridContext?.CreateChildContext("payment-node");
@@ -139,9 +205,12 @@ public async Task<MessageProcessingResult> HandleAsync(
 │                                                              │
 │  1. Inject IGridContext from Kernel                         │
 │  2. Create envelope with Grid context via EnvelopeFactory   │
-│     - NodeId: "order-service"                               │
-│     - CorrelationId: "abc-123"                              │
-│     - StudioId: "production"                                │
+│     - GridContext.NodeId: "order-service"                   │
+│     - Envelope.NodeId: "order-service" (source node)        │
+│     - Envelope.CorrelationId: "abc-123"                     │
+│     - Envelope.TenantId: "tenant-xyz"                       │
+│     - Envelope.ProjectId: "proj-001"                        │
+│     - Envelope.StudioId: "production"                       │
 │  3. Publish to queue/topic                                  │
 └─────────────────────────────────────────────────────────────┘
                             ↓
@@ -154,16 +223,30 @@ public async Task<MessageProcessingResult> HandleAsync(
 │                                                              │
 │  1. Consumer receives envelope                              │
 │  2. GridContextPropagationMiddleware                        │
-│     - Extracts Grid fields from envelope                    │
+│     - Reads CorrelationId / CausationId from envelope       │
+│     - Reads TenantId / ProjectId from envelope              │
+│     - Reads NodeId / StudioId / Environment from envelope   │
 │     - Creates IGridContext via GridContextFactory           │
 │     - Populates MessageContext.GridContext                  │
 │  3. Handler accesses context.GridContext                    │
-│     - CorrelationId: "abc-123" (same)                       │
+│     - CorrelationId: "abc-123" (propagated)                 │
 │     - CausationId: "abc-123" (from original)                │
-│     - NodeId: "payment-service" (current node)              │
+│     - NodeId: "order-service" (source node from envelope)   │
+│     - TenantId: "tenant-xyz" (propagated)                   │
+│     - ProjectId: "proj-001" (propagated)                    │
 │     - StudioId: "production" (propagated)                   │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+### v2 Consideration: Current Node Identity
+
+In the current implementation, `GridContext.NodeId` represents the **source node** that published the message. For scenarios where you need the **current node's** identity (Node B = "payment-service"), consider:
+
+1. **Kernel `INodeIdentity`**: Have Kernel provide current node identity
+2. **GridContextFactory v2**: Inject `INodeIdentity` and use it for `NodeId`
+3. **Source node in baggage**: Store `envelope.NodeId` as `SourceNodeId` in baggage
+
+This is a breaking change reserved for v2 to maintain cleaner layering between "who am I" (Kernel) and "where did this come from" (envelope).
 
 ---
 

--- a/HoneyDrunk.Transport/docs/Metrics.md
+++ b/HoneyDrunk.Transport/docs/Metrics.md
@@ -9,16 +9,25 @@
 - [Overview](#overview)
 - [ITransportMetrics.cs](#itransportmetricscs)
 - [NoOpTransportMetrics.cs](#nooptransportmetricscs)
+- [OpenTelemetryTransportMetrics.cs](#opentelemetrytransportmetricscs)
+- [KernelTransportMetrics.cs](#kerneltransportmetricscs)
 - [TransportTelemetry.cs](#transporttelemetrycs)
-- [Metrics Dashboard Example](#metrics-dashboard-example)
 
 ---
 
 ## Overview
 
-Metrics collection abstractions for recording transport operations. Integrates with Kernel IMetricsCollector for centralized metrics aggregation.
+Metrics collection abstractions for recording transport operations. Integrates with Kernel metrics and OpenTelemetry.
 
-**Location:** `HoneyDrunk.Transport/Metrics/`
+**Locations:**
+
+- **Metrics:** `HoneyDrunk.Transport/Metrics/`
+  - `ITransportMetrics.cs` - Metrics abstraction
+  - `NoOpTransportMetrics.cs` - Default no-op implementation
+
+- **Telemetry:** `HoneyDrunk.Transport/Telemetry/`
+  - `TransportTelemetry.cs` - ActivitySource utilities
+  - `TelemetryMiddleware.cs` - Pipeline integration
 
 ---
 
@@ -79,11 +88,30 @@ public class MetricsCollectingPublisher(
 }
 ```
 
+### Recommended Dimensions
+
+Implementations of `ITransportMetrics` should attach a consistent set of tags so metrics can be aggregated across the Grid. Typical tags:
+
+| Tag | Source |
+|-----|--------|
+| `message_type` | `envelope.MessageType` |
+| `destination` | `destination.Address` or endpoint name |
+| `transport` | Adapter identifier, e.g. `"servicebus"` or `"storagequeue"` |
+| `node_id` | Current `NodeId` from Kernel |
+| `environment` | `Environment` from Kernel |
+| `tenant_id` | When available from Grid context |
+| `project_id` | When available from Grid context |
+| `result` | `MessageProcessingResult` (`Success`, `Retry`, `DeadLetter`, `Abandon`) |
+
+You do not need to bake these into the interface. Implementations can pull them from `IGridContext`, `ITransportTopology`, or options.
+
 [↑ Back to top](#table-of-contents)
 
 ---
 
 ## NoOpTransportMetrics.cs
+
+Default implementation with zero overhead. Registered automatically by `AddHoneyDrunkTransportCore()`.
 
 ```csharp
 public sealed class NoOpTransportMetrics : ITransportMetrics
@@ -107,7 +135,167 @@ public sealed class NoOpTransportMetrics : ITransportMetrics
 // Default (no-op, zero overhead)
 services.AddHoneyDrunkTransportCore();  // Uses NoOpTransportMetrics
 
-// Replace with Kernel-backed implementation
+// Swap with OpenTelemetry or Kernel-backed implementation
+services.AddSingleton<ITransportMetrics, OpenTelemetryTransportMetrics>();
+// or
+services.AddSingleton<ITransportMetrics, KernelTransportMetrics>();
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## OpenTelemetryTransportMetrics.cs
+
+A concrete implementation using `IMeterFactory` from .NET's OpenTelemetry integration. This can be copied directly into your node.
+
+```csharp
+public sealed class OpenTelemetryTransportMetrics : ITransportMetrics
+{
+    private readonly Counter<long> _messagesPublished;
+    private readonly Counter<long> _messagesConsumed;
+    private readonly Histogram<double> _processingDuration;
+    private readonly Counter<long> _errors;
+
+    public OpenTelemetryTransportMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create("HoneyDrunk.Transport");
+
+        _messagesPublished = meter.CreateCounter<long>(
+            "transport.messages.published",
+            description: "Number of messages published");
+
+        _messagesConsumed = meter.CreateCounter<long>(
+            "transport.messages.consumed",
+            description: "Number of messages consumed");
+
+        _processingDuration = meter.CreateHistogram<double>(
+            "transport.processing.duration.ms",
+            unit: "ms",
+            description: "Message processing duration");
+
+        _errors = meter.CreateCounter<long>(
+            "transport.errors",
+            description: "Number of transport errors");
+    }
+
+    public void RecordMessagePublished(string messageType, string destination)
+    {
+        _messagesPublished.Add(1,
+            new KeyValuePair<string, object?>("message_type", messageType),
+            new KeyValuePair<string, object?>("destination", destination));
+    }
+
+    public void RecordMessageConsumed(
+        string messageType,
+        TimeSpan processingDuration,
+        MessageProcessingResult result)
+    {
+        _messagesConsumed.Add(1,
+            new KeyValuePair<string, object?>("message_type", messageType),
+            new KeyValuePair<string, object?>("result", result.ToString()));
+
+        _processingDuration.Record(
+            processingDuration.TotalMilliseconds,
+            new KeyValuePair<string, object?>("message_type", messageType));
+    }
+
+    public void RecordPublishError(string messageType, string destination, Exception exception)
+    {
+        _errors.Add(1,
+            new KeyValuePair<string, object?>("message_type", messageType),
+            new KeyValuePair<string, object?>("destination", destination),
+            new KeyValuePair<string, object?>("error_type", exception.GetType().Name));
+    }
+
+    public void RecordConsumeError(string messageType, Exception exception)
+    {
+        _errors.Add(1,
+            new KeyValuePair<string, object?>("message_type", messageType),
+            new KeyValuePair<string, object?>("error_type", exception.GetType().Name));
+    }
+}
+```
+
+### Registration
+
+```csharp
+services.AddSingleton<ITransportMetrics, OpenTelemetryTransportMetrics>();
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## KernelTransportMetrics.cs
+
+An implementation that adapts to Kernel's `IMetricsCollector` for centralized metrics aggregation across the Grid.
+
+```csharp
+public sealed class KernelTransportMetrics(IMetricsCollector metrics) : ITransportMetrics
+{
+    public void RecordMessagePublished(string messageType, string destination)
+    {
+        metrics.Increment(
+            "transport.messages.published",
+            tags: new()
+            {
+                ["message_type"] = messageType,
+                ["destination"] = destination
+            });
+    }
+
+    public void RecordMessageConsumed(
+        string messageType,
+        TimeSpan processingDuration,
+        MessageProcessingResult result)
+    {
+        metrics.Increment(
+            "transport.messages.consumed",
+            tags: new()
+            {
+                ["message_type"] = messageType,
+                ["result"] = result.ToString()
+            });
+
+        metrics.Observe(
+            "transport.processing.duration.ms",
+            processingDuration.TotalMilliseconds,
+            tags: new()
+            {
+                ["message_type"] = messageType
+            });
+    }
+
+    public void RecordPublishError(string messageType, string destination, Exception exception)
+    {
+        metrics.Increment(
+            "transport.errors",
+            tags: new()
+            {
+                ["message_type"] = messageType,
+                ["destination"] = destination,
+                ["error_type"] = exception.GetType().Name
+            });
+    }
+
+    public void RecordConsumeError(string messageType, Exception exception)
+    {
+        metrics.Increment(
+            "transport.errors",
+            tags: new()
+            {
+                ["message_type"] = messageType,
+                ["error_type"] = exception.GetType().Name
+            });
+    }
+}
+```
+
+### Registration
+
+```csharp
+// Swap default implementation with Kernel-backed metrics
 services.AddSingleton<ITransportMetrics, KernelTransportMetrics>();
 ```
 
@@ -117,7 +305,9 @@ services.AddSingleton<ITransportMetrics, KernelTransportMetrics>();
 
 ## TransportTelemetry.cs
 
-OpenTelemetry integration for distributed tracing.
+**Location:** `HoneyDrunk.Transport/Telemetry/TransportTelemetry.cs`
+
+OpenTelemetry integration for distributed tracing. The `ActivitySource` name (`"HoneyDrunk.Transport"`) is stable and used for log correlation.
 
 ```csharp
 public static class TransportTelemetry
@@ -139,10 +329,12 @@ public static class TransportTelemetry
 }
 ```
 
+> **Note:** In most scenarios you do not call `TransportTelemetry` directly. `TelemetryMiddleware` uses these helpers when `TransportCoreOptions.EnableTelemetry` is `true`. The API remains public to support custom transports and advanced scenarios.
+
 ### Usage Example
 
 ```csharp
-// In publisher
+// In publisher (custom transport implementations)
 using var activity = TransportTelemetry.StartPublishActivity(envelope, destination);
 try
 {
@@ -155,7 +347,7 @@ catch (Exception ex)
     throw;
 }
 
-// In consumer
+// In consumer (custom transport implementations)
 using var activity = TransportTelemetry.StartConsumeActivity(envelope);
 try
 {
@@ -166,64 +358,6 @@ catch (Exception ex)
 {
     TransportTelemetry.RecordError(activity, ex);
     throw;
-}
-```
-
-[↑ Back to top](#table-of-contents)
-
----
-
-## Metrics Dashboard Example
-
-```csharp
-public class TransportMetricsDashboard
-{
-    private readonly Counter<long> _messagesPublished;
-    private readonly Counter<long> _messagesConsumed;
-    private readonly Histogram<double> _processingDuration;
-    private readonly Counter<long> _errors;
-    
-    public TransportMetricsDashboard(IMeterFactory meterFactory)
-    {
-        var meter = meterFactory.Create("HoneyDrunk.Transport");
-        
-        _messagesPublished = meter.CreateCounter<long>(
-            "transport.messages.published",
-            description: "Number of messages published");
-        
-        _messagesConsumed = meter.CreateCounter<long>(
-            "transport.messages.consumed",
-            description: "Number of messages consumed");
-        
-        _processingDuration = meter.CreateHistogram<double>(
-            "transport.processing.duration",
-            unit: "ms",
-            description: "Message processing duration");
-        
-        _errors = meter.CreateCounter<long>(
-            "transport.errors",
-            description: "Number of transport errors");
-    }
-    
-    public void RecordPublished(string messageType, string destination)
-    {
-        _messagesPublished.Add(1,
-            new KeyValuePair<string, object?>("message_type", messageType),
-            new KeyValuePair<string, object?>("destination", destination));
-    }
-    
-    public void RecordConsumed(
-        string messageType,
-        TimeSpan duration,
-        MessageProcessingResult result)
-    {
-        _messagesConsumed.Add(1,
-            new KeyValuePair<string, object?>("message_type", messageType),
-            new KeyValuePair<string, object?>("result", result.ToString()));
-        
-        _processingDuration.Record(duration.TotalMilliseconds,
-            new KeyValuePair<string, object?>("message_type", messageType));
-    }
 }
 ```
 

--- a/HoneyDrunk.Transport/docs/Pipeline.md
+++ b/HoneyDrunk.Transport/docs/Pipeline.md
@@ -7,13 +7,21 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [IMessagePipeline.cs](#imessagepipelinecs)
-- [IMessageMiddleware.cs](#imessagemiddlewarecs)
-- [Built-in Middleware](#built-in-middleware)
+- **Core Pipeline** (`HoneyDrunk.Transport/Pipeline/`)
+  - [IMessagePipeline.cs](#imessagepipelinecs)
+  - [MessagePipeline.cs](#messagepipelinecs)
+  - [IMessageMiddleware.cs](#imessagemiddlewarecs)
+  - [MessageMiddleware.cs](#messagemiddlewarecs)
+  - [MessageHandlerInvoker.cs](#messagehandlerinvokercs)
+  - [TransportExecutionContext.cs](#transportexecutioncontextcs)
+  - [MessageHandlerException.cs](#messagehandlerexceptioncs)
+- **Built-in Middleware** (`HoneyDrunk.Transport/Pipeline/Middleware/`)
   - [GridContextPropagationMiddleware.cs](#gridcontextpropagationmiddlewarecs)
   - [LoggingMiddleware.cs](#loggingmiddlewarecs)
+  - [RetryMiddleware.cs](#retrymiddlewarecs)
+  - [CorrelationMiddleware.cs](#correlationmiddlewarecs) *(deprecated)*
+- **Telemetry Middleware** (`HoneyDrunk.Transport/Telemetry/`)
   - [TelemetryMiddleware.cs](#telemetrymiddlewarecs)
-- [MessageHandlerException.cs](#messagehandlerexceptioncs)
 
 ---
 
@@ -23,24 +31,135 @@ The middleware pipeline system that processes messages in an onion-style pattern
 
 **Location:** `HoneyDrunk.Transport/Pipeline/`
 
+### Error Handling Flow
+
+When a handler throws an exception, the pipeline invokes `IErrorHandlingStrategy.HandleErrorAsync(exception, deliveryCount, cancellationToken)` to decide how to handle the failure. The strategy returns an `ErrorHandlingDecision`, which the pipeline converts to a `MessageProcessingResult` for the transport adapter.
+
+> **Note:** Error handling strategies only receive the exception and delivery count—they do not see the full `MessageContext`. The pipeline is responsible for passing `context.DeliveryCount` into the strategy and then mapping the resulting `ErrorHandlingDecision` to a `MessageProcessingResult`. See [Configuration → IErrorHandlingStrategy](Configuration.md#ierrorhandlingstrategycs) for strategy options.
+
+### Default Middleware Order
+
+When all features are enabled, the pipeline executes middleware in the following order:
+
+1. `GridContextPropagationMiddleware` (correlation / Grid context)
+2. `TelemetryMiddleware` (OpenTelemetry spans)
+3. `LoggingMiddleware` (structured logging)
+4. `RetryMiddleware` (max attempt guard)
+5. Handler invocation (`MessageHandlerInvoker`)
+
+Custom middleware is inserted between 1–4 depending on registration order.
+
+---
+
+# Core Pipeline
+
 ---
 
 ## IMessagePipeline.cs
 
+Contract for the message processing pipeline.
+
 ```csharp
 public interface IMessagePipeline
 {
-    Task<MessageProcessingResult> ExecuteAsync(
+    Task<MessageProcessingResult> ProcessAsync(
         ITransportEnvelope envelope,
+        MessageContext context,
         CancellationToken cancellationToken = default);
+}
+```
+
+### Purpose
+
+Entry point for message processing. Transport consumers call `ProcessAsync` when messages arrive, and the pipeline orchestrates middleware execution and handler invocation.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessagePipeline.cs
+
+Default implementation of the message processing pipeline.
+
+```csharp
+public sealed class MessagePipeline : IMessagePipeline
+{
+    public MessagePipeline(
+        IEnumerable<IMessageMiddleware> middlewares,
+        IMessageSerializer serializer,
+        IServiceProvider serviceProvider,
+        ILogger<MessagePipeline> logger);
+    
+    public Task<MessageProcessingResult> ProcessAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### How It Works
+
+1. **Middleware chain building**: Reverses middleware order to build an onion-style pipeline
+2. **Pipeline execution**: Each middleware wraps the next, allowing pre/post processing
+3. **Handler invocation**: At the core, the pipeline deserializes the message and invokes the registered handler
+4. **Exception handling**:
+   - `OperationCanceledException` → re-thrown for caller handling
+   - `MessageHandlerException` → returns the exception's `Result`
+   - Other exceptions → delegated to `IErrorHandlingStrategy.HandleErrorAsync(exception, context.DeliveryCount, cancellationToken)`. The resulting `ErrorHandlingDecision` is converted into a `MessageProcessingResult` for the transport adapter.
+
+### Exception Handling Flow
+
+```csharp
+try
+{
+    await _composedMiddleware(envelope, context, cancellationToken);
+    return MessageProcessingResult.Success;
+}
+catch (MessageHandlerException ex)
+{
+    return ex.Result;
+}
+catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+{
+    var decision = await _errorStrategy.HandleErrorAsync(
+        ex,
+        context.DeliveryCount,
+        cancellationToken);
+
+    return decision.Action switch
+    {
+        ErrorHandlingAction.Retry      => MessageProcessingResult.Retry,
+        ErrorHandlingAction.DeadLetter => MessageProcessingResult.DeadLetter,
+        ErrorHandlingAction.Abandon    => MessageProcessingResult.Abandon,
+        _                              => MessageProcessingResult.Retry
+    };
 }
 ```
 
 ### Usage Example
 
 ```csharp
-// Used internally by consumers - not typically called directly
-// Pipeline automatically invoked when messages arrive
+// Registered automatically by AddHoneyDrunkTransportCore()
+// Transport consumers use the pipeline internally:
+
+public class ServiceBusConsumer : ITransportConsumer
+{
+    private readonly IMessagePipeline _pipeline;
+    
+    private async Task ProcessMessageAsync(ServiceBusReceivedMessage message)
+    {
+        var envelope = MapToTransportEnvelope(message);
+        var context = new MessageContext
+        {
+            Envelope = envelope,
+            Transaction = new ServiceBusTransaction(message),
+            DeliveryCount = (int)message.DeliveryCount
+        };
+        
+        var result = await _pipeline.ProcessAsync(envelope, context, ct);
+        // Handle result...
+    }
+}
 ```
 
 [↑ Back to top](#table-of-contents)
@@ -48,6 +167,8 @@ public interface IMessagePipeline
 ---
 
 ## IMessageMiddleware.cs
+
+Contract for middleware components in the processing pipeline.
 
 ```csharp
 public interface IMessageMiddleware
@@ -91,15 +212,121 @@ services.AddMessageMiddleware<TenantResolutionMiddleware>();
 
 ---
 
-## Built-in Middleware
+## MessageMiddleware.cs
 
-### GridContextPropagationMiddleware.cs
-
-Extracts Grid context from envelope and populates MessageContext.
+Delegate type for functional middleware (alternative to interface-based).
 
 ```csharp
-public sealed class GridContextPropagationMiddleware(IGridContextFactory factory) 
-    : IMessageMiddleware
+public delegate Task MessageMiddleware(
+    ITransportEnvelope envelope,
+    MessageContext context,
+    Func<Task> next,
+    CancellationToken cancellationToken);
+```
+
+### Purpose
+
+Lightweight delegate alternative to `IMessageMiddleware` interface. Useful for inline middleware or simple cross-cutting concerns.
+
+> **DI Registration:** For registering delegate-based middleware with dependency injection, see `DelegateMessageMiddleware` in the [DependencyInjection](DependencyInjection.md) documentation.
+
+### Usage Example
+
+```csharp
+// Inline functional middleware
+MessageMiddleware validationMiddleware = async (envelope, context, next, ct) =>
+{
+    if (string.IsNullOrEmpty(envelope.MessageId))
+        throw new MessageHandlerException("Missing MessageId", MessageProcessingResult.DeadLetter);
+    
+    await next();
+};
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## MessageHandlerInvoker.cs
+
+High-performance handler invocation using compiled expression trees.
+
+```csharp
+internal sealed class MessageHandlerInvoker
+{
+    public MessageHandlerInvoker(IServiceProvider serviceProvider);
+    
+    public Task? InvokeHandlerAsync(
+        object message,
+        Type messageType,
+        MessageContext context,
+        CancellationToken cancellationToken);
+}
+```
+
+### Purpose
+
+Avoids reflection overhead on every message by caching compiled delegates per message type. This is an internal implementation detail of `MessagePipeline`.
+
+### How It Works
+
+1. **First invocation**: Compiles an expression tree for `IMessageHandler<T>.HandleAsync`
+2. **Subsequent invocations**: Uses cached delegate for near-native performance
+3. **Thread-safe**: Uses `ConcurrentDictionary` for delegate cache
+4. **Null return**: Returns `null` if no handler is registered for the message type
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## TransportExecutionContext.cs *(internal, v2-ready)*
+
+Internal pipeline context for tracking broker-specific metadata and execution state.
+
+```csharp
+public sealed class TransportExecutionContext
+{
+    public required ITransportEnvelope Envelope { get; init; }
+    public IGridContext? GridContext { get; set; }
+    public required ITransportTransaction Transaction { get; init; }
+    public Dictionary<string, object> BrokerProperties { get; init; } = [];
+    public int RetryAttempt { get; set; }
+    public TimeSpan ProcessingDuration { get; set; }
+    public int DeliveryCount => RetryAttempt + 1;
+    
+    public MessageContext ToMessageContext();
+}
+```
+
+### Purpose
+
+`TransportExecutionContext` is used **internally** by the pipeline to track broker-specific metadata, retry attempts, and processing duration. The public pipeline surface still exposes `MessageContext` to middleware and handlers in v1.x.
+
+> **Future:** In v2, middleware may receive `TransportExecutionContext` directly as a breaking change, enabling richer middleware scenarios without copying properties.
+
+### Properties
+
+| Property | Description |
+|----------|-------------|
+| `Envelope` | The transport envelope being processed |
+| `GridContext` | Grid context (populated by GridContextPropagationMiddleware) |
+| `Transaction` | Transaction context for commit/rollback |
+| `BrokerProperties` | Adapter-specific metadata (lock tokens, etc.) |
+| `RetryAttempt` | Current retry attempt (0 = first attempt) |
+| `ProcessingDuration` | Cumulative processing time across retries |
+| `DeliveryCount` | `RetryAttempt + 1` |
+
+### v1.x Behavior
+
+In v1.x, the pipeline:
+1. Creates `TransportExecutionContext` internally with broker properties
+2. Calls `ToMessageContext()` to create the public `MessageContext`
+3. Copies select broker properties into `MessageContext.Properties`
+4. Passes `MessageContext` to middleware and handlers
+
+```csharp
+// Transport adapters populate Properties that middleware can access:
+public class VisibilityExtensionMiddleware : IMessageMiddleware
 {
     public async Task InvokeAsync(
         ITransportEnvelope envelope,
@@ -107,120 +334,15 @@ public sealed class GridContextPropagationMiddleware(IGridContextFactory factory
         Func<Task> next,
         CancellationToken ct)
     {
-        // Extract Grid context from envelope
-        context.GridContext = factory.CreateFromEnvelope(envelope, ct);
+        // LockToken is copied into Properties by the transport adapter
+        if (context.Properties.TryGetValue("LockToken", out var lockToken))
+        {
+            // Extend visibility if processing is taking too long
+        }
         
         await next();
     }
 }
-```
-
-### Usage Example
-
-```csharp
-// Registered automatically when EnableCorrelation = true
-services.AddHoneyDrunkTransportCore(options =>
-{
-    options.EnableCorrelation = true; // Enables GridContextPropagationMiddleware
-});
-```
-
-[↑ Back to top](#table-of-contents)
-
----
-
-### LoggingMiddleware.cs
-
-Logs message receipt, processing, and outcomes.
-
-```csharp
-public sealed class LoggingMiddleware(ILogger<LoggingMiddleware> logger) 
-    : IMessageMiddleware
-{
-    public async Task InvokeAsync(
-        ITransportEnvelope envelope,
-        MessageContext context,
-        Func<Task> next,
-        CancellationToken ct)
-    {
-        logger.LogInformation(
-            "Received message {MessageType} with ID {MessageId}",
-            envelope.MessageType,
-            envelope.MessageId);
-        
-        var sw = Stopwatch.StartNew();
-        
-        try
-        {
-            await next();
-            logger.LogInformation(
-                "Successfully processed {MessageType} in {ElapsedMs}ms",
-                envelope.MessageType,
-                sw.ElapsedMilliseconds);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Failed to process {MessageType} after {ElapsedMs}ms",
-                envelope.MessageType,
-                sw.ElapsedMilliseconds);
-            throw;
-        }
-    }
-}
-```
-
-### Usage Example
-
-```csharp
-// Registered automatically when EnableLogging = true
-services.AddHoneyDrunkTransportCore(options =>
-{
-    options.EnableLogging = true; // Enables LoggingMiddleware
-});
-```
-
-[↑ Back to top](#table-of-contents)
-
----
-
-### TelemetryMiddleware.cs
-
-Creates OpenTelemetry spans for distributed tracing.
-
-```csharp
-public sealed class TelemetryMiddleware : IMessageMiddleware
-{
-    public async Task InvokeAsync(
-        ITransportEnvelope envelope,
-        MessageContext context,
-        Func<Task> next,
-        CancellationToken ct)
-    {
-        using var activity = TransportTelemetry.StartConsumeActivity(envelope);
-        
-        try
-        {
-            await next();
-            TransportTelemetry.RecordOutcome(activity, MessageProcessingResult.Success);
-        }
-        catch (Exception ex)
-        {
-            TransportTelemetry.RecordError(activity, ex);
-            throw;
-        }
-    }
-}
-```
-
-### Usage Example
-
-```csharp
-// Registered automatically when EnableTelemetry = true
-services.AddHoneyDrunkTransportCore(options =>
-{
-    options.EnableTelemetry = true; // Enables TelemetryMiddleware
-});
 ```
 
 [↑ Back to top](#table-of-contents)
@@ -229,6 +351,8 @@ services.AddHoneyDrunkTransportCore(options =>
 
 ## MessageHandlerException.cs
 
+Exception for signaling specific processing outcomes from handlers.
+
 ```csharp
 public sealed class MessageHandlerException : Exception
 {
@@ -236,13 +360,18 @@ public sealed class MessageHandlerException : Exception
     
     public MessageHandlerException(
         string message,
-        MessageProcessingResult result)
-        : base(message)
-    {
-        Result = result;
-    }
+        MessageProcessingResult result);
+    
+    public MessageHandlerException(
+        string message,
+        MessageProcessingResult result,
+        Exception innerException);
 }
 ```
+
+### Purpose
+
+Allows handlers and middleware to signal a specific `MessageProcessingResult` by throwing an exception. The pipeline catches this and returns the specified result.
 
 ### Usage Example
 
@@ -261,6 +390,204 @@ public async Task<MessageProcessingResult> HandleAsync(
     
     return MessageProcessingResult.Success;
 }
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+# Built-in Middleware
+
+---
+
+## GridContextPropagationMiddleware.cs
+
+Propagates Grid context across Node boundaries.
+
+```csharp
+public sealed class GridContextPropagationMiddleware : IMessageMiddleware
+{
+    public GridContextPropagationMiddleware(IGridContextFactory gridContextFactory);
+    
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Purpose
+
+The canonical bridge between Kernel Grid context and Transport messaging. Extracts `IGridContext` from envelope metadata and populates `MessageContext.GridContext` for handlers.
+
+### Context Propagation
+
+Extracts and propagates:
+- `CorrelationId` - Distributed tracing correlation
+- `CausationId` - Message causation chain
+- `NodeId` - Source Grid Node
+- `StudioId` - HoneyDrunk Studio identifier
+- `Environment` - Deployment environment
+- `Baggage` - Custom key-value metadata
+
+### Registration
+
+```csharp
+// Registered automatically when EnableCorrelation = true
+services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableCorrelation = true; // Enables GridContextPropagationMiddleware
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## LoggingMiddleware.cs
+
+Logs message receipt, processing, and outcomes with structured logging.
+
+```csharp
+public sealed class LoggingMiddleware : IMessageMiddleware
+{
+    public LoggingMiddleware(ILogger<LoggingMiddleware> logger);
+    
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken ct);
+}
+```
+
+### What It Logs
+
+- **On receive**: Message type, message ID
+- **On success**: Message type, elapsed time (ms)
+- **On failure**: Exception, message type, elapsed time (ms)
+
+### Registration
+
+```csharp
+// Registered automatically when EnableLogging = true
+services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableLogging = true; // Enables LoggingMiddleware
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## RetryMiddleware.cs
+
+Enforces maximum retry limits.
+
+```csharp
+public sealed class RetryMiddleware : IMessageMiddleware
+{
+    public RetryMiddleware(ILogger<RetryMiddleware> logger, int maxAttempts = 3);
+    
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Behavior
+
+- Checks `context.DeliveryCount` against `maxAttempts`
+- If exceeded, throws `MessageHandlerException` with `MessageProcessingResult.DeadLetter`
+- Otherwise, passes through to next middleware
+
+> **Note:** `RetryMiddleware` is a simple guardrail on top of broker-level delivery attempts. It does **not** reschedule messages itself; it only forces a `DeadLetter` result once `DeliveryCount` exceeds `maxAttempts`, letting the transport adapter move the message to DLQ. Backoff delays are handled by `IErrorHandlingStrategy`, not this middleware.
+
+### Usage Example
+
+```csharp
+// Configure max retry attempts
+services.AddSingleton<IMessageMiddleware>(sp => 
+    new RetryMiddleware(
+        sp.GetRequiredService<ILogger<RetryMiddleware>>(),
+        maxAttempts: 5));
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## CorrelationMiddleware.cs
+
+> **⚠️ DEPRECATED:** Use `GridContextPropagationMiddleware` for full Grid context propagation. This middleware remains for backward compatibility only and will be removed in v1.0.
+
+> **Migration:** `CorrelationMiddleware` is **not added by default**. Only resolve it manually if you are migrating legacy code that depends on the `KernelContext` property key.
+
+```csharp
+[Obsolete("Use GridContextPropagationMiddleware for full Grid context propagation.")]
+public sealed class CorrelationMiddleware : IMessageMiddleware
+{
+    public CorrelationMiddleware(IGridContextFactory gridContextFactory);
+    
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Legacy Behavior
+
+- Creates Grid context from envelope
+- Stores in `context.Properties["KernelContext"]` (legacy key)
+- Stores in `context.Properties["GridContext"]`
+- Stores `CorrelationId` and `CausationId` separately
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+# Telemetry Middleware
+
+---
+
+## TelemetryMiddleware.cs
+
+**Location:** `HoneyDrunk.Transport/Telemetry/TelemetryMiddleware.cs`
+
+Creates OpenTelemetry spans for distributed tracing.
+
+```csharp
+public sealed class TelemetryMiddleware : IMessageMiddleware
+{
+    public Task InvokeAsync(
+        ITransportEnvelope envelope,
+        MessageContext context,
+        Func<Task> next,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### What It Records
+
+- **Activity span**: `TransportTelemetry.StartProcessActivity(envelope, "consumer")`
+- **Delivery count**: As span attribute
+- **Outcome**: Success or error status
+- **Exception**: On failure, records exception details
+
+### Registration
+
+```csharp
+// Registered automatically when EnableTelemetry = true
+services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableTelemetry = true; // Enables TelemetryMiddleware
+});
 ```
 
 [↑ Back to top](#table-of-contents)

--- a/HoneyDrunk.Transport/docs/Runtime.md
+++ b/HoneyDrunk.Transport/docs/Runtime.md
@@ -1,0 +1,492 @@
+﻿# 🏃 Runtime - Lifecycle Orchestration
+
+[← Back to File Guide](FILE_GUIDE.md)
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [ITransportRuntime.cs](#itransportruntimecs)
+- [TransportRuntimeHost.cs](#transportruntimehostcs)
+- [Lifecycle Management](#lifecycle-management)
+- [Health Integration](#health-integration)
+- [Advanced Scenarios](#advanced-scenarios)
+
+---
+
+## Overview
+
+The Runtime layer provides unified lifecycle orchestration for all transport consumers. It integrates with ASP.NET Core's hosting model via `IHostedService`, ensuring proper startup and graceful shutdown of message processing across all registered transport adapters.
+
+**Location:** `HoneyDrunk.Transport/Runtime/`
+
+**Key Responsibilities:**
+- Coordinate startup of all registered transport consumers
+- Manage graceful shutdown allowing in-flight messages to complete
+- Expose transport health contributors for aggregation in ASP.NET Core health checks
+- Integrate with ASP.NET Core hosting lifecycle via `IHostedService`
+
+The runtime lives inside a HoneyDrunk node. Kernel owns node lifecycle, and `TransportRuntimeHost` plugs into that lifecycle to manage only the messaging side of the node.
+
+---
+
+## ITransportRuntime.cs
+
+Contract for the unified runtime orchestrator.
+
+```csharp
+public interface ITransportRuntime
+{
+    /// <summary>
+    /// Gets a value indicating whether the runtime is currently running.
+    /// </summary>
+    bool IsRunning { get; }
+
+    /// <summary>
+    /// Starts all registered transport consumers.
+    /// </summary>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops all transport consumers gracefully, allowing in-flight messages to complete.
+    /// </summary>
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all health contributors from registered transports for aggregation.
+    /// Typically non-blocking; implementations usually return a cached collection.
+    /// </summary>
+    Task<IEnumerable<ITransportHealthContributor>> GetHealthContributorsAsync(
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Purpose
+
+Provides a single point of control for **transport consumers** inside a node. Application code can start or stop all consumers, or query their status, without knowing about individual transport adapters.
+
+This interface does not control publishers or other infrastructure. It only manages components that implement `ITransportConsumer`.
+
+### Usage Example
+
+```csharp
+public class RuntimeController(ITransportRuntime runtime) : ControllerBase
+{
+    [HttpGet("status")]
+    public IActionResult GetStatus()
+    {
+        return Ok(new { IsRunning = runtime.IsRunning });
+    }
+    
+    [HttpPost("restart")]
+    public async Task<IActionResult> RestartAsync(CancellationToken ct)
+    {
+        await runtime.StopAsync(ct);
+        await runtime.StartAsync(ct);
+        return Ok("Restarted");
+    }
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## TransportRuntimeHost.cs
+
+Default implementation that orchestrates consumer lifecycle as an `IHostedService`.
+
+```csharp
+public sealed partial class TransportRuntimeHost(
+    IEnumerable<ITransportConsumer> consumers,
+    IEnumerable<ITransportHealthContributor> healthContributors,
+    ILogger<TransportRuntimeHost> logger) : IHostedService, ITransportRuntime, IDisposable
+{
+    public bool IsRunning { get; }
+    
+    public Task StartAsync(CancellationToken cancellationToken = default);
+    public Task StopAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<ITransportHealthContributor>> GetHealthContributorsAsync(
+        CancellationToken cancellationToken = default);
+    public void Dispose();
+}
+```
+
+**Implements:**
+
+- `IHostedService` for ASP.NET Core integration
+- `ITransportRuntime` for programmatic control
+- `IDisposable` for cleanup of consumer resources
+
+### Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Automatic Startup** | Registered as `IHostedService`, starts with application |
+| **Parallel Consumer Startup** | Starts all registered `ITransportConsumer` instances concurrently for faster initialization |
+| **Graceful Shutdown** | Stops all consumers in parallel, allowing in-flight messages to complete |
+| **Thread-Safe** | Uses `SemaphoreSlim` to prevent concurrent start/stop operations |
+| **High-Performance Logging** | Uses `LoggerMessage` source generators for zero-allocation logging |
+| **Idempotent Operations** | Multiple start/stop calls are safely handled |
+
+### Registration
+
+`TransportRuntimeHost` is registered automatically by `AddHoneyDrunkTransportCore` as both:
+
+- A singleton `ITransportRuntime`
+- An `IHostedService` that ASP.NET Core will start and stop with the node
+
+```csharp
+// Registered automatically by AddHoneyDrunkTransportCore()
+services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableTelemetry = true;
+    options.EnableLogging = true;
+});
+
+// Conceptual registration (simplified):
+// services.TryAddSingleton<ITransportRuntime, TransportRuntimeHost>();
+// services.AddHostedService<TransportRuntimeHost>();
+```
+
+### How It Works
+
+**Startup Flow:**
+
+```
+Application.Run()
+    ↓
+IHostedService.StartAsync()
+    ↓
+TransportRuntimeHost.StartAsync()
+    ↓
+┌─────────────────────────────────────────────┐
+│  For each ITransportConsumer (in parallel): │
+│    1. Log "Starting consumer {Type}"        │
+│    2. consumer.StartAsync()                 │
+│    3. Log "Consumer {Type} started"         │
+└─────────────────────────────────────────────┘
+    ↓
+IsRunning = true
+```
+
+**Shutdown Flow:**
+
+```
+Application Shutdown Signal (SIGTERM, Ctrl+C)
+    ↓
+IHostedService.StopAsync()
+    ↓
+TransportRuntimeHost.StopAsync()
+    ↓
+┌─────────────────────────────────────────────┐
+│  For each ITransportConsumer (in parallel): │
+│    1. Log "Stopping consumer {Type}"        │
+│    2. consumer.StopAsync()                  │
+│    3. Log "Consumer {Type} stopped"         │
+└─────────────────────────────────────────────┘
+    ↓
+IsRunning = false
+```
+
+### Error Handling
+
+- **Startup failures**: If any consumer fails to start, the exception propagates and prevents application startup
+- **Shutdown failures**: Individual consumer stop failures are logged but don't prevent other consumers from stopping
+
+```csharp
+// Startup - fail fast
+private async Task StartConsumerAsync(ITransportConsumer consumer, CancellationToken ct)
+{
+    try
+    {
+        await consumer.StartAsync(ct);
+    }
+    catch (Exception ex)
+    {
+        LogConsumerStartFailed(logger, consumer.GetType().Name, ex);
+        throw; // Propagate - prevents application startup
+    }
+}
+
+// Shutdown - best effort
+private async Task StopConsumerAsync(ITransportConsumer consumer, CancellationToken ct)
+{
+    try
+    {
+        await consumer.StopAsync(ct);
+    }
+    catch (Exception ex)
+    {
+        LogConsumerStopError(logger, consumer.GetType().Name, ex);
+        // Don't rethrow - allow other consumers to stop
+    }
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Lifecycle Management
+
+### Typical Application Flow
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// 1. Register Kernel (required before Transport)
+builder.Services.AddHoneyDrunkCoreNode(nodeDescriptor);
+
+// 2. Register Transport with transport adapter
+builder.Services.AddHoneyDrunkTransportCore(options =>
+{
+    options.EnableTelemetry = true;
+    options.EnableLogging = true;
+})
+.AddHoneyDrunkServiceBusTransport(options =>
+{
+    options.ConnectionString = "...";
+});
+
+// 3. Register message handlers
+builder.Services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+
+var app = builder.Build();
+
+// 4. TransportRuntimeHost starts automatically when app.Run() is called
+app.Run();
+```
+
+In normal applications you do not call `ITransportRuntime` directly. The ASP.NET Core host will call `StartAsync` and `StopAsync` on `TransportRuntimeHost` when `app.Run()` is invoked and when the node shuts down.
+
+### Manual Lifecycle Control
+
+For scenarios requiring programmatic control over the runtime:
+
+```csharp
+public class MaintenanceService(ITransportRuntime runtime, ILogger<MaintenanceService> logger)
+{
+    public async Task EnterMaintenanceModeAsync(CancellationToken ct)
+    {
+        if (runtime.IsRunning)
+        {
+            logger.LogInformation("Entering maintenance mode, stopping consumers...");
+            await runtime.StopAsync(ct);
+            logger.LogInformation("Consumers stopped, maintenance mode active");
+        }
+    }
+    
+    public async Task ExitMaintenanceModeAsync(CancellationToken ct)
+    {
+        if (!runtime.IsRunning)
+        {
+            logger.LogInformation("Exiting maintenance mode, starting consumers...");
+            await runtime.StartAsync(ct);
+            logger.LogInformation("Consumers started, normal operation resumed");
+        }
+    }
+}
+```
+
+### Graceful Shutdown Configuration
+
+Configure shutdown timeout in `appsettings.json`:
+
+```json
+{
+  "HostOptions": {
+    "ShutdownTimeout": "00:00:30"
+  }
+}
+```
+
+Or programmatically:
+
+```csharp
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(30);
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Health Integration
+
+### Aggregating Health Contributors
+
+The runtime collects health contributors from all registered transports:
+
+> See [Health](Health.md) for the definition of `ITransportHealthContributor` and common contributors like `OutboxHealthContributor` and `PublisherHealthContributor`.
+
+```csharp
+public class TransportHealthCheck(ITransportRuntime runtime) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken ct = default)
+    {
+        if (!runtime.IsRunning)
+        {
+            return HealthCheckResult.Unhealthy("Transport runtime is not running");
+        }
+        
+        // Each contributor is an ITransportHealthContributor from the Health folder
+        var contributors = await runtime.GetHealthContributorsAsync(ct);
+        var results = new Dictionary<string, object>();
+        var worstStatus = HealthStatus.Healthy;
+        
+        foreach (var contributor in contributors)
+        {
+            var result = await contributor.CheckHealthAsync(ct);
+            results[contributor.Name] = result.Status.ToString();
+            
+            if (result.Status == HealthStatus.Unhealthy)
+                worstStatus = HealthStatus.Unhealthy;
+            else if (result.Status == HealthStatus.Degraded && worstStatus != HealthStatus.Unhealthy)
+                worstStatus = HealthStatus.Degraded;
+        }
+        
+        return new HealthCheckResult(worstStatus, data: results);
+    }
+}
+```
+
+### Kubernetes Probes
+
+```csharp
+// Register health checks
+builder.Services.AddHealthChecks()
+    .AddCheck<TransportHealthCheck>("transport");
+
+var app = builder.Build();
+
+// Map health endpoints
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready")
+});
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("live")
+});
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Advanced Scenarios
+
+### Multiple Transport Adapters
+
+The runtime automatically discovers and manages all registered consumers:
+
+```csharp
+builder.Services.AddHoneyDrunkTransportCore(options => { })
+    // Register multiple transport adapters
+    .AddHoneyDrunkServiceBusTransport(sb =>
+    {
+        sb.ConnectionString = "...";
+        sb.TopicName = "high-priority-events";
+    })
+    .AddHoneyDrunkStorageQueueTransport(sq =>
+    {
+        sq.ConnectionString = "...";
+        sq.QueueName = "batch-processing";
+    });
+
+// TransportRuntimeHost will start both consumers and include both in health aggregation.
+// It does not care whether they came from Service Bus, Storage Queue, or InMemory.
+```
+
+### Testing with InMemory Transport
+
+```csharp
+[Fact]
+public async Task RuntimeStartsAndStopsConsumers()
+{
+    var services = new ServiceCollection();
+    
+    services.AddLogging();
+    services.AddHoneyDrunkTransportCore(options => { })
+        .AddHoneyDrunkInMemoryTransport();
+    
+    var provider = services.BuildServiceProvider();
+    var runtime = provider.GetRequiredService<ITransportRuntime>();
+    
+    // Initially not running
+    Assert.False(runtime.IsRunning);
+    
+    // Start
+    await runtime.StartAsync();
+    Assert.True(runtime.IsRunning);
+    
+    // Stop
+    await runtime.StopAsync();
+    Assert.False(runtime.IsRunning);
+}
+```
+
+### Custom Consumer Implementation
+
+When implementing a custom transport, ensure your consumer integrates with the runtime:
+
+```csharp
+public sealed class CustomTransportConsumer : ITransportConsumer, IAsyncDisposable
+{
+    private CancellationTokenSource? _cts;
+    private Task? _processingTask;
+    
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _processingTask = ProcessMessagesAsync(_cts.Token);
+    }
+    
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+        
+        await _cts.CancelAsync();
+        
+        if (_processingTask is not null)
+        {
+            // Wait until either processing finishes or the host's shutdown timeout expires
+            await Task.WhenAny(
+                _processingTask,
+                Task.Delay(Timeout.Infinite, cancellationToken));
+        }
+    }
+    
+    public async ValueTask DisposeAsync()
+    {
+        _cts?.Dispose();
+    }
+    
+    private async Task ProcessMessagesAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            // Process messages...
+        }
+    }
+}
+```
+
+Custom consumers must obey the cancellation token and return promptly from `StopAsync`. `TransportRuntimeHost` relies on this to honor the node's configured `ShutdownTimeout`.
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Back to File Guide](FILE_GUIDE.md) | [↑ Back to top](#table-of-contents)

--- a/HoneyDrunk.Transport/docs/StorageQueue.md
+++ b/HoneyDrunk.Transport/docs/StorageQueue.md
@@ -319,8 +319,9 @@ internal sealed class PoisonQueueMover(ILogger<PoisonQueueMover> logger)
             DequeueCount = dequeueCount,
             PoisonedAt = DateTimeOffset.UtcNow,
             ErrorType = error?.GetType().FullName,
-            ErrorMessage = error?.Message,
-            ErrorStackTrace = error?.StackTrace
+            // Optionally redact or omit ErrorMessage if sensitive
+            ErrorMessage = error?.Message
+            // Do not include stack traces in poison queue payloads; log them securely instead
         };
         
         await poisonQueueClient.SendMessageAsync(

--- a/HoneyDrunk.Transport/docs/StorageQueue.md
+++ b/HoneyDrunk.Transport/docs/StorageQueue.md
@@ -10,6 +10,7 @@
 - [StorageQueueOptions.cs](#storagequeueoptionscs)
 - [StorageQueueSender.cs](#storagequeuesendercs)
 - [StorageQueueProcessor.cs](#storagequeueprocessorcs)
+- [StorageQueueTopology.cs](#storagequeuetopologycs)
 - [Concurrency Model](#concurrency-model)
 - [Poison Queue Pattern](#poison-queue-pattern)
 - [Message Size Handling](#message-size-handling)
@@ -21,6 +22,10 @@
 ## Overview
 
 Azure Storage Queue transport for cost-effective, high-volume messaging. Ideal for simple queue-based scenarios without advanced features like topics or sessions.
+
+The Storage Queue transport implements the standard transport contracts (`ITransportPublisher`, `ITransportConsumer`, `ITransportTopology`) and participates in the shared pipeline and runtime just like Service Bus and InMemory.
+
+It is intended for simple, high-volume workloads where at-least-once delivery and small payloads are acceptable.
 
 **Location:** `HoneyDrunk.Transport.StorageQueue/`
 
@@ -35,29 +40,54 @@ Azure Storage Queue transport for cost-effective, high-volume messaging. Ideal f
 - ⚠️ No sessions or transactions
 - ⚠️ No native duplicate detection
 
+**What Gets Registered:**
+
+```csharp
+services.AddHoneyDrunkTransportStorageQueue(...)
+// Registers:
+// - StorageQueueSender as ITransportPublisher
+// - StorageQueueProcessor as ITransportConsumer
+// - StorageQueueTopology as ITransportTopology
+// - QueueClientFactory (internal)
+// - PoisonQueueMover (internal)
+```
+
 ---
 
 ## StorageQueueOptions.cs
 
+Configuration for Azure Storage Queue transport. Extends `TransportOptions` and implements `IValidatableObject`.
+
 ```csharp
-public sealed class StorageQueueOptions
+// Simplified excerpt. For full definition see Configuration → StorageQueueOptions.
+public sealed class StorageQueueOptions : TransportOptions, IValidatableObject
 {
+    // Authentication
     public string? ConnectionString { get; set; }
     public Uri? AccountEndpoint { get; set; }
+
+    // Queue settings
     public string QueueName { get; set; } = string.Empty;
-    public string? PoisonQueueName { get; set; }
+    public string? PoisonQueueName { get; set; }  // Defaults to "{QueueName}-poison"
     public bool CreateIfNotExists { get; set; } = true;
-    
-    public int MaxDequeueCount { get; set; } = 5;
+
+    // Message semantics
+    public TimeSpan? MessageTimeToLive { get; set; }
     public TimeSpan VisibilityTimeout { get; set; } = TimeSpan.FromSeconds(30);
-    public int PrefetchMaxMessages { get; set; } = 16;
+    public int MaxDequeueCount { get; set; } = 5;
+
+    // Concurrency (see Concurrency Model section)
     public int MaxConcurrency { get; set; } = 5;
     public int BatchProcessingConcurrency { get; set; } = 1;
-    
+    public int PrefetchMaxMessages { get; set; } = 16;
+
+    // Polling
     public TimeSpan EmptyQueuePollingInterval { get; set; } = TimeSpan.FromSeconds(1);
     public TimeSpan MaxPollingInterval { get; set; } = TimeSpan.FromSeconds(5);
 }
 ```
+
+> **Validation:** See [Configuration](Configuration.md) for validation rules including `BatchProcessingConcurrency <= PrefetchMaxMessages`, `MaxConcurrency <= 100`, and Azure limits.
 
 ### Usage Example
 
@@ -76,91 +106,141 @@ services.AddHoneyDrunkTransportStorageQueue(options =>
     
     // Processing
     options.MaxConcurrency = 10;
-    options.BatchProcessingConcurrency = 4; // 10 × 4 = 40 concurrent operations
+    options.BatchProcessingConcurrency = 4;  // 10 × 4 = 40 concurrent
     options.PrefetchMaxMessages = 16;
-    
-    // Polling (empty queue backoff)
-    options.EmptyQueuePollingInterval = TimeSpan.FromSeconds(1);
-    options.MaxPollingInterval = TimeSpan.FromSeconds(5);
 });
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## StorageQueueSender.cs
 
+Standard `ITransportPublisher` implementation for Azure Storage Queue.
+
 ```csharp
-public sealed class StorageQueueSender(QueueClientFactory factory) 
-    : ITransportPublisher
+internal sealed class StorageQueueSender(
+    QueueClientFactory queueClientFactory,
+    IOptions<StorageQueueOptions> options,
+    ILogger<StorageQueueSender> logger) 
+    : ITransportPublisher, IAsyncDisposable
 {
-    public async Task PublishAsync(
+    public Task PublishAsync(
         ITransportEnvelope envelope,
         IEndpointAddress destination,
-        CancellationToken ct)
-    {
-        var queueClient = await factory.GetOrCreatePrimaryQueueClientAsync(ct);
-        var storageEnvelope = MapToStorageEnvelope(envelope);
-        var json = JsonSerializer.Serialize(storageEnvelope);
-        
-        await queueClient.SendMessageAsync(json, ct);
-    }
+        CancellationToken cancellationToken = default);
+    
+    public Task PublishBatchAsync(
+        IEnumerable<ITransportEnvelope> envelopes,
+        IEndpointAddress destination,
+        CancellationToken cancellationToken = default);
+    
+    public ValueTask DisposeAsync();
 }
 ```
+
+### Behavior
+
+- Serializes `ITransportEnvelope` to JSON with base64-encoded payload
+- Validates message size before sending (throws `MessageTooLargeException` if > 64KB)
+- `PublishBatchAsync` parallelizes sends with configurable `MaxBatchPublishConcurrency`
+- Telemetry via `TransportTelemetry` when `EnableTelemetry = true`
+
+> **Size Limit:** The envelope is serialized to JSON and sent as a single Storage Queue message. Storage Queue adds its own base64 encoding, so `TransportEnvelope` plus headers and payload must stay under the 64KB limit.
 
 ### Usage Example
 
 ```csharp
 // Automatic usage through ITransportPublisher
-public class OrderService(ITransportPublisher publisher)
+public class OrderService(ITransportPublisher publisher, EnvelopeFactory factory)
 {
-    public async Task PublishOrderAsync(Order order, CancellationToken ct)
+    public async Task PublishOrderAsync(OrderCreated order, CancellationToken ct)
     {
-        var envelope = CreateEnvelope(order);
-        await publisher.PublishAsync(envelope, new EndpointAddress("orders"), ct);
-        // Published to Storage Queue
+        var envelope = factory.CreateEnvelope<OrderCreated>(
+            _serializer.Serialize(order));
+        
+        await publisher.PublishAsync(
+            envelope,
+            EndpointAddress.Create("orders", "orders"),
+            ct);
     }
 }
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## StorageQueueProcessor.cs
 
+Standard `ITransportConsumer` implementation for Azure Storage Queue.
+
 ```csharp
-public sealed class StorageQueueProcessor(
-    QueueClientFactory factory,
+internal sealed class StorageQueueProcessor(
+    QueueClientFactory queueClientFactory,
     IMessagePipeline pipeline,
-    IOptions<StorageQueueOptions> options) 
-    : BackgroundService
+    PoisonQueueMover poisonQueueMover,
+    IOptions<StorageQueueOptions> options,
+    ILogger<StorageQueueProcessor> logger) 
+    : ITransportConsumer, IAsyncDisposable
 {
-    protected override async Task ExecuteAsync(CancellationToken ct)
-    {
-        while (!ct.IsCancellationRequested)
-        {
-            // Fetch batch
-            var messages = await FetchMessagesAsync(ct);
-            
-            if (!messages.Any())
-            {
-                await ApplyBackoffAsync(ct);
-                continue;
-            }
-            
-            // Process messages (sequential or parallel based on BatchProcessingConcurrency)
-            await ProcessBatchAsync(messages, ct);
-        }
-    }
+    public Task StartAsync(CancellationToken cancellationToken = default);
+    public Task StopAsync(CancellationToken cancellationToken = default);
+    public ValueTask DisposeAsync();
 }
 ```
+
+### What StartAsync Does
+
+On `StartAsync`, the processor:
+
+1. Creates `MaxConcurrency` concurrent fetch loops
+2. Each loop calls `ReceiveMessagesAsync` with `PrefetchMaxMessages`
+3. Deserializes each message to `TransportEnvelope`
+4. Forwards to `IMessagePipeline.ProcessAsync()` for full pipeline execution
+5. On `Success`: deletes message from queue
+6. On `Retry`: leaves message to become visible after `VisibilityTimeout`
+7. On `DeadLetter` or `MaxDequeueCount` exceeded: moves to poison queue
+
+The processor is registered as `ITransportConsumer`, so `TransportRuntimeHost` will start and stop it with the rest of the node.
 
 ### Usage Example
 
 ```csharp
-// Started automatically as BackgroundService
-services.AddHoneyDrunkTransportStorageQueue(/* ... */);
-
-// Processor polls queue and processes messages through pipeline
+// Registered automatically - no manual interaction needed
+services.AddHoneyDrunkTransportStorageQueue(options => { ... });
+// TransportRuntimeHost starts the processor when the node starts
 ```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## StorageQueueTopology.cs
+
+Implements `ITransportTopology` to declare Storage Queue transport capabilities.
+
+```csharp
+internal sealed class StorageQueueTopology : ITransportTopology
+{
+    public string Name => "StorageQueue";
+    public bool SupportsTopics => false;
+    public bool SupportsSubscriptions => false;
+    public bool SupportsSessions => false;
+    public bool SupportsOrdering => false;
+    public bool SupportsScheduledMessages => false;
+    public bool SupportsBatching => true;
+    public bool SupportsTransactions => false;
+    public bool SupportsDeadLetterQueue => false;  // Manual via poison queue
+    public bool SupportsPriority => false;
+    public long? MaxMessageSize => 64 * 1024;  // 64 KB
+}
+```
+
+> See [Architecture → Topology Capabilities](Architecture.md) for how topology is used across transport adapters.
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
@@ -170,6 +250,10 @@ Storage Queue transport uses a **two-level concurrency model**:
 
 ```
 Total Concurrent Processing = MaxConcurrency × BatchProcessingConcurrency
+
+Where:
+- MaxConcurrency     = number of concurrent fetch loops (default: 5)
+- BatchProcessingConcurrency = concurrent messages per fetch loop (default: 1)
 
 Examples:
 - MaxConcurrency=5, BatchProcessingConcurrency=1 (default) = 5 concurrent
@@ -181,8 +265,7 @@ Examples:
 
 ```csharp
 // Default: 5 fetch loops × 1 sequential = 5 concurrent operations
-services.AddHoneyDrunkTransportStorageQueue(/* ... */)
-    .WithConcurrency(5);
+services.AddHoneyDrunkTransportStorageQueue(/* ... */);
 
 // High throughput: 10 fetch loops × 4 parallel per batch = 40 concurrent
 services.AddHoneyDrunkTransportStorageQueue(/* ... */)
@@ -195,34 +278,53 @@ services.AddHoneyDrunkTransportStorageQueue(/* ... */)
     .WithBatchProcessingConcurrency(8);
 ```
 
+### Validation Rules
+
+- `BatchProcessingConcurrency` must be ≤ `PrefetchMaxMessages` (no benefit processing more than fetched)
+- `MaxConcurrency` cannot exceed 100 to prevent resource exhaustion
+
+> See [Configuration](Configuration.md) for full validation rules.
+
+[↑ Back to top](#table-of-contents)
+
 ---
 
 ## Poison Queue Pattern
 
+The Storage Queue transport automatically moves messages that exceed `MaxDequeueCount` into the poison queue. The `PoisonQueueMover` is the internal helper that constructs the diagnostic payload.
+
+### Defaults
+
+- `PoisonQueueName` defaults to `"{QueueName}-poison"` if not set
+- Messages move to poison queue after `MaxDequeueCount` delivery attempts (default: 5)
+- Handler returning `MessageProcessingResult.DeadLetter` immediately moves to poison queue
+
+### Poison Queue Message Format
+
 ```csharp
-public sealed class PoisonQueueMover(QueueClientFactory factory)
+// Internal helper that adds diagnostic metadata
+internal sealed class PoisonQueueMover(ILogger<PoisonQueueMover> logger)
 {
-    public async Task MoveToPoisonQueueAsync(
-        QueueMessage message,
-        Exception error,
+    public async Task MoveMessageToPoisonQueueAsync(
+        QueueClient poisonQueueClient,
+        QueueMessage originalMessage,
+        Exception? error,
+        long dequeueCount,
         CancellationToken ct)
     {
-        var poisonClient = await factory.GetOrCreatePoisonQueueClientAsync(ct);
-        
-        var poisonEnvelope = new
+        var poisonPayload = new
         {
-            OriginalMessageId = message.MessageId,
-            OriginalMessage = message.Body.ToString(),
-            DequeueCount = message.DequeueCount,
-            FirstFailureTimestamp = /* ... */,
-            LastFailureTimestamp = DateTime.UtcNow,
-            ErrorType = error.GetType().FullName,
-            ErrorMessage = error.Message,
-            ErrorStackTrace = error.StackTrace
+            OriginalMessageId = originalMessage.MessageId,
+            OriginalMessageText = originalMessage.Body.ToString(),
+            DequeueCount = dequeueCount,
+            PoisonedAt = DateTimeOffset.UtcNow,
+            ErrorType = error?.GetType().FullName,
+            ErrorMessage = error?.Message,
+            ErrorStackTrace = error?.StackTrace
         };
         
-        await poisonClient.SendMessageAsync(
-            JsonSerializer.Serialize(poisonEnvelope),
+        await poisonQueueClient.SendMessageAsync(
+            JsonSerializer.Serialize(poisonPayload),
             ct);
     }
 }
@@ -231,51 +333,66 @@ public sealed class PoisonQueueMover(QueueClientFactory factory)
 ### Monitoring Poison Queue
 
 ```csharp
-public class PoisonQueueMonitor
+public class PoisonQueueMonitor(QueueClient poisonClient)
 {
-    public async Task<IEnumerable<PoisonMessage>> GetPoisonMessagesAsync(
-        CancellationToken ct)
+    public async Task<IEnumerable<PoisonMessage>> GetPoisonMessagesAsync(CancellationToken ct)
     {
-        var poisonClient = new QueueClient(connectionString, "orders-poison");
         var messages = await poisonClient.ReceiveMessagesAsync(maxMessages: 32, ct);
         
         return messages.Value.Select(m =>
-            JsonSerializer.Deserialize<PoisonMessage>(m.Body.ToString()));
+            JsonSerializer.Deserialize<PoisonMessage>(m.Body.ToString())!);
     }
 }
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## Message Size Handling
 
+The Storage Queue adapter detects oversized envelopes **before** calling the SDK and throws `MessageTooLargeException`.
+
 ```csharp
-public class MessageTooLargeException : Exception
+// From HoneyDrunk.Transport.Exceptions
+public sealed class MessageTooLargeException : Exception
 {
     public string MessageId { get; }
-    public int ActualSize { get; }
-    public int MaxSize { get; }
+    public long ActualSize { get; }
+    public long MaxSize { get; }
+    public string TransportName { get; }
 }
+```
 
-// Handle oversized messages
+### Blob Fallback Pattern
+
+The Storage Queue adapter does **not** automatically offload oversized messages. One common pattern is to detect `MessageTooLargeException` in application code and fall back to Blob Storage with a small reference message:
+
+```csharp
 try
 {
-    await publisher.PublishAsync(largeEnvelope, destination, ct);
+    await publisher.PublishAsync(envelope, destination, ct);
 }
 catch (MessageTooLargeException ex)
 {
-    _logger.LogError(ex,
-        "Message {MessageId} is {ActualSize}KB (max: {MaxSize}KB)",
+    _logger.LogWarning(
+        "Message {MessageId} is {ActualKB}KB (max: {MaxKB}KB), using blob fallback",
         ex.MessageId,
         ex.ActualSize / 1024,
         ex.MaxSize / 1024);
     
-    // Fallback: Store in Blob Storage
-    var blobUrl = await _blobStorage.UploadAsync(payload, ct);
-    var referenceMessage = new BlobReferenceMessage(blobUrl);
-    await publisher.PublishAsync(CreateEnvelope(referenceMessage), destination, ct);
+    // Store payload in Blob Storage
+    var blobUrl = await _blobStorage.UploadAsync(envelope.Payload.ToArray(), ct);
+    
+    // Send reference message
+    var referenceEnvelope = factory.CreateEnvelope<BlobReference>(
+        _serializer.Serialize(new BlobReference(blobUrl)));
+    
+    await publisher.PublishAsync(referenceEnvelope, destination, ct);
 }
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
@@ -294,34 +411,57 @@ builder.Services
         "orders")
     .WithMaxDequeueCount(5)
     .WithConcurrency(10)
-    .WithBatchProcessingConcurrency(4) // 10 × 4 = 40 concurrent
-    .WithPoisonQueue("orders-poison");
+    .WithBatchProcessingConcurrency(4)  // 10 × 4 = 40 concurrent
+    .WithPoisonQueue("orders-poison")
+    .WithVisibilityTimeout(TimeSpan.FromSeconds(30));
 
 // 3. Register handlers
 builder.Services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+builder.Services.AddMessageHandler<OrderUpdated, OrderUpdatedHandler>();
 
 var app = builder.Build();
-app.Run();
+app.Run();  // TransportRuntimeHost starts StorageQueueProcessor
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## When to Use Storage Queue
 
+| Scenario | Storage Queue | Service Bus |
+|----------|---------------|-------------|
+| **Cost optimization** | ✅ $0.0004/10K ops | ❌ Higher cost |
+| **High volume (millions/day)** | ✅ Excellent | ✅ Good |
+| **Simple queue semantics** | ✅ Yes | ✅ Yes |
+| **Message size < 64KB** | ✅ Yes | ✅ Up to 1MB+ |
+| **At-least-once acceptable** | ✅ Yes | ✅ Yes |
+| **Single consumer group per queue** | ✅ Yes | ✅ Yes |
+| **No complex routing** | ✅ Yes | - |
+| **Topics/subscriptions (fan-out)** | ❌ No | ✅ Yes |
+| **Sessions (ordered processing)** | ❌ No | ✅ Yes |
+| **Transactions** | ❌ No | ✅ Yes |
+| **Duplicate detection** | ❌ No | ✅ Yes |
+| **Fine-grained routing (filters)** | ❌ No | ✅ Yes |
+
 **Choose Storage Queue when:**
-- ✅ Cost optimization is critical
-- ✅ Message volume is very high (millions/day)
-- ✅ Simple queue semantics are sufficient
-- ✅ Message size < 64KB
-- ✅ At-least-once delivery is acceptable
+- Cost optimization is critical
+- Message volume is very high (millions/day)
+- Simple queue semantics are sufficient
+- Message size < 64KB
+- At-least-once delivery is acceptable
+- You are fine modeling everything as a single consumer group per queue with no complex routing graph
 
 **Choose Service Bus when:**
-- ✅ Need topics/subscriptions (pub/sub)
-- ✅ Require sessions for ordered processing
-- ✅ Need transactional receive
-- ✅ Message size up to 1MB+
-- ✅ Duplicate detection is required
+- Need topics/subscriptions (pub/sub)
+- Require sessions for ordered processing
+- Need transactional receive
+- Message size up to 1MB+
+- Duplicate detection is required
+- Need fine-grained routing (multiple subscriptions, filters, fan-out)
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
-[← Back to File Guide](FILE_GUIDE.md)
+[← Back to File Guide](FILE_GUIDE.md) | [↑ Back to top](#table-of-contents)

--- a/HoneyDrunk.Transport/docs/Testing.md
+++ b/HoneyDrunk.Transport/docs/Testing.md
@@ -4,74 +4,61 @@
 
 ---
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Testing Philosophy](#testing-philosophy)
+- [Unit Testing Patterns](#unit-testing-patterns)
+  - [Testing Message Handlers](#testing-message-handlers)
+  - [Testing Middleware](#testing-middleware)
+- [Integration Testing Patterns](#integration-testing-patterns)
+  - [Shared Test Fixture](#shared-test-fixture)
+  - [Pipeline-Level Tests](#pipeline-level-tests)
+  - [Runtime-Level Tests](#runtime-level-tests)
+  - [Grid Context Propagation](#grid-context-propagation)
+  - [Retry Behavior](#retry-behavior)
+- [Outbox Testing](#outbox-testing)
+- [Test Helpers](#test-helpers)
+  - [TestEnvelopeFactory](#testenvelopefactory)
+  - [TestGridContext](#testgridcontext)
+  - [FakeTimeProvider](#faketimeprovider)
+  - [TestMessageContext](#testmessagecontext)
+
+---
+
 ## Overview
 
 Testing patterns for Transport applications using InMemory transport, mocking strategies, and integration test patterns.
 
 **Location:** `HoneyDrunk.Transport.Tests/`
 
+**Key Concepts:**
+- **Unit tests** are pure and independent—no DI container, no runtime
+- **Integration tests** either drive `IMessagePipeline` directly or start `ITransportRuntime`
+- **Never mutate a built `ServiceProvider`**—rebuild for each test or use a shared fixture as read-only
+
 ---
 
-## Test Setup
+## Testing Philosophy
 
-### Basic Test Configuration
+Transport testing follows two distinct patterns:
 
-```csharp
-public class TransportTestFixture : IDisposable
-{
-    public ServiceProvider Services { get; }
-    public ITransportPublisher Publisher { get; }
-    public InMemoryBroker Broker { get; }
-    
-    public TransportTestFixture()
-    {
-        var services = new ServiceCollection();
-        
-        // Register Kernel
-        services.AddHoneyDrunkCoreNode(new NodeDescriptor
-        {
-            NodeId = "test-node",
-            Version = "1.0.0",
-            Name = "Test Node"
-        });
-        
-        // Register InMemory transport
-        services.AddHoneyDrunkTransportCore(options =>
-        {
-            options.EnableTelemetry = false;
-            options.EnableLogging = true;
-        })
-        .AddHoneyDrunkInMemoryTransport();
-        
-        // Register test handlers
-        services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
-        
-        Services = services.BuildServiceProvider();
-        Publisher = Services.GetRequiredService<ITransportPublisher>();
-        Broker = Services.GetRequiredService<InMemoryBroker>();
-    }
-    
-    public void Dispose()
-    {
-        Services?.Dispose();
-    }
-}
+| Pattern | When to Use | What's Involved |
+|---------|-------------|-----------------|
+| **Unit Tests** | Testing handlers, middleware, serializers in isolation | Mocks, no DI, `NoOpTransportTransaction.Instance` |
+| **Integration Tests** | Testing pipeline flow, Grid context propagation, retry behavior | Build `ServiceProvider` per test, or use shared fixture + `IMessagePipeline` / `ITransportRuntime` |
 
-// Use in tests
-public class OrderTests : IClassFixture<TransportTestFixture>
-{
-    private readonly TransportTestFixture _fixture;
-    
-    public OrderTests(TransportTestFixture fixture)
-    {
-        _fixture = fixture;
-    }
-}
-```
+> **Critical Rule:** You cannot add services to an already-built `ServiceProvider`. It's a one-way door. Either:
+> - Use a **shared fixture** as read-only (all wiring done in constructor)
+> - **Build a fresh provider** for each test that needs custom wiring
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## Unit Testing Patterns
+
+Unit tests should be **pure**—no DI container, no runtime, no Kernel registration required.
 
 ### Testing Message Handlers
 
@@ -81,16 +68,16 @@ public class OrderCreatedHandlerTests
     [Fact]
     public async Task HandleAsync_ValidMessage_ReturnsSuccess()
     {
-        // Arrange
+        // Arrange - pure unit test, no DI
         var repository = new Mock<IOrderRepository>();
         var handler = new OrderCreatedHandler(repository.Object);
         
         var message = new OrderCreated(OrderId: 123, CustomerId: 456);
         var context = new MessageContext
         {
-            Envelope = CreateTestEnvelope(message),
-            Transaction = new NoOpTransportTransaction(),
-            Properties = new Dictionary<string, object>()
+            Envelope = TestEnvelopeFactory.CreateEnvelope(message),
+            Transaction = NoOpTransportTransaction.Instance,  // Singleton
+            DeliveryCount = 1
         };
         
         // Act
@@ -112,7 +99,7 @@ public class OrderCreatedHandlerTests
         
         var handler = new OrderCreatedHandler(repository.Object);
         var message = new OrderCreated(123, 456);
-        var context = CreateTestContext(message);
+        var context = TestMessageContext.Create(message);
         
         // Act
         var result = await handler.HandleAsync(message, context, CancellationToken.None);
@@ -120,8 +107,29 @@ public class OrderCreatedHandlerTests
         // Assert
         Assert.Equal(MessageProcessingResult.Retry, result);
     }
+    
+    [Fact]
+    public async Task HandleAsync_ValidationFails_ReturnsDeadLetter()
+    {
+        // Arrange
+        var repository = new Mock<IOrderRepository>();
+        var handler = new OrderCreatedHandler(repository.Object);
+        var invalidMessage = new OrderCreated(OrderId: -1, CustomerId: 456);
+        var context = TestMessageContext.Create(invalidMessage);
+        
+        // Act
+        var result = await handler.HandleAsync(invalidMessage, context, CancellationToken.None);
+        
+        // Assert
+        Assert.Equal(MessageProcessingResult.DeadLetter, result);
+        repository.Verify(r => r.ProcessOrderAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }
 ```
+
+> **Note:** Unit tests don't need `IGridContext` or Kernel. The `MessageContext.GridContext` property is nullable and populated by middleware during pipeline execution.
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
@@ -138,15 +146,15 @@ public class ValidationMiddlewareTests
         validator.Setup(v => v.ValidateAsync(It.IsAny<object>())).ReturnsAsync(true);
         
         var middleware = new ValidationMiddleware(validator.Object);
-        var envelope = CreateTestEnvelope();
-        var context = CreateTestContext();
+        var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
+        var context = TestMessageContext.Create<OrderCreated>();
         var nextCalled = false;
         
         // Act
-        await middleware.InvokeAsync(envelope, context, () =>
+        await middleware.InvokeAsync(envelope, context, async () =>
         {
             nextCalled = true;
-            return Task.CompletedTask;
+            await Task.CompletedTask;
         }, CancellationToken.None);
         
         // Assert
@@ -154,247 +162,598 @@ public class ValidationMiddlewareTests
     }
     
     [Fact]
-    public async Task InvokeAsync_InvalidMessage_ThrowsException()
+    public async Task InvokeAsync_InvalidMessage_ThrowsWithoutCallingNext()
     {
         // Arrange
         var validator = new Mock<IValidator>();
         validator.Setup(v => v.ValidateAsync(It.IsAny<object>())).ReturnsAsync(false);
         
         var middleware = new ValidationMiddleware(validator.Object);
+        var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
+        var context = TestMessageContext.Create<OrderCreated>();
+        var nextCalled = false;
         
         // Act & Assert
         await Assert.ThrowsAsync<ValidationException>(async () =>
             await middleware.InvokeAsync(
-                CreateTestEnvelope(),
-                CreateTestContext(),
-                () => Task.CompletedTask,
+                envelope,
+                context,
+                async () => { nextCalled = true; await Task.CompletedTask; },
                 CancellationToken.None));
+        
+        Assert.False(nextCalled);
     }
 }
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
 ## Integration Testing Patterns
 
-### End-to-End Message Flow
+Integration tests validate that components work together through the Transport pipeline.
+
+### Shared Test Fixture
+
+A shared fixture provides a **ready-to-go** publisher, broker, and pipeline for integration tests. **Do not mutate it after construction.**
 
 ```csharp
-public class OrderIntegrationTests : IClassFixture<TransportTestFixture>
+public class TransportTestFixture : IAsyncLifetime
+{
+    public ServiceProvider Services { get; private set; } = null!;
+    public ITransportPublisher Publisher { get; private set; } = null!;
+    public IMessagePipeline Pipeline { get; private set; } = null!;
+    public InMemoryBroker Broker { get; private set; } = null!;
+    public EnvelopeFactory EnvelopeFactory { get; private set; } = null!;
+    public IMessageSerializer Serializer { get; private set; } = null!;
+    
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+        
+        // Register Kernel
+        services.AddHoneyDrunkCoreNode(new NodeDescriptor
+        {
+            NodeId = "test-node",
+            Version = "1.0.0",
+            Name = "Test Node"
+        });
+        
+        // Register InMemory transport
+        services.AddHoneyDrunkTransportCore(options =>
+        {
+            options.EnableTelemetry = false;
+            options.EnableLogging = true;
+            options.EnableCorrelation = true;
+        })
+        .AddHoneyDrunkInMemoryTransport();
+        
+        // Register handlers that are shared across all tests
+        services.AddMessageHandler<OrderCreated, OrderCreatedHandler>();
+        services.AddMessageHandler<OrderUpdated, OrderUpdatedHandler>();
+        
+        Services = services.BuildServiceProvider();
+        Publisher = Services.GetRequiredService<ITransportPublisher>();
+        Pipeline = Services.GetRequiredService<IMessagePipeline>();
+        Broker = Services.GetRequiredService<InMemoryBroker>();
+        EnvelopeFactory = Services.GetRequiredService<EnvelopeFactory>();
+        Serializer = Services.GetRequiredService<IMessageSerializer>();
+    }
+    
+    public async Task DisposeAsync()
+    {
+        await Services.DisposeAsync();
+    }
+}
+
+// Use in tests - fixture is READ-ONLY
+public class OrderTests : IClassFixture<TransportTestFixture>
 {
     private readonly TransportTestFixture _fixture;
     
-    [Fact]
-    public async Task PublishAndConsume_OrderCreated_ProcessesSuccessfully()
+    public OrderTests(TransportTestFixture fixture)
     {
-        // Arrange
-        var processed = new TaskCompletionSource<bool>();
-        
-        _fixture.Broker.Subscribe("orders", async (envelope, ct) =>
-        {
-            processed.SetResult(true);
-            await Task.CompletedTask;
-        });
-        
-        var message = new OrderCreated(123, 456);
-        var envelope = CreateEnvelope(message);
-        
-        // Act
-        await _fixture.Publisher.PublishAsync(
-            envelope,
-            new EndpointAddress("orders"),
-            CancellationToken.None);
-        
-        // Assert
-        var result = await processed.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(result);
+        _fixture = fixture;
     }
 }
 ```
 
+> **Key Point:** The fixture is built once and shared. If a test needs custom handler wiring, it should build its own `ServiceProvider`.
+
+[↑ Back to top](#table-of-contents)
+
 ---
 
-### Testing Grid Context Propagation
+### Pipeline-Level Tests
+
+For testing message processing through the full pipeline (middleware → handler), call `IMessagePipeline.ProcessAsync()` directly.
 
 ```csharp
-[Fact]
-public async Task GridContext_FlowsAcrossNodes()
+public class PipelineIntegrationTests : IClassFixture<TransportTestFixture>
 {
-    // Arrange
-    var gridContext = new TestGridContext
+    private readonly TransportTestFixture _fixture;
+    
+    public PipelineIntegrationTests(TransportTestFixture fixture)
     {
-        CorrelationId = "test-correlation",
-        NodeId = "node-a",
-        StudioId = "test-studio"
-    };
+        _fixture = fixture;
+    }
     
-    IGridContext? receivedContext = null;
-    
-    _fixture.Services.AddMessageHandler<OrderCreated>((msg, ctx, ct) =>
+    [Fact]
+    public async Task ProcessAsync_ValidMessage_InvokesHandlerAndReturnsSuccess()
     {
-        receivedContext = ctx.GridContext;
-        return Task.FromResult(MessageProcessingResult.Success);
-    });
-    
-    // Act
-    var message = new OrderCreated(123, 456);
-    var envelope = _fixture.Factory.CreateEnvelopeWithGridContext<OrderCreated>(
-        _serializer.Serialize(message),
-        gridContext);
-    
-    await _fixture.Publisher.PublishAsync(envelope, destination, ct);
-    await Task.Delay(100);
-    
-    // Assert
-    Assert.NotNull(receivedContext);
-    Assert.Equal("test-correlation", receivedContext.CorrelationId);
-    Assert.Equal("test-studio", receivedContext.StudioId);
+        // Arrange
+        var message = new OrderCreated(123, 456);
+        var payload = _fixture.Serializer.Serialize(message);
+        var envelope = _fixture.EnvelopeFactory.CreateEnvelope<OrderCreated>(payload);
+        
+        var context = new MessageContext
+        {
+            Envelope = envelope,
+            Transaction = NoOpTransportTransaction.Instance,
+            DeliveryCount = 1
+        };
+        
+        // Act - drive pipeline directly
+        var result = await _fixture.Pipeline.ProcessAsync(envelope, context, CancellationToken.None);
+        
+        // Assert
+        Assert.Equal(MessageProcessingResult.Success, result);
+    }
 }
 ```
 
+[↑ Back to top](#table-of-contents)
+
 ---
 
-### Testing Retry Behavior
+### Runtime-Level Tests
+
+For true end-to-end tests with consumers running, start `ITransportRuntime`. This is useful for testing the full flow from publish → broker → consumer → pipeline → handler.
+
+```csharp
+public class RuntimeIntegrationTests
+{
+    [Fact]
+    public async Task Publish_OrderCreated_InvokesHandlerThroughRuntime()
+    {
+        // Arrange - build a fresh provider for this test
+        var handlerInvoked = new TaskCompletionSource<OrderCreated>();
+        
+        var services = new ServiceCollection();
+        services.AddHoneyDrunkCoreNode(new NodeDescriptor
+        {
+            NodeId = "test-node",
+            Version = "1.0.0"
+        });
+        
+        services.AddHoneyDrunkTransportCore(options =>
+        {
+            options.EnableCorrelation = true;
+        })
+        .AddHoneyDrunkInMemoryTransport();
+        
+        // Register handler that signals completion
+        services.AddMessageHandler<OrderCreated>(async (msg, ctx, ct) =>
+        {
+            handlerInvoked.SetResult(msg);
+            return MessageProcessingResult.Success;
+        });
+        
+        await using var provider = services.BuildServiceProvider();
+        
+        var runtime = provider.GetRequiredService<ITransportRuntime>();
+        var publisher = provider.GetRequiredService<ITransportPublisher>();
+        var factory = provider.GetRequiredService<EnvelopeFactory>();
+        var serializer = provider.GetRequiredService<IMessageSerializer>();
+        
+        // Act - start runtime so consumers are active
+        await runtime.StartAsync(CancellationToken.None);
+        
+        try
+        {
+            var message = new OrderCreated(123, 456);
+            var payload = serializer.Serialize(message);
+            var envelope = factory.CreateEnvelope<OrderCreated>(payload);
+            
+            await publisher.PublishAsync(
+                envelope,
+                EndpointAddress.Create("orders", "orders"),
+                CancellationToken.None);
+            
+            // Assert - wait for handler to be invoked
+            var receivedMessage = await handlerInvoked.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(123, receivedMessage.OrderId);
+            Assert.Equal(456, receivedMessage.CustomerId);
+        }
+        finally
+        {
+            await runtime.StopAsync(CancellationToken.None);
+        }
+    }
+}
+```
+
+> **Note:** Runtime tests are slower but test the complete flow including `InMemoryTransportConsumer` picking up messages from `InMemoryBroker`.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+### Grid Context Propagation
+
+Test that `GridContextPropagationMiddleware` correctly populates `MessageContext.GridContext` from envelope metadata.
 
 ```csharp
 [Fact]
-public async Task RetryMiddleware_TransientError_RetriesWithBackoff()
+public async Task GridContext_PropagatesThroughPipeline()
+{
+    // Arrange - build fresh provider for custom handler
+    IGridContext? receivedContext = null;
+    
+    var services = new ServiceCollection();
+    services.AddHoneyDrunkCoreNode(new NodeDescriptor
+    {
+        NodeId = "test-node",
+        Version = "1.0.0"
+    });
+    
+    services.AddHoneyDrunkTransportCore(options =>
+    {
+        options.EnableCorrelation = true;
+    })
+    .AddHoneyDrunkInMemoryTransport();
+    
+    services.AddMessageHandler<OrderCreated>(async (msg, ctx, ct) =>
+    {
+        receivedContext = ctx.GridContext;
+        return MessageProcessingResult.Success;
+    });
+    
+    await using var provider = services.BuildServiceProvider();
+    
+    var pipeline = provider.GetRequiredService<IMessagePipeline>();
+    var factory = provider.GetRequiredService<EnvelopeFactory>();
+    var serializer = provider.GetRequiredService<IMessageSerializer>();
+    
+    // Create envelope with Grid context
+    var gridContext = new TestGridContext
+    {
+        CorrelationId = "test-correlation-123",
+        StudioId = "test-studio",
+        NodeId = "source-node",
+        TenantId = "tenant-abc",
+        ProjectId = "project-xyz"
+    };
+    
+    var payload = serializer.Serialize(new OrderCreated(123, 456));
+    var envelope = factory.CreateEnvelopeWithGridContext<OrderCreated>(payload, gridContext);
+    
+    var context = new MessageContext
+    {
+        Envelope = envelope,
+        Transaction = NoOpTransportTransaction.Instance,
+        DeliveryCount = 1
+    };
+    
+    // Act - process through pipeline
+    var result = await pipeline.ProcessAsync(envelope, context, CancellationToken.None);
+    
+    // Assert
+    Assert.Equal(MessageProcessingResult.Success, result);
+    Assert.NotNull(receivedContext);
+    Assert.Equal("test-correlation-123", receivedContext!.CorrelationId);
+    Assert.Equal("test-studio", receivedContext.StudioId);
+    Assert.Equal("tenant-abc", receivedContext.TenantId);
+    Assert.Equal("project-xyz", receivedContext.ProjectId);
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+### Retry Behavior
+
+Test retry logic by driving the pipeline directly and counting handler invocations. Use `FakeTimeProvider` to control time for backoff assertions.
+
+```csharp
+[Fact]
+public async Task RetryMiddleware_TransientError_RetriesUpToMaxAttempts()
 {
     // Arrange
     var attemptCount = 0;
-    var attemptTimes = new List<DateTimeOffset>();
     
-    _fixture.Services.AddMessageHandler<OrderCreated>((msg, ctx, ct) =>
+    var services = new ServiceCollection();
+    services.AddHoneyDrunkCoreNode(new NodeDescriptor { NodeId = "test" });
+    
+    services.AddHoneyDrunkTransportCore()
+        .AddHoneyDrunkInMemoryTransport()
+        .WithRetry(retry =>
+        {
+            retry.MaxAttempts = 3;
+            retry.BackoffStrategy = BackoffStrategy.Fixed;
+            retry.InitialDelay = TimeSpan.Zero;  // No delay for fast tests
+        });
+    
+    services.AddMessageHandler<OrderCreated>(async (msg, ctx, ct) =>
     {
         attemptCount++;
-        attemptTimes.Add(DateTimeOffset.UtcNow);
-        
         if (attemptCount < 3)
-            return Task.FromResult(MessageProcessingResult.Retry);
-        
-        return Task.FromResult(MessageProcessingResult.Success);
+            return MessageProcessingResult.Retry;
+        return MessageProcessingResult.Success;
     });
     
+    await using var provider = services.BuildServiceProvider();
+    var pipeline = provider.GetRequiredService<IMessagePipeline>();
+    var factory = provider.GetRequiredService<EnvelopeFactory>();
+    var serializer = provider.GetRequiredService<IMessageSerializer>();
+    
+    var payload = serializer.Serialize(new OrderCreated(123, 456));
+    var envelope = factory.CreateEnvelope<OrderCreated>(payload);
+    var context = new MessageContext
+    {
+        Envelope = envelope,
+        Transaction = NoOpTransportTransaction.Instance,
+        DeliveryCount = 1
+    };
+    
     // Act
-    await _fixture.Publisher.PublishAsync(envelope, destination, ct);
-    await Task.Delay(5000); // Allow retries
+    var result = await pipeline.ProcessAsync(envelope, context, CancellationToken.None);
     
     // Assert
     Assert.Equal(3, attemptCount);
+    Assert.Equal(MessageProcessingResult.Success, result);
+}
+
+[Fact]
+public async Task RetryMiddleware_ExceedsMaxAttempts_ReturnsDeadLetter()
+{
+    // Arrange
+    var attemptCount = 0;
     
-    // Verify exponential backoff
-    var delay1 = attemptTimes[1] - attemptTimes[0];
-    var delay2 = attemptTimes[2] - attemptTimes[1];
-    Assert.True(delay2 > delay1, "Second retry should have longer delay");
+    var services = new ServiceCollection();
+    services.AddHoneyDrunkCoreNode(new NodeDescriptor { NodeId = "test" });
+    
+    services.AddHoneyDrunkTransportCore()
+        .AddHoneyDrunkInMemoryTransport()
+        .WithRetry(retry =>
+        {
+            retry.MaxAttempts = 3;
+            retry.InitialDelay = TimeSpan.Zero;
+        });
+    
+    services.AddMessageHandler<OrderCreated>(async (msg, ctx, ct) =>
+    {
+        attemptCount++;
+        return MessageProcessingResult.Retry;  // Always retry
+    });
+    
+    await using var provider = services.BuildServiceProvider();
+    var pipeline = provider.GetRequiredService<IMessagePipeline>();
+    var factory = provider.GetRequiredService<EnvelopeFactory>();
+    var serializer = provider.GetRequiredService<IMessageSerializer>();
+    
+    var payload = serializer.Serialize(new OrderCreated(123, 456));
+    var envelope = factory.CreateEnvelope<OrderCreated>(payload);
+    var context = new MessageContext
+    {
+        Envelope = envelope,
+        Transaction = NoOpTransportTransaction.Instance,
+        DeliveryCount = 1
+    };
+    
+    // Act
+    var result = await pipeline.ProcessAsync(envelope, context, CancellationToken.None);
+    
+    // Assert
+    Assert.Equal(3, attemptCount);
+    Assert.Equal(MessageProcessingResult.DeadLetter, result);
 }
 ```
 
+> **Tip:** For testing actual backoff timing, use `FakeTimeProvider` and inject it into the retry middleware. Avoid wall-clock timing assertions in tests.
+
+[↑ Back to top](#table-of-contents)
+
 ---
 
-### Testing Outbox Pattern
+## Outbox Testing
+
+Test outbox behavior by verifying transaction semantics and dispatch logic.
 
 ```csharp
 public class OutboxIntegrationTests
 {
     [Fact]
-    public async Task Outbox_TransactionRollback_MessageNotDispatched()
+    public async Task Outbox_TransactionRollback_MessageNotPersisted()
     {
         // Arrange
         using var db = CreateTestDatabase();
         var outbox = new EfCoreOutboxStore(db);
         
+        var message = new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            Destination = EndpointAddress.Create("orders", "orders"),
+            Envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456)),
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        
         // Act - Rollback transaction
         using (var transaction = await db.Database.BeginTransactionAsync())
         {
-            await outbox.SaveAsync(CreateTestMessage(), ct);
+            await outbox.SaveAsync(message.Destination, message.Envelope, CancellationToken.None);
             await transaction.RollbackAsync();
         }
         
         // Assert - Message not in outbox
-        var pending = await outbox.LoadPendingAsync(10, ct);
+        var pending = await outbox.LoadPendingAsync(10, CancellationToken.None);
         Assert.Empty(pending);
     }
     
     [Fact]
-    public async Task Outbox_TransactionCommit_MessageDispatched()
+    public async Task Outbox_TransactionCommit_MessagePersisted()
+    {
+        // Arrange
+        using var db = CreateTestDatabase();
+        var outbox = new EfCoreOutboxStore(db);
+        
+        var destination = EndpointAddress.Create("orders", "orders");
+        var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
+        
+        // Act - Commit transaction
+        using (var transaction = await db.Database.BeginTransactionAsync())
+        {
+            await outbox.SaveAsync(destination, envelope, CancellationToken.None);
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        
+        // Assert - Message in outbox
+        var pending = await outbox.LoadPendingAsync(10, CancellationToken.None);
+        Assert.Single(pending);
+        Assert.Equal("orders", pending[0].Destination.Name);
+    }
+    
+    [Fact]
+    public async Task OutboxDispatcher_DispatchesPendingMessages()
     {
         // Arrange
         using var db = CreateTestDatabase();
         var outbox = new EfCoreOutboxStore(db);
         var publisher = new Mock<ITransportPublisher>();
-        var dispatcher = new OutboxDispatcherService(outbox, publisher.Object, logger);
-        
-        // Act - Commit transaction
-        using (var transaction = await db.Database.BeginTransactionAsync())
+        var logger = NullLogger<DefaultOutboxDispatcher>.Instance;
+        var options = Options.Create(new OutboxDispatcherOptions
         {
-            await outbox.SaveAsync(CreateTestMessage(), ct);
-            await db.SaveChangesAsync();
-            await transaction.CommitAsync();
-        }
+            BatchSize = 10,
+            DispatchInterval = TimeSpan.FromSeconds(1)
+        });
         
-        // Dispatch
-        await dispatcher.DispatchPendingAsync(ct);
+        // Create dispatcher directly (not as hosted service)
+        var dispatcher = new DefaultOutboxDispatcher(outbox, publisher.Object, options, logger);
+        
+        // Save a message
+        var destination = EndpointAddress.Create("orders", "orders");
+        var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
+        await outbox.SaveAsync(destination, envelope, CancellationToken.None);
+        await db.SaveChangesAsync();
+        
+        // Act - dispatch pending
+        await dispatcher.DispatchPendingAsync(CancellationToken.None);
         
         // Assert
         publisher.Verify(p => p.PublishAsync(
             It.IsAny<ITransportEnvelope>(),
-            It.IsAny<IEndpointAddress>(),
+            It.Is<IEndpointAddress>(d => d.Name == "orders"),
+            It.IsAny<PublishOptions?>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }
 ```
 
+> **Note:** `DefaultOutboxDispatcher` exposes `DispatchPendingAsync()` for testing. In production it runs as a `BackgroundService` via `ExecuteAsync()`.
+
+[↑ Back to top](#table-of-contents)
+
 ---
 
 ## Test Helpers
 
-### Envelope Creation
+Reusable helpers for Transport tests.
+
+### TestEnvelopeFactory
+
+Creates envelopes for unit tests without requiring a DI container.
 
 ```csharp
 public static class TestEnvelopeFactory
 {
-    public static ITransportEnvelope CreateEnvelope<TMessage>(
-        TMessage message,
-        IGridContext? gridContext = null)
+    private static readonly IMessageSerializer Serializer = new JsonMessageSerializer();
+    private static readonly EnvelopeFactory Factory = new(TimeProvider.System);
+    
+    /// <summary>
+    /// Creates an envelope for unit tests. For integration tests, prefer
+    /// resolving EnvelopeFactory and IMessageSerializer from DI.
+    /// </summary>
+    public static ITransportEnvelope CreateEnvelope<TMessage>(TMessage message)
         where TMessage : class
     {
-        var serializer = new JsonMessageSerializer();
-        var payload = serializer.Serialize(message);
-        var factory = new EnvelopeFactory(TimeProvider.System);
-        
-        return gridContext != null
-            ? factory.CreateEnvelopeWithGridContext<TMessage>(payload, gridContext)
-            : factory.CreateEnvelope<TMessage>(payload);
+        var payload = Serializer.Serialize(message);
+        return Factory.CreateEnvelope<TMessage>(payload);
+    }
+    
+    public static ITransportEnvelope CreateEnvelopeWithGridContext<TMessage>(
+        TMessage message,
+        IGridContext gridContext)
+        where TMessage : class
+    {
+        var payload = Serializer.Serialize(message);
+        return Factory.CreateEnvelopeWithGridContext<TMessage>(payload, gridContext);
+    }
+    
+    public static ITransportEnvelope CreateEnvelopeWithTimestamp<TMessage>(
+        TMessage message,
+        DateTimeOffset timestamp)
+        where TMessage : class
+    {
+        var timeProvider = new FakeTimeProvider(timestamp);
+        var factory = new EnvelopeFactory(timeProvider);
+        var payload = Serializer.Serialize(message);
+        return factory.CreateEnvelope<TMessage>(payload);
     }
 }
 ```
 
+> **Integration Tests:** For integration tests, prefer resolving `IMessageSerializer` and `EnvelopeFactory` from DI to match production wiring.
+
+[↑ Back to top](#table-of-contents)
+
 ---
 
-### Mock Grid Context
+### TestGridContext
+
+Minimal `IGridContext` implementation for tests.
 
 ```csharp
+/// <summary>
+/// Minimal IGridContext fake for tests. CreateChildContext and WithBaggage
+/// return `this` for simplicity - not representative of production behavior.
+/// </summary>
 public class TestGridContext : IGridContext
 {
     public string CorrelationId { get; set; } = "test-correlation";
     public string? CausationId { get; set; }
     public string NodeId { get; set; } = "test-node";
     public string StudioId { get; set; } = "test-studio";
+    public string? TenantId { get; set; }
+    public string? ProjectId { get; set; }
     public string Environment { get; set; } = "test";
     public IReadOnlyDictionary<string, string> Baggage { get; set; } 
         = new Dictionary<string, string>();
-    public CancellationToken Cancellation { get; set; }
+    public CancellationToken Cancellation { get; set; } = CancellationToken.None;
     public DateTimeOffset CreatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
     
     public IDisposable BeginScope() => new NoOpScope();
+    
+    // Simplified for tests - production creates actual child contexts
     public IGridContext CreateChildContext(string? nodeId = null) => this;
     public IGridContext WithBaggage(string key, string value) => this;
+    
+    private sealed class NoOpScope : IDisposable
+    {
+        public void Dispose() { }
+    }
 }
 ```
 
+[↑ Back to top](#table-of-contents)
+
 ---
 
-### Time Provider Fakes
+### FakeTimeProvider
+
+Controllable `TimeProvider` for deterministic timestamp and backoff testing.
 
 ```csharp
 public class FakeTimeProvider : TimeProvider
@@ -412,20 +771,92 @@ public class FakeTimeProvider : TimeProvider
     {
         _current = _current.Add(duration);
     }
+    
+    public void SetTime(DateTimeOffset time)
+    {
+        _current = time;
+    }
 }
 
-// Usage
-var timeProvider = new FakeTimeProvider(new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero));
-var factory = new EnvelopeFactory(timeProvider);
-
-var envelope1 = factory.CreateEnvelope<OrderCreated>(payload);
-Assert.Equal(new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero), envelope1.Timestamp);
-
-timeProvider.Advance(TimeSpan.FromHours(1));
-var envelope2 = factory.CreateEnvelope<OrderCreated>(payload);
-Assert.Equal(new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero), envelope2.Timestamp);
+// Usage with EnvelopeFactory
+[Fact]
+public void EnvelopeFactory_UsesFakeTimeProvider()
+{
+    var timeProvider = new FakeTimeProvider(
+        new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero));
+    var factory = new EnvelopeFactory(timeProvider);
+    var serializer = new JsonMessageSerializer();
+    
+    var payload = serializer.Serialize(new OrderCreated(123, 456));
+    var envelope1 = factory.CreateEnvelope<OrderCreated>(payload);
+    
+    Assert.Equal(
+        new DateTimeOffset(2025, 1, 15, 10, 0, 0, TimeSpan.Zero),
+        envelope1.Timestamp);
+    
+    timeProvider.Advance(TimeSpan.FromHours(1));
+    var envelope2 = factory.CreateEnvelope<OrderCreated>(payload);
+    
+    Assert.Equal(
+        new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero),
+        envelope2.Timestamp);
+}
 ```
+
+[↑ Back to top](#table-of-contents)
 
 ---
 
-[← Back to File Guide](FILE_GUIDE.md)
+### TestMessageContext
+
+Factory for creating `MessageContext` in tests.
+
+```csharp
+public static class TestMessageContext
+{
+    public static MessageContext Create<TMessage>(TMessage? message = null)
+        where TMessage : class, new()
+    {
+        var actualMessage = message ?? new TMessage();
+        return new MessageContext
+        {
+            Envelope = TestEnvelopeFactory.CreateEnvelope(actualMessage),
+            Transaction = NoOpTransportTransaction.Instance,
+            DeliveryCount = 1
+        };
+    }
+    
+    public static MessageContext CreateWithGridContext<TMessage>(
+        TMessage message,
+        IGridContext gridContext)
+        where TMessage : class
+    {
+        return new MessageContext
+        {
+            Envelope = TestEnvelopeFactory.CreateEnvelopeWithGridContext(message, gridContext),
+            Transaction = NoOpTransportTransaction.Instance,
+            GridContext = gridContext,
+            DeliveryCount = 1
+        };
+    }
+    
+    public static MessageContext CreateWithDeliveryCount<TMessage>(
+        TMessage message,
+        int deliveryCount)
+        where TMessage : class
+    {
+        return new MessageContext
+        {
+            Envelope = TestEnvelopeFactory.CreateEnvelope(message),
+            Transaction = NoOpTransportTransaction.Instance,
+            DeliveryCount = deliveryCount
+        };
+    }
+}
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Back to File Guide](FILE_GUIDE.md) | [↑ Back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 
 HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive"). It provides a transport-agnostic abstraction layer over different message brokers with built-in resilience, observability, and exactly-once semantics:
 
-- ✅ **Transport Abstraction** - Unified interface for Azure Service Bus, RabbitMQ, Kafka, in-memory, and more
-- ✅ **Middleware Pipeline** - Onion-style processing with correlation, telemetry, logging, and retry
-- ✅ **Envelope Pattern** - Immutable message wrapping with correlation/causation tracking
+- ✅ **Transport Abstraction** - Unified `ITransportPublisher` and `ITransportConsumer` over Azure Service Bus, Azure Storage Queue, and InMemory
+- ✅ **Middleware Pipeline** - Onion-style processing with logging, telemetry, correlation, and retry
+- ✅ **Envelope Pattern** - Immutable `ITransportEnvelope` with correlation/causation tracking
 - ✅ **Transactional Outbox** - Exactly-once processing with database transactions
-- ✅ **Kernel Integration** - Uses `IClock`, `IIdGenerator`, `IKernelContext` for deterministic, testable messaging
-- ✅ **Framework Integration** - Extends Microsoft.Extensions, integrates seamlessly with ASP.NET Core
+- ✅ **Kernel Integration** - Uses `TimeProvider` and `IGridContext` from HoneyDrunk.Kernel for deterministic timestamps and distributed context
+- ✅ **Observability** - OpenTelemetry spans and pluggable `ITransportMetrics`
 - ✅ **Blob Fallback for Service Bus** - Persist failed publishes to Azure Blob Storage for later replay
 
 ---
@@ -29,28 +29,25 @@ HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive")
 
 ```xml
 <ItemGroup>
-  <!-- Core Transport -->
   <PackageReference Include="HoneyDrunk.Transport" Version="0.1.0" />
-  
-  <!-- Azure Service Bus Provider -->
   <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.1.0" />
-  
-  <!-- Azure Storage Queue Provider -->
   <PackageReference Include="HoneyDrunk.Transport.StorageQueue" Version="0.1.0" />
-  
-  <!-- In-Memory Provider (for testing) -->
   <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.1.0" />
 </ItemGroup>
 ```
 
-### Register Transport Services
+### Configure in Program.cs
 
 ```csharp
+using HoneyDrunk.Kernel.DependencyInjection;
 using HoneyDrunk.Transport.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Register Transport core (includes Kernel defaults)
+// 1. Register Kernel node
+builder.Services.AddHoneyDrunkCoreNode(nodeDescriptor);
+
+// 2. Register Transport core
 builder.Services.AddHoneyDrunkTransportCore(options =>
 {
     options.EnableTelemetry = true;
@@ -58,33 +55,137 @@ builder.Services.AddHoneyDrunkTransportCore(options =>
     options.EnableCorrelation = true;
 });
 
-// Option 1: Add Azure Service Bus transport
+// 3. Choose a transport
+
+// Azure Service Bus
 builder.Services.AddHoneyDrunkServiceBusTransport(options =>
 {
     options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
-    options.EntityType = ServiceBusEntityType.Queue;
-    options.Address = "my-queue";
-    options.AutoComplete = true;
+    options.Address = "orders";
+    options.EntityType = ServiceBusEntityType.Topic;
+    options.SubscriptionName = "order-processor";
+    options.MaxConcurrency = 10;
+    options.PrefetchCount = 20;
 
-    // Optional: enable Blob fallback for publish failures
-    // options.BlobFallback.Enabled = true;
-    // options.BlobFallback.ConnectionString = builder.Configuration["Blob:ConnectionString"];
-    // options.BlobFallback.ContainerName = "transport-fallback";
-    // options.BlobPrefix = "servicebus";
+    options.ServiceBusRetry.Mode = ServiceBusRetryMode.Exponential;
+    options.ServiceBusRetry.MaxRetries = 3;
 });
 
-// Option 2: Add Azure Storage Queue transport
-builder.Services.AddHoneyDrunkTransportStorageQueue(
-    connectionString: builder.Configuration["StorageQueue:ConnectionString"]!,
-    queueName: "orders")
+// OR Azure Storage Queue
+builder.Services
+    .AddHoneyDrunkTransportStorageQueue(
+        builder.Configuration["StorageQueue:ConnectionString"]!,
+        "orders")
     .WithMaxDequeueCount(5)
     .WithConcurrency(10);
 
-// Register message handlers
+// 4. Register message handlers
 builder.Services.AddMessageHandler<OrderCreatedEvent, OrderCreatedHandler>();
 
 var app = builder.Build();
 app.Run();
+```
+
+---
+
+## 📖 Usage Examples
+
+### Publishing Messages
+
+```csharp
+public class OrderService(
+    ITransportPublisher publisher,
+    EnvelopeFactory envelopeFactory,
+    IMessageSerializer serializer,
+    IGridContext gridContext)
+{
+    public async Task CreateOrderAsync(CreateOrderCommand command, CancellationToken ct)
+    {
+        // Create order...
+        
+        // Publish event
+        var @event = new OrderCreatedEvent { OrderId = orderId, Total = total };
+        var payload = serializer.Serialize(@event);
+        var envelope = envelopeFactory.CreateEnvelopeWithGridContext<OrderCreatedEvent>(
+            payload, gridContext);
+        
+        await publisher.PublishAsync(
+            envelope,
+            EndpointAddress.Create("orders", "orders-topic"),
+            ct);
+    }
+}
+```
+
+### Handling Messages
+
+```csharp
+public class OrderCreatedHandler : IMessageHandler<OrderCreatedEvent>
+{
+    private readonly ILogger<OrderCreatedHandler> _logger;
+    
+    public OrderCreatedHandler(ILogger<OrderCreatedHandler> logger)
+    {
+        _logger = logger;
+    }
+    
+    public async Task<MessageProcessingResult> HandleAsync(
+        OrderCreatedEvent message,
+        MessageContext context,
+        CancellationToken cancellationToken)
+    {
+        var grid = context.GridContext;
+        
+        _logger.LogInformation(
+            "Processing order {OrderId} with CorrelationId {CorrelationId} on Node {NodeId}",
+            message.OrderId,
+            grid?.CorrelationId,
+            grid?.NodeId);
+        
+        await SendConfirmationEmailAsync(message.OrderId, cancellationToken);
+        return MessageProcessingResult.Success;
+    }
+}
+```
+
+### Transactional Outbox
+
+```csharp
+public class OrderService(
+    IOutboxStore outboxStore,
+    EnvelopeFactory factory,
+    IMessageSerializer serializer,
+    IDbContext dbContext)
+{
+    public async Task CreateOrderAsync(CreateOrderCommand command, CancellationToken ct)
+    {
+        await using var transaction = await dbContext.BeginTransactionAsync(ct);
+        
+        try
+        {
+            // Save order to database
+            var order = new Order { /* ... */ };
+            await dbContext.Orders.AddAsync(order, ct);
+            
+            // Save message to outbox (same transaction)
+            var payload = serializer.Serialize(new OrderCreatedEvent { OrderId = order.Id });
+            var envelope = factory.CreateEnvelope<OrderCreatedEvent>(payload);
+            var destination = EndpointAddress.Create("orders", "orders-topic");
+            
+            await outboxStore.SaveAsync(destination, envelope, ct);
+            
+            await dbContext.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+            
+            // DefaultOutboxDispatcher publishes from outbox in background
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+    }
+}
 ```
 
 ---
@@ -98,9 +199,9 @@ app.Run();
 | **Transport Abstraction** | Unified publisher/consumer interface | `ITransportPublisher`, `ITransportConsumer` |
 | **Message Pipeline** | Middleware execution engine | `IMessagePipeline`, `IMessageMiddleware` |
 | **Envelope System** | Immutable message wrapping | `ITransportEnvelope`, `EnvelopeFactory` |
-| **Kernel Context** | Correlation/causation tracking | `IKernelContextFactory`, `KernelContext` |
+| **Grid Context** | Correlation/causation tracking | `IGridContext`, `IGridContextFactory` |
 | **Serialization** | Pluggable message serialization | `IMessageSerializer`, `JsonMessageSerializer` |
-| **Outbox Pattern** | Transactional outbox support | `IOutboxStore`, `IOutboxDispatcher` |
+| **Outbox Pattern** | Transactional outbox support | `IOutboxStore`, `DefaultOutboxDispatcher` |
 
 ### 🔗 Kernel Integration
 
@@ -108,11 +209,11 @@ HoneyDrunk.Transport **extends** HoneyDrunk.Kernel with messaging primitives:
 
 | Kernel Service | How Transport Uses It |
 |----------------|----------------------|
-| `IIdGenerator` | Message ID generation (ULID) |
-| `IClock` | Deterministic message timestamps |
-| `IKernelContext` | Correlation/causation propagation |
-| `IMetricsCollector` | Message processing metrics |
-| `ILogger<T>` | Structured logging throughout |
+| `TimeProvider` | Deterministic message timestamps via `EnvelopeFactory` |
+| `IGridContext` | Correlation, causation, Node/Studio/Tenant propagation |
+| `IGridContextFactory` | Creates Grid context for outbound messages |
+| `ILogger<T>` | Structured logging throughout pipeline |
+| `IMeterFactory` | OpenTelemetry metrics via `ITransportMetrics` |
 
 ### 🚀 Available Transports
 
@@ -126,446 +227,99 @@ HoneyDrunk.Transport **extends** HoneyDrunk.Kernel with messaging primitives:
 
 ---
 
-## 📖 Usage Examples
+## 🧪 Testing
 
-### Publishing Messages
-
-```csharp
-using HoneyDrunk.Transport.Abstractions;
-using HoneyDrunk.Transport.Primitives;
-
-public class OrderService(
-    ITransportPublisher publisher,
-    EnvelopeFactory envelopeFactory,
-    IMessageSerializer serializer)
-{
-    public async Task CreateOrderAsync(CreateOrderCommand command)
-    {
-        // Create order...
-        
-        // Publish event
-        var @event = new OrderCreatedEvent { OrderId = orderId, Total = total };
-        var payload = serializer.Serialize(@event);
-        var envelope = envelopeFactory.CreateEnvelope<OrderCreatedEvent>(
-            payload,
-            correlationId: command.CorrelationId);
-        
-        await publisher.PublishAsync(
-            envelope,
-            new EndpointAddress("orders-topic"),
-            cancellationToken);
-    }
-}
-```
-
-### Handling Messages
+Use InMemory transport and DI for tests:
 
 ```csharp
-using HoneyDrunk.Transport.Abstractions;
+var services = new ServiceCollection();
+services.AddHoneyDrunkCoreNode(TestNodeDescriptor);
+services.AddHoneyDrunkTransportCore()
+    .AddHoneyDrunkInMemoryTransport();
 
-public class OrderCreatedHandler : IMessageHandler<OrderCreatedEvent>
+services.AddMessageHandler<OrderCreatedEvent>((msg, ctx, ct) =>
 {
-    private readonly ILogger<OrderCreatedHandler> _logger;
-    
-    public OrderCreatedHandler(ILogger<OrderCreatedHandler> logger)
-    {
-        _logger = logger;
-    }
-    
-    public async Task HandleAsync(
-        OrderCreatedEvent message,
-        MessageContext context,
-        CancellationToken cancellationToken)
-    {
-        // Access kernel context for correlation tracking
-        if (context.Properties.TryGetValue("KernelContext", out var ctxObj)
-            && ctxObj is IKernelContext kernelContext)
-        {
-            _logger.LogInformation(
-                "Processing order {OrderId} with CorrelationId {CorrelationId}",
-                message.OrderId,
-                kernelContext.CorrelationId);
-        }
-        
-        // Process the event
-        await SendConfirmationEmailAsync(message.OrderId, cancellationToken);
-    }
-}
-```
-
-### Custom Middleware
-
-```csharp
-using HoneyDrunk.Transport.Pipeline;
-
-public class ValidationMiddleware : IMessageMiddleware
-{
-    public async Task InvokeAsync(
-        ITransportEnvelope envelope,
-        MessageContext context,
-        Func<Task> next,
-        CancellationToken cancellationToken)
-    {
-        // Validate envelope
-        if (string.IsNullOrEmpty(envelope.MessageType))
-        {
-            throw new MessageHandlerException(
-                "MessageType is required",
-                MessageProcessingResult.DeadLetter);
-        }
-        
-        // Continue pipeline
-        await next();
-    }
-}
-
-// Register in DI
-services.AddMessageMiddleware<ValidationMiddleware>();
-```
-
-### Transactional Outbox
-
-```csharp
-using HoneyDrunk.Transport.Outbox;
-
-public class OrderService(IOutboxStore outboxStore, IDbContext dbContext)
-{
-    public async Task CreateOrderAsync(CreateOrderCommand command)
-    {
-        await using var transaction = await dbContext.BeginTransactionAsync();
-        
-        try
-        {
-            // Save order to database
-            var order = new Order { /* ... */ };
-            await dbContext.Orders.AddAsync(order);
-            
-            // Save message to outbox (same transaction)
-            var envelope = CreateOrderCreatedEnvelope(order);
-            await outboxStore.SaveAsync(
-                envelope,
-                new EndpointAddress("orders-topic"),
-                cancellationToken);
-            
-            await transaction.CommitAsync();
-            
-            // Background dispatcher will publish from outbox
-        }
-        catch
-        {
-            await transaction.RollbackAsync();
-            throw;
-        }
-    }
-}
-```
-
-### Azure Service Bus Blob Fallback (optional)
-
-```csharp
-// Enable fallback to Azure Blob Storage when publish fails
-builder.Services.AddHoneyDrunkServiceBusTransport(options =>
-{
-    options.ConnectionString = builder.Configuration["ServiceBus:ConnectionString"];    
-    options.Address = "orders";
-
-    options.BlobFallback.Enabled = true;
-    options.BlobFallback.ConnectionString = builder.Configuration["Blob:ConnectionString"]; // or use AccountUrl with MSI
-    options.BlobFallback.ContainerName = "transport-fallback";
-    options.BlobFallback.BlobPrefix = "servicebus";
+    // Assert in handler
+    return Task.FromResult(MessageProcessingResult.Success);
 });
+
+await using var provider = services.BuildServiceProvider();
+
+var broker = provider.GetRequiredService<InMemoryBroker>();
+var publisher = provider.GetRequiredService<ITransportPublisher>();
+var pipeline = provider.GetRequiredService<IMessagePipeline>();
+
+// Use broker for broker-level tests, pipeline for pipeline-level tests
 ```
 
-Behavior: on publish exception, the publisher saves the full envelope + destination metadata to blob JSON and suppresses the error if the upload succeeds. If blob upload fails too, the original error is rethrown.
-
-### Azure Storage Queue with Poison Handling
-
-```csharp
-using HoneyDrunk.Transport.Abstractions;
-
-// Handler with explicit error control
-public class PaymentProcessingHandler : IMessageHandler<ProcessPaymentCommand>
-{
-    private readonly IPaymentGateway _gateway;
-    private readonly ILogger<PaymentProcessingHandler> _logger;
-    
-    public PaymentProcessingHandler(
-        IPaymentGateway gateway,
-        ILogger<PaymentProcessingHandler> logger)
-    {
-        _gateway = gateway;
-        _logger = logger;
-    }
-    
-    public async Task<MessageProcessingResult> HandleAsync(
-        ProcessPaymentCommand message,
-        MessageContext context,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Check dequeue count to detect repeated failures
-            if (context.DeliveryCount > 3)
-            {
-                _logger.LogWarning(
-                    "Payment {PaymentId} has been retried {Count} times",
-                    message.PaymentId,
-                    context.DeliveryCount);
-            }
-            
-            var result = await _gateway.ProcessPaymentAsync(
-                message.PaymentId,
-                message.Amount,
-                cancellationToken);
-            
-            if (result.IsSuccess)
-            {
-                return MessageProcessingResult.Success; // Message deleted from queue
-            }
-            else if (result.IsTransientError)
-            {
-                // Transient error (timeout, rate limit) - retry
-                _logger.LogWarning(
-                    "Transient error processing payment {PaymentId}: {Error}",
-                    message.PaymentId,
-                    result.ErrorMessage);
-                
-                return MessageProcessingResult.Retry; // Message becomes visible again
-            }
-            else
-            {
-                // Permanent error (invalid card, insufficient funds) - dead letter
-                _logger.LogError(
-                    "Permanent error processing payment {PaymentId}: {Error}",
-                    message.PaymentId,
-                    result.ErrorMessage);
-                
-                return MessageProcessingResult.DeadLetter; // Moved to poison queue
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unexpected error processing payment {PaymentId}", message.PaymentId);
-            
-            // After MaxDequeueCount (default: 5), message automatically moves to poison queue
-            return MessageProcessingResult.Retry;
-        }
-    }
-}
-```
+See [Testing.md](HoneyDrunk.Transport/docs/Testing.md) for complete patterns including unit tests, integration tests, and test helpers.
 
 ---
 
-## 🧪 Testing & Validation
+## 📚 Documentation
 
-### In-Memory Transport for Tests
-
-```csharp
-using HoneyDrunk.Transport.InMemory;
-using Xunit;
-
-public class OrderServiceTests
-{
-    [Fact]
-    public async Task CreateOrder_PublishesOrderCreatedEvent()
-    {
-        // Arrange
-        var broker = new InMemoryBroker();
-        var publisher = new InMemoryTransportPublisher(broker, logger);
-        var service = new OrderService(publisher, /* ... */);
-        
-        var messagesReceived = new List<ITransportEnvelope>();
-        broker.Subscribe("orders-topic", (envelope, ct) =>
-        {
-            messagesReceived.Add(envelope);
-            return Task.CompletedTask;
-        });
-        
-        // Act
-        await service.CreateOrderAsync(new CreateOrderCommand { /* ... */ });
-        
-        // Assert
-        Assert.Single(messagesReceived);
-        Assert.Equal("OrderCreatedEvent", messagesReceived[0].MessageType);
-    }
-}
-```
-
-### Testing with Fixed Time
-
-```csharp
-using HoneyDrunk.Kernel.Abstractions.Time;
-
-public class EnvelopeFactoryTests
-{
-    [Fact]
-    public void CreateEnvelope_UsesFixedTimestamp()
-    {
-        // Arrange
-        var fixedTime = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
-        var clock = new FixedClock(fixedTime);
-        var idGenerator = new TestIdGenerator("test-id");
-        var factory = new EnvelopeFactory(idGenerator, clock);
-        
-        // Act
-        var envelope = factory.CreateEnvelope<TestMessage>(payload);
-        
-        // Assert
-        Assert.Equal(fixedTime, envelope.Timestamp);
-        Assert.Equal("test-id", envelope.MessageId);
-    }
-}
-```
+| Document | Description |
+|----------|-------------|
+| [Architecture.md](HoneyDrunk.Transport/docs/Architecture.md) | High-level architecture and design principles |
+| [Abstractions.md](HoneyDrunk.Transport/docs/Abstractions.md) | Core contracts: `ITransportEnvelope`, `IMessageHandler`, `MessageContext` |
+| [Pipeline.md](HoneyDrunk.Transport/docs/Pipeline.md) | Middleware pipeline and built-in middleware |
+| [Configuration.md](HoneyDrunk.Transport/docs/Configuration.md) | All options: `TransportCoreOptions`, `RetryOptions`, error strategies |
+| [Context.md](HoneyDrunk.Transport/docs/Context.md) | Grid context propagation and `IGridContextFactory` |
+| [Primitives.md](HoneyDrunk.Transport/docs/Primitives.md) | `EnvelopeFactory`, `TransportEnvelope`, serialization |
+| [AzureServiceBus.md](HoneyDrunk.Transport/docs/AzureServiceBus.md) | Service Bus transport: sessions, topics, blob fallback |
+| [StorageQueue.md](HoneyDrunk.Transport/docs/StorageQueue.md) | Storage Queue transport: concurrency model, poison queues |
+| [InMemory.md](HoneyDrunk.Transport/docs/InMemory.md) | InMemory transport for testing |
+| [Outbox.md](HoneyDrunk.Transport/docs/Outbox.md) | Transactional outbox pattern |
+| [Runtime.md](HoneyDrunk.Transport/docs/Runtime.md) | `ITransportRuntime` and consumer lifecycle |
+| [Health.md](HoneyDrunk.Transport/docs/Health.md) | Health monitoring with `ITransportHealthContributor` |
+| [Metrics.md](HoneyDrunk.Transport/docs/Metrics.md) | `ITransportMetrics` and OpenTelemetry integration |
+| [Testing.md](HoneyDrunk.Transport/docs/Testing.md) | Test patterns and helpers |
 
 ---
 
-## 🛠️ Configuration
-
-### Transport Core Options
-
-```csharp
-builder.Services.AddHoneyDrunkTransportCore(options =>
-{
-    options.EndpointName = "my-service";
-    options.Address = "my-queue";
-    options.EnableTelemetry = true;
-    options.EnableLogging = true;
-    options.EnableCorrelation = true;
-    options.MaxConcurrency = 10;
-    options.PrefetchCount = 20;
-});
-```
-
-### Azure Service Bus Options
-
-```csharp
-builder.Services.AddHoneyDrunkServiceBusTransport(options =>
-{
-    // Connection
-    options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
-    options.ConnectionString = config["ServiceBus:ConnectionString"];
-    
-    // Entity
-    options.EntityType = ServiceBusEntityType.Topic;
-    options.Address = "orders-topic";
-    options.SubscriptionName = "order-processor";
-    
-    // Processing
-    options.AutoComplete = true;
-    options.SessionEnabled = false;
-    options.MaxConcurrency = 10;
-    options.PrefetchCount = 20;
-    options.MessageLockDuration = TimeSpan.FromMinutes(5);
-    
-    // Retry
-    options.ServiceBusRetry.Mode = ServiceBusRetryMode.Exponential;
-    options.ServiceBusRetry.MaxRetries = 3;
-    options.ServiceBusRetry.Delay = TimeSpan.FromSeconds(0.8);
-    options.ServiceBusRetry.MaxDelay = TimeSpan.FromMinutes(1);
-    
-    // Dead Letter
-    options.EnableDeadLetterQueue = true;
-    options.MaxDeliveryCount = 10;
-    
-    // Blob fallback (optional)
-    // options.BlobFallback.Enabled = true;
-    // options.BlobFallback.ConnectionString = config["Blob:ConnectionString"]; // or AccountUrl + MSI
-    // options.BlobFallback.ContainerName = "transport-fallback";
-    // options.BlobFallback.BlobPrefix = "servicebus";
-});
-```
-
-### Azure Storage Queue Options
-
-```csharp
-builder.Services.AddHoneyDrunkTransportStorageQueue(options =>
-{
-    // Connection
-    options.ConnectionString = config["StorageQueue:ConnectionString"];
-    options.QueueName = "orders";
-    options.CreateIfNotExists = true;
-    
-    // Message Settings
-    options.Base64EncodePayload = true;
-    options.MessageTimeToLive = TimeSpan.FromDays(7);
-    options.VisibilityTimeout = TimeSpan.FromSeconds(30);
-    
-    // Processing
-    options.MaxConcurrency = 5;
-    options.PrefetchMaxMessages = 16;
-    
-    // Poison Handling
-    options.MaxDequeueCount = 5;
-    options.PoisonQueueName = "orders-poison";
-    
-    // Polling
-    options.EmptyQueuePollingInterval = TimeSpan.FromSeconds(1);
-    options.MaxPollingInterval = TimeSpan.FromSeconds(5);
-    
-    // Observability
-    options.EnableTelemetry = true;
-    options.EnableLogging = true;
-    options.EnableCorrelation = true;
-});
-
-// Or use fluent configuration
-builder.Services
-    .AddHoneyDrunkTransportStorageQueue(
-        config["StorageQueue:ConnectionString"]!,
-        "orders")
-    .WithMaxDequeueCount(3)
-    .WithVisibilityTimeout(TimeSpan.FromSeconds(60))
-    .WithPrefetchCount(32)
-    .WithConcurrency(10)
-    .WithPoisonQueue("orders-dlq");
-```
-
-### Repository Layout
+## 🛠️ Repository Layout
 
 ```
 HoneyDrunk.Transport/
- ├── HoneyDrunk.Transport/                    # Core abstractions & pipeline
- │   ├── Abstractions/                        # Contracts & interfaces
- │   ├── Pipeline/                            # Middleware execution engine
- │   ├── Configuration/                       # Options & settings
- │   ├── Context/                             # Kernel context integration
- │   ├── Primitives/                          # Envelope & factory
- │   ├── Outbox/                              # Transactional outbox
- │   └── DependencyInjection/                 # DI registration
- ├── HoneyDrunk.Transport.AzureServiceBus/    # Azure Service Bus provider
- ├── HoneyDrunk.Transport.StorageQueue/       # Azure Storage Queue provider
- ├── HoneyDrunk.Transport.InMemory/           # In-memory provider
- ├── HoneyDrunk.Transport.Tests/              # Test project
- ├── HoneyDrunk.Transport.slnx
- ├── .editorconfig
- └── .github/workflows/
-     ├── validate-pr.yml
-     └── publish.yml
+├── HoneyDrunk.Transport/                    # Core abstractions & pipeline
+│   ├── Abstractions/                        # Contracts & interfaces
+│   ├── Pipeline/                            # Middleware execution engine
+│   ├── Configuration/                       # Options & settings
+│   ├── Context/                             # Grid context integration
+│   ├── Primitives/                          # Envelope & factory
+│   ├── Outbox/                              # Transactional outbox
+│   ├── Runtime/                             # ITransportRuntime host
+│   ├── Health/                              # Health contributors
+│   ├── Metrics/                             # ITransportMetrics
+│   ├── Telemetry/                           # OpenTelemetry integration
+│   └── DependencyInjection/                 # DI registration
+├── HoneyDrunk.Transport.AzureServiceBus/    # Azure Service Bus provider
+├── HoneyDrunk.Transport.StorageQueue/       # Azure Storage Queue provider
+├── HoneyDrunk.Transport.InMemory/           # In-memory provider
+├── HoneyDrunk.Transport.Tests/              # Test project
+└── docs/                                    # Documentation
 ```
 
-#### Storage Queue vs Service Bus
+---
 
-**When to use Storage Queue:**
-- ✅ Simple queue-based messaging
-- ✅ Cost-effective for high-volume scenarios
-- ✅ No need for advanced features (sessions, transactions)
-- ✅ Message size < 64KB
-- ✅ At-least-once delivery is acceptable
+## ⚖️ Storage Queue vs Service Bus
 
-**When to use Service Bus:**
-- ✅ Need topics/subscriptions (pub/sub)
-- ✅ Require sessions for ordered processing
-- ✅ Need transactional receive
-- ✅ Message size up to 1MB (or 100MB with Premium)
-- ✅ Dead-letter queue with automatic retry policies
-- ✅ Advanced features (duplicate detection, message deferral)
+| Scenario | Storage Queue | Service Bus |
+|----------|---------------|-------------|
+| **Cost optimization** | ✅ $0.0004/10K ops | ❌ Higher cost |
+| **High volume (millions/day)** | ✅ Excellent | ✅ Good |
+| **Simple queue semantics** | ✅ Yes | ✅ Yes |
+| **Message size < 64KB** | ✅ Yes | ✅ Up to 100MB |
+| **Topics/subscriptions (fan-out)** | ❌ No | ✅ Yes |
+| **Sessions (ordered processing)** | ❌ No | ✅ Yes |
+| **Transactions** | ❌ No | ✅ Yes |
+| **Duplicate detection** | ❌ No | ✅ Yes |
 
-**Storage Queue Limitations:**
-- ⚠️ Maximum message size: ~64KB (after base64 encoding)
-- ⚠️ No native dead-letter queue (implemented via poison queue pattern)
-- ⚠️ No FIFO guarantees beyond queue semantics
-- ⚠️ No built-in duplicate detection
-- ⚠️ No transactional receive
-- ⚠️ Batch operations are not atomic (parallelized individual sends)
+**Choose Storage Queue** for cost-effective, high-volume, simple queue scenarios.  
+**Choose Service Bus** for enterprise messaging with topics, sessions, or transactions.
 
-For large payloads, consider storing data in Blob Storage and sending a reference/pointer message.
+---
+
+## 📄 License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Introduce significant updates to HoneyDrunk.Transport, focusing on multi-tenancy, durability, and developer experience.

- **Changelog**: Added detailed entries for v0.3.0, documenting breaking changes, new features, and fixes.
- **README**: Improved feature descriptions, configuration examples, and usage patterns.
- **Azure Service Bus**: Added `EntityType`, `BlobFallback`, and session-based routing.
- **Storage Queue**: Enhanced concurrency, poison queue handling, and Blob fallback.
- **InMemory Transport**: Clarified testing-only use, added `InMemoryTopology`.
- **Pipeline**: Added `RetryMiddleware`, deprecated `CorrelationMiddleware`.
- **Outbox**: Refactored `IOutboxStore`, added `DefaultOutboxDispatcher`.
- **Metrics**: Integrated OpenTelemetry for tracing and metrics tagging.
- **Testing.md**: Refactored structure, added examples for retry, grid context, and outbox.
- **Runtime.md**: Added new documentation for `ITransportRuntime` lifecycle orchestration.
- **Breaking Changes**: Renamed configuration properties (`IsQueue` → `EntityType`), updated interfaces, deprecated legacy middleware.

BREAKING CHANGE: Renamed `IsQueue` to `EntityType`, `EnableSessions` to `SessionEnabled`. Updated `IOutboxStore` and `ITransportPublisher` interfaces.