### PR TITLE
feat: adopt typed TenantId for grid context

### DIFF
--- a/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2026-05-04
+
+### Changed
+
+- Aligned solution package versions with Kernel v0.5.0.
+- Updated `HoneyDrunk.Transport` Grid context initialization for Kernel's typed `TenantId` primitive.
+
 ## [0.4.0] - 2026-01-20
 
 ### Breaking Changes
@@ -82,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fluent builder pattern for service registration
 - Metrics collection abstractions
 
+[0.5.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/releases/tag/v0.5.0
 [0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/releases/tag/v0.2.0

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.AzureServiceBus</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Service Bus transport implementation for HoneyDrunk.Transport. Provides topic/subscription support, session handling, and distributed tracing integration for Service Bus messaging.</Description>
-    <PackageReleaseNotes>v0.4.0: Kernel v0.4.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure SDK dependencies.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure SDK dependencies.</PackageReleaseNotes>
 	<PackageTags>messaging;transport;azure;servicebus;cloud;distributed;queue;topic;session;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.InMemory</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory transport implementation for HoneyDrunk.Transport. Provides observable queues and pub/sub subscriptions for testing without external dependencies.</Description>
-    <PackageReleaseNotes>v0.4.0: Kernel v0.4.0 upgrade with IGridContext.AddBaggage() API change and fail-fast envelope validation.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change and fail-fast envelope validation.</PackageReleaseNotes>
     <PackageTags>messaging;transport;inmemory;testing;broker;queue;pubsub;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/HoneyDrunk.Transport.SandboxNode.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/HoneyDrunk.Transport.SandboxNode.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <!-- Kernel packages for node identity and context -->
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     
     <!-- Generic Host -->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/Program.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/Program.cs
@@ -134,7 +134,7 @@ static async Task RunNormalModeAsync()
         kernelContext.Initialize(
             correlationId: "sandbox-correlation-001",
             causationId: "sandbox-causation-root",
-            tenantId: "tenant-acme",
+            tenantId: new TenantId("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
             projectId: "project-alpha",
             baggage: new Dictionary<string, string>
             {

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.StorageQueue</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Storage Queue transport implementation for HoneyDrunk.Transport. Provides cost-effective, high-volume messaging with automatic poison queue handling and exponential backoff.</Description>
-    <PackageReleaseNotes>v0.4.0: Kernel v0.4.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure.Storage.Queues to 12.25.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure.Storage.Queues to 12.25.0.</PackageReleaseNotes>
     <PackageTags>messaging;storage-queue;azure;transport;poison-queue;retry;backoff;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
@@ -1,6 +1,8 @@
+using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Kernel.Context;
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.Primitives;
+using Microsoft.Extensions.Logging;
 
 using TransportGridContextFactory = HoneyDrunk.Transport.Context.GridContextFactory;
 
@@ -36,7 +38,7 @@ public sealed class GridContextFactoryTests
             CausationId = "cause-789",
             NodeId = "node-1",
             StudioId = "studio-1",
-            TenantId = "tenant-1",
+            TenantId = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             ProjectId = "project-1",
             Environment = "production",
             Headers = new Dictionary<string, string>
@@ -56,7 +58,7 @@ public sealed class GridContextFactoryTests
         Assert.True(gridContext.IsInitialized);
         Assert.Equal("corr-456", gridContext.CorrelationId);
         Assert.Equal("cause-789", gridContext.CausationId);
-        Assert.Equal("tenant-1", gridContext.TenantId);
+        Assert.Equal("01ARZ3NDEKTSV4RRFFQ69G5FAV", gridContext.TenantId.ToString());
         Assert.Equal("project-1", gridContext.ProjectId);
         Assert.Equal(2, gridContext.Baggage.Count);
         Assert.Equal("value1", gridContext.Baggage["key1"]);
@@ -221,7 +223,7 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
-            TenantId = "tenant-abc",
+            TenantId = "01BX5ZZKBKACTAV9WEVGEMMVRZ",
             ProjectId = "project-xyz",
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
@@ -232,7 +234,7 @@ public sealed class GridContextFactoryTests
         factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
 
         // Assert
-        Assert.Equal("tenant-abc", gridContext.TenantId);
+        Assert.Equal("01BX5ZZKBKACTAV9WEVGEMMVRZ", gridContext.TenantId.ToString());
         Assert.Equal("project-xyz", gridContext.ProjectId);
     }
 
@@ -240,7 +242,7 @@ public sealed class GridContextFactoryTests
     /// Verifies factory handles null tenant and project IDs gracefully.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithNullTenantAndProject_SetsNullProperties()
+    public void InitializeFromEnvelope_WithNullTenantAndProject_UsesInternalTenant()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
@@ -260,7 +262,131 @@ public sealed class GridContextFactoryTests
         factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
 
         // Assert
-        Assert.Null(gridContext.TenantId);
+        Assert.Equal(TenantId.Internal, gridContext.TenantId);
         Assert.Null(gridContext.ProjectId);
     }
+
+    /// <summary>
+    /// Verifies factory parses valid ULID tenant IDs.
+    /// </summary>
+    [Fact]
+    public void InitializeFromEnvelope_WithValidUlidTenant_ParsesTenantId()
+    {
+        // Arrange
+        var factory = new TransportGridContextFactory();
+        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
+        var tenantId = TenantId.NewId();
+
+        var envelope = new TransportEnvelope
+        {
+            MessageId = "msg-valid-tenant",
+            TenantId = tenantId.ToString(),
+            MessageType = "TestMessage",
+            Payload = ReadOnlyMemory<byte>.Empty,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(tenantId, gridContext.TenantId);
+    }
+
+    /// <summary>
+    /// Verifies malformed tenant IDs fall back to Internal and log without leaking the raw value in the template.
+    /// </summary>
+    [Fact]
+    public void InitializeFromEnvelope_WithMalformedTenant_UsesInternalTenantAndLogsWarning()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var factory = new TransportGridContextFactory(logger);
+        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
+        const string malformedTenant = "not-a-tenant-ulid";
+
+        var envelope = new TransportEnvelope
+        {
+            MessageId = "msg-bad-tenant",
+            TenantId = malformedTenant,
+            MessageType = "TestMessage",
+            Payload = ReadOnlyMemory<byte>.Empty,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(TenantId.Internal, gridContext.TenantId);
+        var warning = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.Contains("{MessageId}", warning.Template, StringComparison.Ordinal);
+        Assert.DoesNotContain(malformedTenant, warning.Template, StringComparison.Ordinal);
+        Assert.DoesNotContain(malformedTenant, warning.Message, StringComparison.Ordinal);
+        Assert.Equal("msg-bad-tenant", warning.Properties["MessageId"]);
+    }
+
+    /// <summary>
+    /// Verifies the serialized Internal sentinel maps back to Internal.
+    /// </summary>
+    [Fact]
+    public void InitializeFromEnvelope_WithInternalTenantString_UsesInternalTenant()
+    {
+        // Arrange
+        var factory = new TransportGridContextFactory();
+        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
+
+        var envelope = new TransportEnvelope
+        {
+            MessageId = "msg-internal-tenant",
+            TenantId = TenantId.Internal.ToString(),
+            MessageType = "TestMessage",
+            Payload = ReadOnlyMemory<byte>.Empty,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(TenantId.Internal, gridContext.TenantId);
+    }
+
+    private sealed class CapturingLogger : ILogger<TransportGridContextFactory>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state as IReadOnlyList<KeyValuePair<string, object?>>;
+            var template = properties?.FirstOrDefault(p => p.Key == "{OriginalFormat}").Value?.ToString()
+                ?? formatter(state, exception);
+
+            var logProperties = properties?.Where(p => p.Key != "{OriginalFormat}")
+                .ToDictionary(p => p.Key, p => p.Value) ?? [];
+
+            Entries.Add(new LogEntry(
+                logLevel,
+                template,
+                formatter(state, exception),
+                logProperties));
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        string Template,
+        string Message,
+        IReadOnlyDictionary<string, object?> Properties);
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Envelope/EnvelopeFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Envelope/EnvelopeFactoryTests.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Exceptions;
 using HoneyDrunk.Transport.Primitives;
 using NSubstitute;
@@ -120,7 +121,7 @@ public sealed class EnvelopeFactoryTests
         var timeProvider = new TestTimeProvider(FixedTime);
         var factory = new EnvelopeFactory(timeProvider);
         var gridContext = CreateTestGridContext(
-            tenantId: "tenant-abc-123",
+            tenantId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             projectId: "project-xyz-789");
 
         // Act
@@ -129,15 +130,15 @@ public sealed class EnvelopeFactoryTests
             gridContext);
 
         // Assert
-        Assert.Equal("tenant-abc-123", envelope.TenantId);
+        Assert.Equal("01ARZ3NDEKTSV4RRFFQ69G5FAV", envelope.TenantId);
         Assert.Equal("project-xyz-789", envelope.ProjectId);
     }
 
     /// <summary>
-    /// Verifies CreateEnvelopeWithGridContext handles null TenantId and ProjectId correctly.
+    /// Verifies CreateEnvelopeWithGridContext maps an absent tenant to the Kernel Internal sentinel.
     /// </summary>
     [Fact]
-    public void CreateEnvelopeWithGridContext_HandlesNullTenantIdAndProjectId()
+    public void CreateEnvelopeWithGridContext_WithAbsentTenant_MapsInternalTenantAndNullProject()
     {
         // Arrange
         var timeProvider = new TestTimeProvider(FixedTime);
@@ -152,7 +153,7 @@ public sealed class EnvelopeFactoryTests
             gridContext);
 
         // Assert
-        Assert.Null(envelope.TenantId);
+        Assert.Equal(TenantId.Internal.ToString(), envelope.TenantId);
         Assert.Null(envelope.ProjectId);
     }
 
@@ -170,7 +171,7 @@ public sealed class EnvelopeFactoryTests
             causationId: "cause-456",
             nodeId: "node-789",
             studioId: "studio-abc",
-            tenantId: "tenant-def",
+            tenantId: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
             projectId: "project-ghi",
             environment: "production");
 
@@ -184,7 +185,7 @@ public sealed class EnvelopeFactoryTests
         Assert.Equal("cause-456", envelope.CausationId);
         Assert.Equal("node-789", envelope.NodeId);
         Assert.Equal("studio-abc", envelope.StudioId);
-        Assert.Equal("tenant-def", envelope.TenantId);
+        Assert.Equal("01BX5ZZKBKACTAV9WEVGEMMVRZ", envelope.TenantId);
         Assert.Equal("project-ghi", envelope.ProjectId);
         Assert.Equal("production", envelope.Environment);
     }
@@ -259,7 +260,7 @@ public sealed class EnvelopeFactoryTests
         var timeProvider = new TestTimeProvider(FixedTime);
         var factory = new EnvelopeFactory(timeProvider);
         var gridContext = CreateTestGridContext(
-            tenantId: "original-tenant",
+            tenantId: "01ARYZ6S41TSV4RRFFQ69G5FAV",
             projectId: "original-project");
 
         var original = factory.CreateEnvelopeWithGridContext<EnvelopeFactoryTests>(
@@ -273,7 +274,7 @@ public sealed class EnvelopeFactoryTests
             new ReadOnlyMemory<byte>([4, 5, 6]));
 
         // Assert
-        Assert.Equal("original-tenant", reply.TenantId);
+        Assert.Equal("01ARYZ6S41TSV4RRFFQ69G5FAV", reply.TenantId);
         Assert.Equal("original-project", reply.ProjectId);
     }
 
@@ -290,7 +291,7 @@ public sealed class EnvelopeFactoryTests
             correlationId: "corr-123",
             nodeId: "node-789",
             studioId: "studio-abc",
-            tenantId: "tenant-def",
+            tenantId: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
             projectId: "project-ghi",
             environment: "production");
 
@@ -315,10 +316,10 @@ public sealed class EnvelopeFactoryTests
     }
 
     /// <summary>
-    /// Verifies CreateReply handles null TenantId and ProjectId in original envelope.
+    /// Verifies CreateReply propagates the Internal tenant sentinel and null project from the original envelope.
     /// </summary>
     [Fact]
-    public void CreateReply_HandlesNullTenantIdAndProjectIdInOriginal()
+    public void CreateReply_WithInternalTenantAndNullProjectInOriginal_PropagatesValues()
     {
         // Arrange
         var timeProvider = new TestTimeProvider(FixedTime);
@@ -338,7 +339,7 @@ public sealed class EnvelopeFactoryTests
             new ReadOnlyMemory<byte>([4, 5, 6]));
 
         // Assert
-        Assert.Null(reply.TenantId);
+        Assert.Equal(TenantId.Internal.ToString(), reply.TenantId);
         Assert.Null(reply.ProjectId);
     }
 
@@ -579,13 +580,20 @@ public sealed class EnvelopeFactoryTests
         context.CausationId.Returns(causationId);
         context.NodeId.Returns(nodeId);
         context.StudioId.Returns(studioId);
-        context.TenantId.Returns(tenantId);
+        context.TenantId.Returns(ParseTenantIdOrInternal(tenantId));
         context.ProjectId.Returns(projectId);
         context.Environment.Returns(environment);
         context.Baggage.Returns(baggage ?? []);
         context.CreatedAtUtc.Returns(FixedTime);
         context.IsInitialized.Returns(true);
         return context;
+    }
+
+    private static TenantId ParseTenantIdOrInternal(string? tenantId)
+    {
+        return tenantId is not null && TenantId.TryParse(tenantId, out var parsedTenantId)
+            ? parsedTenantId
+            : TenantId.Internal;
     }
 
     /// <summary>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Publishers/MessagePublisherTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Publishers/MessagePublisherTests.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.DependencyInjection;
 using HoneyDrunk.Transport.Primitives;
@@ -77,7 +78,7 @@ public sealed class MessagePublisherTests
             causationId: "cause-456",
             nodeId: "node-789",
             studioId: "studio-abc",
-            tenantId: "tenant-def",
+            tenantId: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
             projectId: "project-ghi",
             environment: "production");
 
@@ -91,7 +92,7 @@ public sealed class MessagePublisherTests
                 env.CausationId == "cause-456" &&
                 env.NodeId == "node-789" &&
                 env.StudioId == "studio-abc" &&
-                env.TenantId == "tenant-def" &&
+                env.TenantId == "01BX5ZZKBKACTAV9WEVGEMMVRZ" &&
                 env.ProjectId == "project-ghi" &&
                 env.Environment == "production"),
             Arg.Any<IEndpointAddress>(),
@@ -303,7 +304,7 @@ public sealed class MessagePublisherTests
         };
         var gridContext = CreateTestGridContext(
             correlationId: "shared-corr",
-            tenantId: "shared-tenant");
+            tenantId: "01ARYZ6S41YYYYYYYYYYYYYYYY");
 
         // Act
         await publisher.PublishBatchAsync("test-queue", messages, gridContext, CancellationToken.None);
@@ -313,7 +314,7 @@ public sealed class MessagePublisherTests
             Arg.Is<IEnumerable<ITransportEnvelope>>(envelopes =>
                 envelopes.All(env =>
                     env.CorrelationId == "shared-corr" &&
-                    env.TenantId == "shared-tenant")),
+                    env.TenantId == "01ARYZ6S41YYYYYYYYYYYYYYYY")),
             Arg.Any<IEndpointAddress>(),
             Arg.Any<CancellationToken>());
     }
@@ -479,7 +480,7 @@ public sealed class MessagePublisherTests
         string? causationId = "test-causation",
         string nodeId = "test-node",
         string studioId = "test-studio",
-        string? tenantId = "test-tenant",
+        string? tenantId = "01B7X6S41YYYYYYYYYYYYYYYY",
         string? projectId = "test-project",
         string environment = "test")
     {
@@ -488,13 +489,20 @@ public sealed class MessagePublisherTests
         context.CausationId.Returns(causationId);
         context.NodeId.Returns(nodeId);
         context.StudioId.Returns(studioId);
-        context.TenantId.Returns(tenantId);
+        context.TenantId.Returns(ParseTenantIdOrInternal(tenantId));
         context.ProjectId.Returns(projectId);
         context.Environment.Returns(environment);
         context.CreatedAtUtc.Returns(FixedTime);
         context.Baggage.Returns(new Dictionary<string, string>());
         context.IsInitialized.Returns(true);
         return context;
+    }
+
+    private static TenantId ParseTenantIdOrInternal(string? tenantId)
+    {
+        return tenantId is not null && TenantId.TryParse(tenantId, out var parsedTenantId)
+            ? parsedTenantId
+            : TenantId.Internal;
     }
 
     /// <summary>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to HoneyDrunk.Transport will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-04
+
+### Changed
+
+- **Kernel v0.5.0 Upgrade**: Transport now targets HoneyDrunk.Kernel v0.5.0.
+- **Typed TenantId Adoption**: `GridContextFactory.InitializeFromEnvelope()` now converts envelope `TenantId` strings to Kernel's typed `TenantId` primitive, defaults missing or malformed values to `TenantId.Internal`, and logs malformed values without throwing or leaking the raw tenant value.
+
 ## [0.4.0] - 2026-01-20
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
@@ -1,5 +1,7 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Abstractions;
+using Microsoft.Extensions.Logging;
 
 using KernelGridContext = HoneyDrunk.Kernel.Context.GridContext;
 
@@ -17,6 +19,17 @@ namespace HoneyDrunk.Transport.Context;
 /// </remarks>
 public sealed class GridContextFactory : IGridContextFactory
 {
+    private readonly ILogger<GridContextFactory>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GridContextFactory"/> class.
+    /// </summary>
+    /// <param name="logger">Optional logger used for non-fatal envelope metadata warnings.</param>
+    public GridContextFactory(ILogger<GridContextFactory>? logger = null)
+    {
+        _logger = logger;
+    }
+
     /// <inheritdoc/>
     public void InitializeFromEnvelope(
         IGridContext gridContext,
@@ -37,6 +50,7 @@ public sealed class GridContextFactory : IGridContextFactory
         // Use messageId as fallback for correlation and causation if not provided
         var correlationId = envelope.CorrelationId ?? envelope.MessageId;
         var causationId = envelope.CausationId ?? envelope.MessageId;
+        var tenantId = ParseTenantIdOrInternal(envelope.TenantId, envelope.MessageId);
 
         // Copy headers as baggage
         var baggage = envelope.Headers != null
@@ -47,9 +61,28 @@ public sealed class GridContextFactory : IGridContextFactory
         kernelContext.Initialize(
             correlationId: correlationId,
             causationId: causationId,
-            tenantId: envelope.TenantId,
+            tenantId: tenantId,
             projectId: envelope.ProjectId,
             baggage: baggage,
             cancellation: cancellationToken);
+    }
+
+    private TenantId ParseTenantIdOrInternal(string? value, string messageId)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return TenantId.Internal;
+        }
+
+        if (TenantId.TryParse(value, out var tenantId))
+        {
+            return tenantId;
+        }
+
+        _logger?.LogWarning(
+            "Malformed tenant id on transport envelope {MessageId}; using internal tenant.",
+            messageId);
+
+        return TenantId.Internal;
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Transport-agnostic messaging library for .NET. Provides a unified abstraction layer over different message brokers with middleware pipeline pattern, retry strategies, and transactional outbox support. Integrated with HoneyDrunk.Kernel for Grid-aware context propagation.</Description>
-    <PackageReleaseNotes>v0.4.0: Kernel vNext integration - Transport now initializes Kernel's DI-scoped IGridContext via IGridContextFactory.InitializeFromEnvelope(). Removed TransportGridContext and CorrelationMiddleware. Added fail-fast envelope validation.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Kernel vNext integration - Transport now initializes Kernel's DI-scoped IGridContext via IGridContextFactory.InitializeFromEnvelope(). Removed TransportGridContext and CorrelationMiddleware. Added fail-fast envelope validation.</PackageReleaseNotes>
     <PackageTags>messaging;transport;broker;middleware;pipeline;outbox;retry;servicebus;distributed;kernel;grid;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,9 +30,9 @@
 
   <ItemGroup>
     <!-- Core abstractions only - no runtime dependencies -->
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     <!-- Full Kernel for GridContext.Initialize() method needed by Kernel vNext integration -->
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- Adopt Kernel 0.5.0 typed `TenantId` in `GridContextFactory.InitializeFromEnvelope` while preserving Transport envelope/factory signatures.
- Default missing/malformed envelope tenants to `TenantId.Internal`; malformed values log a warning with only `{MessageId}` in the template and do not throw.
- Bump solution project/package versions and Kernel package references from 0.4.0 to 0.5.0.
- Update Transport changelogs and typed TenantId test coverage.

## Issue / packet
- Closes #22
- Packet: `generated/issue-packets/active/adr-0026-grid-multi-tenant-primitives/01b-transport-grid-context-factory-typed-adoption.md`

## Validation
- `dotnet restore HoneyDrunk.Transport /p:NuGetAudit=false`
- `dotnet build HoneyDrunk.Transport --no-restore /p:NuGetAudit=false`
- `dotnet test HoneyDrunk.Transport --no-build /p:NuGetAudit=false` — 381 passed

Note: plain restore hit NU1900 as warning-as-error for the private Azure Artifacts vulnerability feed; reran with `NuGetAudit=false` as the warnings are non-fatal for this change.