### PR TITLE
chore(ci): set explicit permissions for pr-core workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 jobs:
   pr-core:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   pr-core:
     name: PR Core
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       dotnet-version: '10.0.x'


### PR DESCRIPTION
Update pr-core job in pr.yml to explicitly grant contents:read, checks:write, pull-requests:write, and security-events:write permissions, enabling required access for PR updates, check reporting, and CodeQL SARIF uploads