### PR TITLE
ci(hive-field-mirror): add app-id and private-key secrets to workflow

### DIFF
--- a/.github/workflows/hive-field-mirror.yml
+++ b/.github/workflows/hive-field-mirror.yml
@@ -12,4 +12,6 @@ jobs:
   mirror:
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/hive-field-mirror.yml@main
     secrets:
+      app-id: ${{ secrets.HIVE_APP_ID }}
+      app-private-key: ${{ secrets.HIVE_APP_PRIVATE_KEY }}
       hive-field-mirror-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}


### PR DESCRIPTION
Add HIVE_APP_ID and HIVE_APP_PRIVATE_KEY as secrets for the mirror job to support authentication alongside hive-field-mirror-token