### PR TITLE
fix(ci): grant issues:read to hive-field-mirror caller

### DIFF
--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened, labeled, unlabeled, edited]
 
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   mirror:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main


### PR DESCRIPTION
## Summary
- Reusable workflow `HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main` declares `permissions: issues: read`; GitHub rejects the caller with `requesting 'issues: read', but is only allowed 'issues: none'` because this repo's caller had no `permissions:` block.
- Adds `contents: read` / `issues: read` at the caller level, matching the shape already in Kernel and Web.Rest.

## Test plan
- [ ] Workflow syntax validates (no "Invalid workflow file" annotation on next push)
- [ ] Next `issues` event (open/label) triggers `Hive Field Mirror` and it completes the `mirror` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)