### PR TITLE
ci(pipelines): weekly deps, custom secrets, gitleaks config

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -24,4 +24,4 @@ jobs:
       create-issues: true
       actions-ref: 'main'
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}

--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -1,4 +1,4 @@
-name: Nightly Dependencies
+name: Weekly Dependencies
 
 on:
   schedule:
@@ -10,15 +10,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  nightly-deps:
-    name: Nightly Dependencies
+  weekly-deps:
+    name: Weekly Dependencies
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
     with:
       dotnet-version: '10.0.x'
       runs-on: 'ubuntu-latest'
       working-directory: 'HoneyDrunk.Transport'
       check-dotnet-deps: true
-      create-update-prs: false
+      create-update-prs: true
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,50 @@
+# ==============================================================================
+# Gitleaks configuration
+# ==============================================================================
+# Auto-discovered by gitleaks when scanning this repo. Adds allowlists for
+# documentation placeholder secrets on top of the default ruleset.
+#
+# Shared source of truth: HoneyDrunk.Actions/.github/config/gitleaks.toml
+# Keep in sync across all grid repos.
+# ==============================================================================
+
+title = "HoneyDrunk gitleaks config"
+
+[extend]
+useDefault = true
+
+# ------------------------------------------------------------------------------
+# Documentation placeholders
+# ------------------------------------------------------------------------------
+# Code samples in README/docs use obvious fake values like "test-api-key-12345"
+# or "my-api-key-12345". Gitleaks' generic-api-key rule flags them. Scope the
+# allowlist to markdown/docs paths so a real secret leaking into source is still
+# caught.
+[[allowlists]]
+description = "Documentation placeholder API keys and secrets"
+condition = "AND"
+paths = [
+  '''(?i).*\.md$''',
+  '''(?i)^docs/.*''',
+]
+regexes = [
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy|changeme|xxxx+)[-_]?api[-_]?key[-_]?[\w-]*''',
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy)[-_]?secret[-_]?[\w-]*''',
+  '''(?i)(test|my|your|example|sample|demo|fake|placeholder|dummy)[-_]?token[-_]?[\w-]*''',
+]
+
+# ------------------------------------------------------------------------------
+# Hex identifiers in documentation
+# ------------------------------------------------------------------------------
+# Azure Key Vault secret versions are 32-char hex strings and are legitimately
+# shown in docs as example identifiers (not secrets). Allow only inside docs.
+[[allowlists]]
+description = "Hex identifiers in docs (e.g. AKV secret version IDs)"
+condition = "AND"
+paths = [
+  '''(?i).*\.md$''',
+  '''(?i)^docs/.*''',
+]
+regexes = [
+  '''^[a-f0-9]{32}$''',
+]

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Envelope/EnvelopeFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Envelope/EnvelopeFactoryTests.cs
@@ -559,9 +559,9 @@ public sealed class EnvelopeFactoryTests
             factory.CreateEnvelopeWithGridContext<EnvelopeFactoryTests>(
                 new ReadOnlyMemory<byte>([1, 2, 3]),
                 null!));
-                }
+    }
 
-                /// <summary>
+    /// <summary>
     /// Creates a test Grid context with customizable field values.
     /// </summary>
     private static IGridContext CreateTestGridContext(


### PR DESCRIPTION
Rename nightly to weekly deps workflow and enable PRs. Use HIVE_FIELD_MIRROR_TOKEN in nightly-security. Add .gitleaks.toml with doc placeholder allowlists. Fix summary comment formatting in EnvelopeFactoryTests.