### PR TITLE
fix(transport): register ITransportMetrics singleton in DI

### DIFF
--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to HoneyDrunk.Transport.AzureServiceBus will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-01-14
+
+### Fixed
+- **ITransportMetrics DI Registration**: Inherits fix from HoneyDrunk.Transport v0.3.1 - `ITransportMetrics` is now automatically registered during transport setup.
+
 ## [0.3.0] - 2025-12-03
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to HoneyDrunk.Transport.AzureServiceBus will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2025-01-14
+## [0.3.1] - 2026-01-18
 
 ### Fixed
 - **ITransportMetrics DI Registration**: Inherits fix from HoneyDrunk.Transport v0.3.1 - `ITransportMetrics` is now automatically registered during transport setup.

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.AzureServiceBus</PackageId>
-    <Version>0.3.0</Version>
-    <Authors>HoneyDrunk Studios</Authors>
-    <Description>Azure Service Bus transport implementation for HoneyDrunk.Transport. Provides topic/subscription support, session handling, and distributed tracing integration for Service Bus messaging.</Description>
-	<PackageReleaseNotes>v0.3.0: Kernel v0.3.0 integration with TenantId/ProjectId multi-tenancy support and GridHeaderNames standardization. BREAKING: Updated header names. See CHANGELOG.md.</PackageReleaseNotes>
+    <Version>0.3.1</Version>
+       <Authors>HoneyDrunk Studios</Authors>
+       <Description>Azure Service Bus transport implementation for HoneyDrunk.Transport. Provides topic/subscription support, session handling, and distributed tracing integration for Service Bus messaging.</Description>
+	<PackageReleaseNotes>v0.3.1: Inherits ITransportMetrics DI fix from HoneyDrunk.Transport v0.3.1.</PackageReleaseNotes>
 	<PackageTags>messaging;transport;azure;servicebus;cloud;distributed;queue;topic;session;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to HoneyDrunk.Transport.InMemory will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-01-18
+
+### Fixed
+- **ITransportMetrics DI Registration**: Inherits fix from HoneyDrunk.Transport v0.3.1 - `ITransportMetrics` is now automatically registered during transport setup.
+
 ## [0.3.0] - 2025-12-03
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.InMemory</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory transport implementation for HoneyDrunk.Transport. Provides observable queues and pub/sub subscriptions for testing without external dependencies.</Description>
-    <PackageReleaseNotes>v0.3.0: Kernel v0.3.0 integration with TenantId/ProjectId multi-tenancy support. Non-breaking for InMemory transport.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.1: Inherits ITransportMetrics DI fix from HoneyDrunk.Transport v0.3.1.</PackageReleaseNotes>
     <PackageTags>messaging;transport;inmemory;testing;broker;queue;pubsub;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to HoneyDrunk.Transport.StorageQueue will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-01-14
+
+### Fixed
+- **ITransportMetrics DI Registration**: Inherits fix from HoneyDrunk.Transport v0.3.1 - `ITransportMetrics` is now automatically registered during transport setup.
+
 ## [0.3.0] - 2025-12-03
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to HoneyDrunk.Transport.StorageQueue will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2025-01-14
+## [0.3.1] - 2026-01-18
 
 ### Fixed
 - **ITransportMetrics DI Registration**: Inherits fix from HoneyDrunk.Transport v0.3.1 - `ITransportMetrics` is now automatically registered during transport setup.

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.StorageQueue</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Storage Queue transport implementation for HoneyDrunk.Transport. Provides cost-effective, high-volume messaging with automatic poison queue handling and exponential backoff.</Description>
-    <PackageReleaseNotes>v0.3.0: BREAKING - Kernel v0.3.0 integration with TenantId/ProjectId in JSON envelope schema. Drain queues before upgrading. See CHANGELOG.md.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.1: Inherits ITransportMetrics DI fix from HoneyDrunk.Transport v0.3.1.</PackageReleaseNotes>
     <PackageTags>messaging;storage-queue;azure;transport;poison-queue;retry;backoff;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.DependencyInjection;
+using HoneyDrunk.Transport.Metrics;
 using HoneyDrunk.Transport.Tests.Support;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -77,5 +78,79 @@ public sealed class ServiceCollectionExtensionsTests
 
         await handler!.HandleAsync(new SampleMessage { Value = "test" }, context, CancellationToken.None);
         Assert.True(called);
+    }
+
+    /// <summary>
+    /// Verifies AddHoneyDrunkTransportCore registers ITransportMetrics.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkTransportCore_WhenCalled_RegistersITransportMetrics()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHoneyDrunkTransportCore();
+
+        // Act
+        var provider = new DefaultServiceProviderFactory().CreateServiceProvider(services);
+        var metrics = provider.GetService<ITransportMetrics>();
+
+        // Assert
+        Assert.NotNull(metrics);
+        Assert.Same(NoOpTransportMetrics.Instance, metrics);
+    }
+
+    /// <summary>
+    /// Verifies consumer can override ITransportMetrics before calling AddHoneyDrunkTransportCore.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkTransportCore_WhenCustomMetricsRegisteredFirst_UsesCustomMetrics()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var customMetrics = new CustomTransportMetrics();
+        services.AddSingleton<ITransportMetrics>(customMetrics);
+
+        services.AddHoneyDrunkTransportCore();
+
+        // Act
+        var provider = new DefaultServiceProviderFactory().CreateServiceProvider(services);
+        var metrics = provider.GetService<ITransportMetrics>();
+
+        // Assert
+        Assert.NotNull(metrics);
+        Assert.Same(customMetrics, metrics);
+    }
+
+    /// <summary>
+    /// Custom implementation for testing consumer override.
+    /// </summary>
+    private sealed class CustomTransportMetrics : ITransportMetrics
+    {
+        public void RecordMessagePublished(string messageType, string destination)
+        {
+        }
+
+        public void RecordMessageConsumed(string messageType, string source)
+        {
+        }
+
+        public void RecordProcessingDuration(string messageType, TimeSpan duration, string result)
+        {
+        }
+
+        public void RecordMessageRetry(string messageType, int attemptNumber)
+        {
+        }
+
+        public void RecordMessageDeadLettered(string messageType, string reason)
+        {
+        }
+
+        public void RecordPayloadSize(string messageType, long sizeBytes, string direction)
+        {
+        }
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportTests.cs
@@ -1,4 +1,6 @@
 using HoneyDrunk.Transport.InMemory;
+using HoneyDrunk.Transport.InMemory.DependencyInjection;
+using HoneyDrunk.Transport.Metrics;
 using HoneyDrunk.Transport.Tests.Support;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -43,5 +45,25 @@ public sealed class InMemoryTransportTests
         await Task.Delay(100);
 
         await consumer.StopAsync();
+    }
+
+    /// <summary>
+    /// Verifies AddHoneyDrunkInMemoryTransport registers ITransportMetrics automatically.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkInMemoryTransport_WhenCalled_RegistersITransportMetrics()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHoneyDrunkInMemoryTransport();
+
+        // Act
+        var provider = services.BuildServiceProvider();
+        var metrics = provider.GetService<ITransportMetrics>();
+
+        // Assert
+        Assert.NotNull(metrics);
+        Assert.Same(NoOpTransportMetrics.Instance, metrics);
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to HoneyDrunk.Transport will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-01-14
+
+### Fixed
+- **ITransportMetrics DI Registration**: Fixed `NoOpTransportMetrics` not being resolvable from DI. The singleton instance is now registered correctly, eliminating the need for downstream services to manually register `ITransportMetrics`. Consumers calling any transport registration method (e.g., `AddHoneyDrunkInMemoryTransport`) now automatically receive a valid `ITransportMetrics` implementation.
+
 ## [0.3.0] - 2025-12-03
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to HoneyDrunk.Transport will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2025-01-14
+## [0.3.1] - 2026-01-18
 
 ### Fixed
 - **ITransportMetrics DI Registration**: Fixed `NoOpTransportMetrics` not being resolvable from DI. The singleton instance is now registered correctly, eliminating the need for downstream services to manually register `ITransportMetrics`. Consumers calling any transport registration method (e.g., `AddHoneyDrunkInMemoryTransport`) now automatically receive a valid `ITransportMetrics` implementation.

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,7 +58,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IMessagePublisher, MessagePublisher>();
 
         // Metrics (no-op by default, can be replaced with Kernel-backed implementation)
-        services.TryAddSingleton<ITransportMetrics, NoOpTransportMetrics>();
+        // Use the singleton instance since NoOpTransportMetrics has a private constructor
+        services.TryAddSingleton<ITransportMetrics>(NoOpTransportMetrics.Instance);
 
         // Register transport runtime host (coordinates consumer lifecycle)
         services.TryAddSingleton<ITransportRuntime, TransportRuntimeHost>();

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Transport-agnostic messaging library for .NET. Provides a unified abstraction layer over different message brokers with middleware pipeline pattern, retry strategies, and transactional outbox support. Integrated with HoneyDrunk.Kernel for Grid-aware context propagation.</Description>
-    <PackageReleaseNotes>v0.3.0: BREAKING - Kernel v0.3.0 integration with TenantId/ProjectId multi-tenancy, IMessagePublisher high-level API, and GridHeaderNames standardization. See CHANGELOG.md for migration guide.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.1: Fixed ITransportMetrics DI registration - NoOpTransportMetrics is now automatically registered, eliminating manual registration requirements.</PackageReleaseNotes>
     <PackageTags>messaging;transport;broker;middleware;pipeline;outbox;retry;servicebus;distributed;kernel;grid;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/docs/DependencyInjection.md
+++ b/HoneyDrunk.Transport/docs/DependencyInjection.md
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtensions
 - The message pipeline (`IMessagePipeline`)
 - Built-in middleware (conditionally via `TransportCoreOptions`)
 - `JsonMessageSerializer` as the default `IMessageSerializer`
+- `NoOpTransportMetrics` as the default `ITransportMetrics` (can be overridden by registering a custom implementation before calling this method)
 - The transport runtime host (`ITransportRuntime` / `IHostedService`)
 - The transport builder (`ITransportBuilder`) for fluent configuration
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,52 @@
 # HoneyDrunk.Transport
 
+[![Validate PR](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/actions/workflows/validate-pr.yml/badge.svg)](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/actions/workflows/validate-pr.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/download/dotnet/10.0)
 
 > **Reliable messaging and outbox infrastructure for the Hive** - Transport unifies brokers, queues, and event buses under one contract ensuring delivery, order, and idempotence. It powers communication between Nodes—Data, Pulse, Vault, and beyond—so every message finds its way.
 
-**Signal Quote:** *"Every message finds its way."*
+## 📦 What Is This?
+
+HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive"). It provides a transport-agnostic abstraction layer over different message brokers with built-in resilience, observability, and exactly-once semantics.
+
+### What This Package Provides
+
+- **Transport Abstraction** - Unified `ITransportPublisher` and `ITransportConsumer` over Azure Service Bus, Azure Storage Queue, and InMemory
+- **Middleware Pipeline** - Onion-style message processing with logging, telemetry, correlation, and retry
+- **Envelope Pattern** - Immutable `ITransportEnvelope` with correlation/causation tracking and Grid context propagation
+- **Grid Context Integration** - Uses `IGridContext` from HoneyDrunk.Kernel for distributed context propagation
+- **Transactional Outbox** - `IOutboxStore` and `IOutboxDispatcher` contracts for exactly-once processing
+- **Health Contributors** - `ITransportHealthContributor` for Kubernetes probe integration
+- **Observability** - OpenTelemetry spans via `ITransportMetrics` and built-in telemetry middleware
+- **Blob Fallback** - Persist failed Service Bus publishes to Azure Blob Storage for later replay
+
+### What This Package Does Not Provide
+
+- **Automatic message routing** — Application responsibility; no built-in routing conventions
+- **Message schema registry** — No schema validation or evolution support in v0.1.0
+- **Distributed transactions** — Outbox provides eventual consistency, not two-phase commit
+- **Non-Azure provider implementations** — RabbitMQ and Kafka are planned but not available
 
 ---
 
-## 📦 What Is This?
+## ⚠️ v0.1.0 Limitations
 
-HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive"). It provides a transport-agnostic abstraction layer over different message brokers with built-in resilience, observability, and exactly-once semantics:
+The following features exist as **contracts only** or have limitations in v0.1.0:
 
-- ✅ **Transport Abstraction** - Unified `ITransportPublisher` and `ITransportConsumer` over Azure Service Bus, Azure Storage Queue, and InMemory
-- ✅ **Middleware Pipeline** - Onion-style processing with logging, telemetry, correlation, and retry
-- ✅ **Envelope Pattern** - Immutable `ITransportEnvelope` with correlation/causation tracking
-- ✅ **Transactional Outbox** - Exactly-once processing with database transactions
-- ✅ **Kernel Integration** - Uses `TimeProvider` and `IGridContext` from HoneyDrunk.Kernel for deterministic timestamps and distributed context
-- ✅ **Observability** - OpenTelemetry spans and pluggable `ITransportMetrics`
-- ✅ **Blob Fallback for Service Bus** - Persist failed publishes to Azure Blob Storage for later replay
+| Feature | Contract | v0.1.0 Status |
+|---------|----------|---------------|
+| Transport publishing | `ITransportPublisher` | ✅ Implemented for Service Bus, Storage Queue, InMemory |
+| Transport consuming | `ITransportConsumer` | ✅ Implemented for Service Bus, Storage Queue, InMemory |
+| Transactional outbox | `IOutboxStore` | ⚠️ Contract only — application must implement against their database |
+| Outbox dispatching | `IOutboxDispatcher` | ✅ `DefaultOutboxDispatcher` provided |
+| Health aggregation | `ITransportHealthContributor` | ⚠️ Contributors exist — application wires into health system |
+| Message serialization | `IMessageSerializer` | ✅ `JsonMessageSerializer` provided as default |
+
+**Bottom line:** v0.1.0 provides **complete transport abstraction** with Azure providers. Applications must implement:
+- `IOutboxStore` if using transactional outbox pattern (database-specific)
+- Health endpoint wiring for contributor aggregation
+- Custom `IMessageSerializer` if JSON is not suitable
 
 ---
 
@@ -27,16 +54,25 @@ HoneyDrunk.Transport is the **messaging backbone** of HoneyDrunk.OS ("the Hive")
 
 ### Installation
 
-```xml
-<ItemGroup>
-  <PackageReference Include="HoneyDrunk.Transport" Version="0.1.0" />
-  <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.1.0" />
-  <PackageReference Include="HoneyDrunk.Transport.StorageQueue" Version="0.1.0" />
-  <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.1.0" />
-</ItemGroup>
+```sh
+# Azure Service Bus transport
+dotnet add package HoneyDrunk.Transport.AzureServiceBus
+
+# Or Azure Storage Queue transport
+dotnet add package HoneyDrunk.Transport.StorageQueue
+
+# Or InMemory transport (for testing)
+dotnet add package HoneyDrunk.Transport.InMemory
+
+# Or just the core abstractions (contracts only)
+dotnet add package HoneyDrunk.Transport
 ```
 
-### Configure in Program.cs
+### Web API Setup
+
+This example shows a web application with Kernel and Azure Service Bus. Simpler setups are possible—see package-specific documentation.
+
+> **Registration order matters.** Kernel must be registered before Transport. See [DependencyInjection.md](HoneyDrunk.Transport/docs/DependencyInjection.md) for details.
 
 ```csharp
 using HoneyDrunk.Kernel.DependencyInjection;
@@ -44,20 +80,17 @@ using HoneyDrunk.Transport.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// 1. Register Kernel node
+// 1. Kernel (required for Grid context)
 builder.Services.AddHoneyDrunkCoreNode(nodeDescriptor);
 
-// 2. Register Transport core
+// 2. Transport core (middleware pipeline, envelope factory)
 builder.Services.AddHoneyDrunkTransportCore(options =>
 {
     options.EnableTelemetry = true;
     options.EnableLogging = true;
-    options.EnableCorrelation = true;
 });
 
-// 3. Choose a transport
-
-// Azure Service Bus
+// 3. Azure Service Bus provider
 builder.Services.AddHoneyDrunkServiceBusTransport(options =>
 {
     options.FullyQualifiedNamespace = "mynamespace.servicebus.windows.net";
@@ -65,19 +98,7 @@ builder.Services.AddHoneyDrunkServiceBusTransport(options =>
     options.EntityType = ServiceBusEntityType.Topic;
     options.SubscriptionName = "order-processor";
     options.MaxConcurrency = 10;
-    options.PrefetchCount = 20;
-
-    options.ServiceBusRetry.Mode = ServiceBusRetryMode.Exponential;
-    options.ServiceBusRetry.MaxRetries = 3;
 });
-
-// OR Azure Storage Queue
-builder.Services
-    .AddHoneyDrunkTransportStorageQueue(
-        builder.Configuration["StorageQueue:ConnectionString"]!,
-        "orders")
-    .WithMaxDequeueCount(5)
-    .WithConcurrency(10);
 
 // 4. Register message handlers
 builder.Services.AddMessageHandler<OrderCreatedEvent, OrderCreatedHandler>();
@@ -86,30 +107,27 @@ var app = builder.Build();
 app.Run();
 ```
 
----
+### Abstractions-Only Usage
 
-## 📖 Usage Examples
-
-### Publishing Messages
+For libraries that only need contracts without runtime dependencies:
 
 ```csharp
-public class OrderService(
-    ITransportPublisher publisher,
-    EnvelopeFactory envelopeFactory,
-    IMessageSerializer serializer,
-    IGridContext gridContext)
+// Reference only HoneyDrunk.Transport
+// No Kernel runtime, no broker SDK dependencies
+
+public class OrderService
 {
-    public async Task CreateOrderAsync(CreateOrderCommand command, CancellationToken ct)
+    private readonly ITransportPublisher _publisher;
+    private readonly EnvelopeFactory _envelopeFactory;
+    private readonly IMessageSerializer _serializer;
+
+    public async Task PublishOrderCreatedAsync(Order order, CancellationToken ct)
     {
-        // Create order...
+        var @event = new OrderCreatedEvent { OrderId = order.Id };
+        var payload = _serializer.Serialize(@event);
+        var envelope = _envelopeFactory.CreateEnvelope<OrderCreatedEvent>(payload);
         
-        // Publish event
-        var @event = new OrderCreatedEvent { OrderId = orderId, Total = total };
-        var payload = serializer.Serialize(@event);
-        var envelope = envelopeFactory.CreateEnvelopeWithGridContext<OrderCreatedEvent>(
-            payload, gridContext);
-        
-        await publisher.PublishAsync(
+        await _publisher.PublishAsync(
             envelope,
             EndpointAddress.Create("orders", "orders-topic"),
             ct);
@@ -117,23 +135,46 @@ public class OrderService(
 }
 ```
 
-### Handling Messages
+---
+
+## 🎯 Key Features (v0.1.0)
+
+### 📨 Transport Envelope Pattern
+
+All messages are wrapped in immutable `ITransportEnvelope` for distributed tracing:
+
+```csharp
+public interface ITransportEnvelope
+{
+    string MessageId { get; }
+    string? CorrelationId { get; }
+    string? CausationId { get; }
+    string MessageType { get; }
+    ReadOnlyMemory<byte> Payload { get; }
+    IReadOnlyDictionary<string, string> Headers { get; }
+    DateTimeOffset Timestamp { get; }
+}
+
+// Create envelopes via factory (integrates with TimeProvider and Grid context)
+var envelope = envelopeFactory.CreateEnvelopeWithGridContext<OrderCreatedEvent>(
+    payload, gridContext);
+```
+
+**Note:** Always use `EnvelopeFactory` to create envelopes. It integrates with `TimeProvider` for deterministic timestamps and `IGridContext` for distributed context propagation.
+
+### 🔗 Grid Context Integration
+
+Transport is fully integrated with Kernel's `IGridContext` for distributed context propagation:
 
 ```csharp
 public class OrderCreatedHandler : IMessageHandler<OrderCreatedEvent>
 {
-    private readonly ILogger<OrderCreatedHandler> _logger;
-    
-    public OrderCreatedHandler(ILogger<OrderCreatedHandler> logger)
-    {
-        _logger = logger;
-    }
-    
     public async Task<MessageProcessingResult> HandleAsync(
         OrderCreatedEvent message,
         MessageContext context,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
+        // Access Grid context directly from MessageContext
         var grid = context.GridContext;
         
         _logger.LogInformation(
@@ -142,13 +183,34 @@ public class OrderCreatedHandler : IMessageHandler<OrderCreatedEvent>
             grid?.CorrelationId,
             grid?.NodeId);
         
-        await SendConfirmationEmailAsync(message.OrderId, cancellationToken);
         return MessageProcessingResult.Success;
     }
 }
 ```
 
-### Transactional Outbox
+**Note:** Grid context is extracted from envelope headers by `GridContextPropagationMiddleware` and populated in `MessageContext` automatically.
+
+### 🧅 Middleware Pipeline
+
+Message processing follows an onion-style middleware pattern:
+
+```csharp
+// Built-in middleware (executed in order)
+// 1. GridContextPropagationMiddleware - Extracts IGridContext from envelope
+// 2. TelemetryMiddleware - Distributed tracing via OpenTelemetry
+// 3. LoggingMiddleware - Structured logging of message processing
+
+// Custom middleware registration
+builder.Services.AddHoneyDrunkTransportCore()
+    .AddMiddleware<CustomRetryMiddleware>()
+    .AddMiddleware<CustomValidationMiddleware>();
+```
+
+**Note:** Middleware order matters. GridContextPropagation must run before telemetry to ensure correlation IDs are available for tracing.
+
+### 📤 Transactional Outbox
+
+For exactly-once processing with database transactions:
 
 ```csharp
 public class OrderService(
@@ -161,144 +223,46 @@ public class OrderService(
     {
         await using var transaction = await dbContext.BeginTransactionAsync(ct);
         
-        try
-        {
-            // Save order to database
-            var order = new Order { /* ... */ };
-            await dbContext.Orders.AddAsync(order, ct);
-            
-            // Save message to outbox (same transaction)
-            var payload = serializer.Serialize(new OrderCreatedEvent { OrderId = order.Id });
-            var envelope = factory.CreateEnvelope<OrderCreatedEvent>(payload);
-            var destination = EndpointAddress.Create("orders", "orders-topic");
-            
-            await outboxStore.SaveAsync(destination, envelope, ct);
-            
-            await dbContext.SaveChangesAsync(ct);
-            await transaction.CommitAsync(ct);
-            
-            // DefaultOutboxDispatcher publishes from outbox in background
-        }
-        catch
-        {
-            await transaction.RollbackAsync(ct);
-            throw;
-        }
+        // Save order to database
+        var order = new Order { /* ... */ };
+        await dbContext.Orders.AddAsync(order, ct);
+        
+        // Save message to outbox (same transaction)
+        var payload = serializer.Serialize(new OrderCreatedEvent { OrderId = order.Id });
+        var envelope = factory.CreateEnvelope<OrderCreatedEvent>(payload);
+        
+        await outboxStore.SaveAsync(
+            EndpointAddress.Create("orders", "orders-topic"),
+            envelope, ct);
+        
+        await dbContext.SaveChangesAsync(ct);
+        await transaction.CommitAsync(ct);
+        
+        // DefaultOutboxDispatcher publishes from outbox in background
     }
 }
 ```
 
----
+**Note:** `IOutboxStore` is a contract—application must implement against their database. `DefaultOutboxDispatcher` polls the store and publishes pending messages.
 
-## 🎯 Features
+### 🏥 Health Contributors
 
-### 🔍 Core Components
-
-| Component | Purpose | Key Types |
-|-----------|---------|-----------|
-| **Transport Abstraction** | Unified publisher/consumer interface | `ITransportPublisher`, `ITransportConsumer` |
-| **Message Pipeline** | Middleware execution engine | `IMessagePipeline`, `IMessageMiddleware` |
-| **Envelope System** | Immutable message wrapping | `ITransportEnvelope`, `EnvelopeFactory` |
-| **Grid Context** | Correlation/causation tracking | `IGridContext`, `IGridContextFactory` |
-| **Serialization** | Pluggable message serialization | `IMessageSerializer`, `JsonMessageSerializer` |
-| **Outbox Pattern** | Transactional outbox support | `IOutboxStore`, `DefaultOutboxDispatcher` |
-
-### 🔗 Kernel Integration
-
-HoneyDrunk.Transport **extends** HoneyDrunk.Kernel with messaging primitives:
-
-| Kernel Service | How Transport Uses It |
-|----------------|----------------------|
-| `TimeProvider` | Deterministic message timestamps via `EnvelopeFactory` |
-| `IGridContext` | Correlation, causation, Node/Studio/Tenant propagation |
-| `IGridContextFactory` | Creates Grid context for outbound messages |
-| `ILogger<T>` | Structured logging throughout pipeline |
-| `IMeterFactory` | OpenTelemetry metrics via `ITransportMetrics` |
-
-### 🚀 Available Transports
-
-| Transport | Package | Status |
-|-----------|---------|--------|
-| **Azure Service Bus** | `HoneyDrunk.Transport.AzureServiceBus` | ✅ Available |
-| **Azure Storage Queue** | `HoneyDrunk.Transport.StorageQueue` | ✅ Available |
-| **In-Memory** | `HoneyDrunk.Transport.InMemory` | ✅ Available (Testing) |
-| **RabbitMQ** | `HoneyDrunk.Transport.RabbitMQ` | 🚧 Planned |
-| **Kafka** | `HoneyDrunk.Transport.Kafka` | 🚧 Planned |
-
----
-
-## 🧪 Testing
-
-Use InMemory transport and DI for tests:
+Transport providers include health monitoring for Kubernetes probes:
 
 ```csharp
-var services = new ServiceCollection();
-services.AddHoneyDrunkCoreNode(TestNodeDescriptor);
-services.AddHoneyDrunkTransportCore()
-    .AddHoneyDrunkInMemoryTransport();
-
-services.AddMessageHandler<OrderCreatedEvent>((msg, ctx, ct) =>
+public interface ITransportHealthContributor
 {
-    // Assert in handler
-    return Task.FromResult(MessageProcessingResult.Success);
-});
+    string Name { get; }
+    ValueTask<TransportHealthResult> CheckHealthAsync(CancellationToken ct);
+}
 
-await using var provider = services.BuildServiceProvider();
-
-var broker = provider.GetRequiredService<InMemoryBroker>();
-var publisher = provider.GetRequiredService<ITransportPublisher>();
-var pipeline = provider.GetRequiredService<IMessagePipeline>();
-
-// Use broker for broker-level tests, pipeline for pipeline-level tests
+// Each transport registers its own contributor
+// - ServiceBusHealthContributor
+// - StorageQueueHealthContributor
+// - InMemoryHealthContributor
 ```
 
-See [Testing.md](HoneyDrunk.Transport/docs/Testing.md) for complete patterns including unit tests, integration tests, and test helpers.
-
----
-
-## 📚 Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Architecture.md](HoneyDrunk.Transport/docs/Architecture.md) | High-level architecture and design principles |
-| [Abstractions.md](HoneyDrunk.Transport/docs/Abstractions.md) | Core contracts: `ITransportEnvelope`, `IMessageHandler`, `MessageContext` |
-| [Pipeline.md](HoneyDrunk.Transport/docs/Pipeline.md) | Middleware pipeline and built-in middleware |
-| [Configuration.md](HoneyDrunk.Transport/docs/Configuration.md) | All options: `TransportCoreOptions`, `RetryOptions`, error strategies |
-| [Context.md](HoneyDrunk.Transport/docs/Context.md) | Grid context propagation and `IGridContextFactory` |
-| [Primitives.md](HoneyDrunk.Transport/docs/Primitives.md) | `EnvelopeFactory`, `TransportEnvelope`, serialization |
-| [AzureServiceBus.md](HoneyDrunk.Transport/docs/AzureServiceBus.md) | Service Bus transport: sessions, topics, blob fallback |
-| [StorageQueue.md](HoneyDrunk.Transport/docs/StorageQueue.md) | Storage Queue transport: concurrency model, poison queues |
-| [InMemory.md](HoneyDrunk.Transport/docs/InMemory.md) | InMemory transport for testing |
-| [Outbox.md](HoneyDrunk.Transport/docs/Outbox.md) | Transactional outbox pattern |
-| [Runtime.md](HoneyDrunk.Transport/docs/Runtime.md) | `ITransportRuntime` and consumer lifecycle |
-| [Health.md](HoneyDrunk.Transport/docs/Health.md) | Health monitoring with `ITransportHealthContributor` |
-| [Metrics.md](HoneyDrunk.Transport/docs/Metrics.md) | `ITransportMetrics` and OpenTelemetry integration |
-| [Testing.md](HoneyDrunk.Transport/docs/Testing.md) | Test patterns and helpers |
-
----
-
-## 🛠️ Repository Layout
-
-```
-HoneyDrunk.Transport/
-├── HoneyDrunk.Transport/                    # Core abstractions & pipeline
-│   ├── Abstractions/                        # Contracts & interfaces
-│   ├── Pipeline/                            # Middleware execution engine
-│   ├── Configuration/                       # Options & settings
-│   ├── Context/                             # Grid context integration
-│   ├── Primitives/                          # Envelope & factory
-│   ├── Outbox/                              # Transactional outbox
-│   ├── Runtime/                             # ITransportRuntime host
-│   ├── Health/                              # Health contributors
-│   ├── Metrics/                             # ITransportMetrics
-│   ├── Telemetry/                           # OpenTelemetry integration
-│   └── DependencyInjection/                 # DI registration
-├── HoneyDrunk.Transport.AzureServiceBus/    # Azure Service Bus provider
-├── HoneyDrunk.Transport.StorageQueue/       # Azure Storage Queue provider
-├── HoneyDrunk.Transport.InMemory/           # In-memory provider
-├── HoneyDrunk.Transport.Tests/              # Test project
-└── docs/                                    # Documentation
-```
+**Note:** Health contributors are passive—invoked by host health system on demand. Applications wire contributors into their health check infrastructure.
 
 ---
 
@@ -320,6 +284,126 @@ HoneyDrunk.Transport/
 
 ---
 
+## 📖 Documentation
+
+### Package Documentation
+- **[Architecture](HoneyDrunk.Transport/docs/Architecture.md)** - High-level architecture and design principles
+- **[Abstractions](HoneyDrunk.Transport/docs/Abstractions.md)** - Core contracts: `ITransportEnvelope`, `IMessageHandler`, `MessageContext`
+- **[Pipeline](HoneyDrunk.Transport/docs/Pipeline.md)** - Middleware pipeline and built-in middleware
+- **[Configuration](HoneyDrunk.Transport/docs/Configuration.md)** - All options: `TransportCoreOptions`, `RetryOptions`, error strategies
+- **[Context](HoneyDrunk.Transport/docs/Context.md)** - Grid context propagation and `IGridContextFactory`
+- **[Primitives](HoneyDrunk.Transport/docs/Primitives.md)** - `EnvelopeFactory`, `TransportEnvelope`, serialization
+- **[Outbox](HoneyDrunk.Transport/docs/Outbox.md)** - Transactional outbox pattern
+
+### Transport Providers
+- **[AzureServiceBus](HoneyDrunk.Transport/docs/AzureServiceBus.md)** - Service Bus transport: sessions, topics, blob fallback
+- **[StorageQueue](HoneyDrunk.Transport/docs/StorageQueue.md)** - Storage Queue transport: concurrency model, poison queues
+- **[InMemory](HoneyDrunk.Transport/docs/InMemory.md)** - InMemory transport for testing
+
+### Runtime & Observability
+- **[Runtime](HoneyDrunk.Transport/docs/Runtime.md)** - `ITransportRuntime` and consumer lifecycle
+- **[Health](HoneyDrunk.Transport/docs/Health.md)** - Health monitoring with `ITransportHealthContributor`
+- **[Metrics](HoneyDrunk.Transport/docs/Metrics.md)** - `ITransportMetrics` and OpenTelemetry integration
+- **[Testing](HoneyDrunk.Transport/docs/Testing.md)** - Test patterns and helpers
+
+---
+
+## 🏗️ Project Structure
+
+```
+HoneyDrunk.Transport/
+├── HoneyDrunk.Transport/                    # Core abstractions & pipeline
+│   ├── Abstractions/                        # Publisher, consumer, handler contracts
+│   ├── Pipeline/                            # Middleware execution engine
+│   ├── Configuration/                       # TransportCoreOptions, RetryOptions
+│   ├── Context/                             # Grid context factory and propagation
+│   ├── Primitives/                          # EnvelopeFactory, TransportEnvelope
+│   ├── Outbox/                              # IOutboxStore, DefaultOutboxDispatcher
+│   ├── Runtime/                             # ITransportRuntime host
+│   ├── Health/                              # ITransportHealthContributor
+│   ├── Metrics/                             # ITransportMetrics
+│   ├── Telemetry/                           # OpenTelemetry integration
+│   └── DependencyInjection/                 # AddHoneyDrunkTransportCore()
+│
+├── HoneyDrunk.Transport.AzureServiceBus/    # Azure Service Bus provider
+│   ├── Publishing/                          # ServiceBusTransportPublisher
+│   ├── Consuming/                           # ServiceBusTransportConsumer
+│   ├── BlobFallback/                        # Blob storage for failed publishes
+│   ├── Health/                              # ServiceBusHealthContributor
+│   └── DependencyInjection/                 # AddHoneyDrunkServiceBusTransport()
+│
+├── HoneyDrunk.Transport.StorageQueue/       # Azure Storage Queue provider
+│   ├── Publishing/                          # StorageQueueTransportPublisher
+│   ├── Consuming/                           # StorageQueueTransportConsumer
+│   ├── Health/                              # StorageQueueHealthContributor
+│   └── DependencyInjection/                 # AddHoneyDrunkTransportStorageQueue()
+│
+├── HoneyDrunk.Transport.InMemory/           # In-memory provider (testing)
+│   ├── InMemoryBroker                       # Thread-safe in-memory message store
+│   ├── Health/                              # InMemoryHealthContributor
+│   └── DependencyInjection/                 # AddHoneyDrunkInMemoryTransport()
+│
+└── HoneyDrunk.Transport.Tests/              # xUnit test suite
+```
+
+---
+
+## 🆕 What's New in v0.1.0
+
+### Core Transport
+- `ITransportPublisher` and `ITransportConsumer` transport abstraction
+- `ITransportEnvelope` immutable message wrapper with Grid context
+- `EnvelopeFactory` integrating `TimeProvider` and `IGridContext`
+- `IMessagePipeline` with onion-style middleware execution
+- `IMessageHandler<T>` and `MessageProcessingResult` for handler contracts
+- `GridContextPropagationMiddleware`, `TelemetryMiddleware`, `LoggingMiddleware`
+- `IOutboxStore` and `DefaultOutboxDispatcher` for transactional outbox
+- `ITransportHealthContributor` for health check participation
+- `ITransportMetrics` for OpenTelemetry integration
+
+### Azure Service Bus Provider
+- `ServiceBusTransportPublisher` with topic and queue support
+- `ServiceBusTransportConsumer` with session and subscription support
+- `BlobFallbackPublisher` for failed publish persistence
+- `ServiceBusHealthContributor` for connectivity health checks
+- `AzureServiceBusOptions` with retry and prefetch configuration
+
+### Azure Storage Queue Provider
+- `StorageQueueTransportPublisher` with base64 encoding
+- `StorageQueueTransportConsumer` with concurrent polling
+- `StorageQueueHealthContributor` for connectivity health checks
+- `StorageQueueOptions` with dequeue count and visibility timeout
+
+### InMemory Provider
+- `InMemoryBroker` thread-safe message store for testing
+- `InMemoryTransportPublisher` and `InMemoryTransportConsumer`
+- `InMemoryHealthContributor` always-healthy contributor
+
+---
+
+## 🔗 Related Projects
+
+| Project | Relationship |
+|---------|--------------|
+| **[HoneyDrunk.Kernel](https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel)** | Transport depends on Kernel for `IGridContext` and `TimeProvider` |
+| **[HoneyDrunk.Standards](https://github.com/HoneyDrunkStudios/HoneyDrunk.Standards)** | Analyzers and coding conventions |
+| **HoneyDrunk.Data** | Data access and persistence *(in development)* |
+| **HoneyDrunk.Auth** | Authentication and authorization *(in development)* |
+
+**Note:** `HoneyDrunk.Transport` depends only on `HoneyDrunk.Kernel.Abstractions` (contracts, no runtime). Transport providers depend on their respective Azure SDKs.
+
+---
+
 ## 📄 License
 
-[MIT](LICENSE)
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+<div align="center">
+
+**Built with 🍯 by HoneyDrunk Studios**
+
+[GitHub](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport) • [Issues](https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/issues)
+
+</div>


### PR DESCRIPTION
NoOpTransportMetrics is now registered automatically during transport setup, ensuring ITransportMetrics is always resolvable from DI. Applies to core and all Azure transport providers. Updates CHANGELOGs, csproj versions, and docs. Adds tests for registration and consumer override. No breaking changes.