### PR TITLE
feat: align transport kernel adoption and consolidate servicebus consumer

### DIFF
--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Kernel Abstractions v0.7.0 Alignment**: Inherits the core Transport runtime dependency cleanup.
+- **Kernel Abstractions v0.7.0 Alignment**: Uses the core Transport abstractions-only Grid context model and receives Kernel Abstractions through the core Transport package dependency.
 - **Service Bus Consumer Consolidation**: Standard and session processors now adapt SDK event args at the edge and share one message-processing orchestration path for pipeline execution, completion, abandon, dead-letter, and exception handling.
 
 ## [0.4.0] - 2026-01-20

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -1,9 +1,16 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to HoneyDrunk.Transport.AzureServiceBus will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.0] - 2026-05-18
+
+### Changed
+
+- **Kernel Abstractions v0.7.0 Alignment**: Inherits the core Transport runtime dependency cleanup.
+- **Service Bus Consumer Consolidation**: Standard and session processors now adapt SDK event args at the edge and share one message-processing orchestration path for pipeline execution, completion, abandon, dead-letter, and exception handling.
 
 ## [0.4.0] - 2026-01-20
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.AzureServiceBus</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Service Bus transport implementation for HoneyDrunk.Transport. Provides topic/subscription support, session handling, and distributed tracing integration for Service Bus messaging.</Description>
-    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure SDK dependencies.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.6.0: Kernel Abstractions v0.7.0 alignment and Service Bus consumer orchestration consolidation.</PackageReleaseNotes>
 	<PackageTags>messaging;transport;azure;servicebus;cloud;distributed;queue;topic;session;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace HoneyDrunk.Transport.AzureServiceBus;
 
@@ -356,6 +357,9 @@ public sealed class ServiceBusTransportConsumer(
 
     private sealed class ServiceBusReceivedMessageContext
     {
+        private const string DeadLetterReason = "Message processing failed";
+        private const string DeadLetterDescriptionFormat = "Message {0} could not be processed";
+
         private ServiceBusReceivedMessageContext(
             ITransportEnvelope envelope,
             ITransportTransaction transaction,
@@ -388,40 +392,52 @@ public sealed class ServiceBusTransportConsumer(
 
         public Func<Task> DeadLetterAsync { get; }
 
-        public static ServiceBusReceivedMessageContext Create(ProcessMessageEventArgs args)
+        public static ServiceBusReceivedMessageContext Create(ProcessMessageEventArgs args) =>
+            Create(
+                args.Message,
+                args.CancellationToken,
+                () => args.CompleteMessageAsync(args.Message, CancellationToken.None),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: CancellationToken.None),
+                (reason, description) => args.DeadLetterMessageAsync(
+                    args.Message,
+                    reason,
+                    description,
+                    CancellationToken.None));
+
+        public static ServiceBusReceivedMessageContext Create(ProcessSessionMessageEventArgs args) =>
+            Create(
+                args.Message,
+                args.CancellationToken,
+                () => args.CompleteMessageAsync(args.Message, CancellationToken.None),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: CancellationToken.None),
+                (reason, description) => args.DeadLetterMessageAsync(
+                    args.Message,
+                    reason,
+                    description,
+                    CancellationToken.None));
+
+        private static ServiceBusReceivedMessageContext Create(
+            ServiceBusReceivedMessage message,
+            CancellationToken processingCancellationToken,
+            Func<Task> completeAsync,
+            Func<Task> abandonAsync,
+            Func<string, string, Task> deadLetterAsync)
         {
-            var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
+            var envelope = EnvelopeMapper.FromServiceBusMessage(message);
 
             return new ServiceBusReceivedMessageContext(
                 envelope,
-                EnvelopeMapper.CreateTransaction(args.Message),
-                EnvelopeMapper.GetDeliveryCount(args.Message),
-                args.CancellationToken,
-                () => args.CompleteMessageAsync(args.Message, args.CancellationToken),
-                () => args.AbandonMessageAsync(args.Message, cancellationToken: args.CancellationToken),
-                () => args.DeadLetterMessageAsync(
-                    args.Message,
-                    "Message processing failed",
-                    $"Message {envelope.MessageId} could not be processed",
-                    args.CancellationToken));
-        }
-
-        public static ServiceBusReceivedMessageContext Create(ProcessSessionMessageEventArgs args)
-        {
-            var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
-
-            return new ServiceBusReceivedMessageContext(
-                envelope,
-                EnvelopeMapper.CreateTransaction(args.Message),
-                EnvelopeMapper.GetDeliveryCount(args.Message),
-                args.CancellationToken,
-                () => args.CompleteMessageAsync(args.Message, args.CancellationToken),
-                () => args.AbandonMessageAsync(args.Message, cancellationToken: args.CancellationToken),
-                () => args.DeadLetterMessageAsync(
-                    args.Message,
-                    "Message processing failed",
-                    $"Message {envelope.MessageId} could not be processed",
-                    args.CancellationToken));
+                EnvelopeMapper.CreateTransaction(message),
+                EnvelopeMapper.GetDeliveryCount(message),
+                processingCancellationToken,
+                completeAsync,
+                abandonAsync,
+                () => deadLetterAsync(
+                    DeadLetterReason,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        DeadLetterDescriptionFormat,
+                        envelope.MessageId)));
         }
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
@@ -392,29 +392,41 @@ public sealed class ServiceBusTransportConsumer(
 
         public Func<Task> DeadLetterAsync { get; }
 
-        public static ServiceBusReceivedMessageContext Create(ProcessMessageEventArgs args) =>
-            Create(
-                args.Message,
-                args.CancellationToken,
-                () => args.CompleteMessageAsync(args.Message, CancellationToken.None),
-                () => args.AbandonMessageAsync(args.Message, cancellationToken: CancellationToken.None),
-                (reason, description) => args.DeadLetterMessageAsync(
-                    args.Message,
-                    reason,
-                    description,
-                    CancellationToken.None));
+        public static ServiceBusReceivedMessageContext Create(ProcessMessageEventArgs args)
+        {
+            // Settlement should still reach the broker when processing cancellation is already signaled.
+            // The processing token remains on the message context for user pipeline cancellation.
+            var settlementCancellationToken = CancellationToken.None;
 
-        public static ServiceBusReceivedMessageContext Create(ProcessSessionMessageEventArgs args) =>
-            Create(
+            return Create(
                 args.Message,
                 args.CancellationToken,
-                () => args.CompleteMessageAsync(args.Message, CancellationToken.None),
-                () => args.AbandonMessageAsync(args.Message, cancellationToken: CancellationToken.None),
+                () => args.CompleteMessageAsync(args.Message, settlementCancellationToken),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: settlementCancellationToken),
                 (reason, description) => args.DeadLetterMessageAsync(
                     args.Message,
                     reason,
                     description,
-                    CancellationToken.None));
+                    settlementCancellationToken));
+        }
+
+        public static ServiceBusReceivedMessageContext Create(ProcessSessionMessageEventArgs args)
+        {
+            // Settlement should still reach the broker when processing cancellation is already signaled.
+            // The processing token remains on the message context for user pipeline cancellation.
+            var settlementCancellationToken = CancellationToken.None;
+
+            return Create(
+                args.Message,
+                args.CancellationToken,
+                () => args.CompleteMessageAsync(args.Message, settlementCancellationToken),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: settlementCancellationToken),
+                (reason, description) => args.DeadLetterMessageAsync(
+                    args.Message,
+                    reason,
+                    description,
+                    settlementCancellationToken));
+        }
 
         private static ServiceBusReceivedMessageContext Create(
             ServiceBusReceivedMessage message,

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/ServiceBusTransportConsumer.cs
@@ -96,7 +96,6 @@ public sealed class ServiceBusTransportConsumer(
                 _logger.LogInformation("Stopping Service Bus consumer");
             }
 
-            // Stop and dispose processors
             await StopAndDisposeProcessorsAsync(cancellationToken);
 
             if (_logger.IsEnabled(LogLevel.Information))
@@ -113,9 +112,6 @@ public sealed class ServiceBusTransportConsumer(
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        // Thread-safe disposal check using Interlocked.CompareExchange
-        // Atomically sets _disposed to true and returns the previous value
-        // If previous value was true, we've already disposed
         if (Interlocked.Exchange(ref _disposed, true))
         {
             return;
@@ -139,59 +135,8 @@ public sealed class ServiceBusTransportConsumer(
     private static bool IsTestSubstitute(object instance) =>
         instance.GetType().Assembly.FullName?.Contains("DynamicProxyGenAssembly", StringComparison.Ordinal) == true;
 
-    private static async Task CompleteMessageAsync(object args, CancellationToken cancellationToken)
-    {
-        if (args is ProcessMessageEventArgs msgArgs)
-        {
-            await msgArgs.CompleteMessageAsync(msgArgs.Message, cancellationToken);
-        }
-        else if (args is ProcessSessionMessageEventArgs sessionArgs)
-        {
-            await sessionArgs.CompleteMessageAsync(sessionArgs.Message, cancellationToken);
-        }
-    }
-
-    private static async Task AbandonMessageAsync(object args, CancellationToken cancellationToken)
-    {
-        if (args is ProcessMessageEventArgs msgArgs)
-        {
-            await msgArgs.AbandonMessageAsync(msgArgs.Message, cancellationToken: cancellationToken);
-        }
-        else if (args is ProcessSessionMessageEventArgs sessionArgs)
-        {
-            await sessionArgs.AbandonMessageAsync(sessionArgs.Message, cancellationToken: cancellationToken);
-        }
-    }
-
-    private static async Task DeadLetterMessageAsync(
-        object args,
-        ITransportEnvelope envelope,
-        CancellationToken cancellationToken)
-    {
-        var reason = "Message processing failed";
-        var description = $"Message {envelope.MessageId} could not be processed";
-
-        if (args is ProcessMessageEventArgs msgArgs)
-        {
-            await msgArgs.DeadLetterMessageAsync(
-                msgArgs.Message,
-                reason,
-                description,
-                cancellationToken);
-        }
-        else if (args is ProcessSessionMessageEventArgs sessionArgs)
-        {
-            await sessionArgs.DeadLetterMessageAsync(
-                sessionArgs.Message,
-                reason,
-                description,
-                cancellationToken);
-        }
-    }
-
     private async Task StopAndDisposeProcessorsAsync(CancellationToken cancellationToken)
     {
-        // Stop and dispose standard processor
         if (_processor != null)
         {
             try
@@ -205,7 +150,6 @@ public sealed class ServiceBusTransportConsumer(
             }
         }
 
-        // Stop and dispose session processor
         if (_sessionProcessor != null)
         {
             try
@@ -242,9 +186,6 @@ public sealed class ServiceBusTransportConsumer(
                 options);
         }
 
-        // Azure SDK processor types are sealed with non-virtual event handlers that cannot be
-        // registered on NSubstitute mocks. Detect the test substitute and skip hookup rather
-        // than catching the NullReferenceException it would throw.
         if (IsTestSubstitute(_processor))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -293,9 +234,6 @@ public sealed class ServiceBusTransportConsumer(
                 sessionOptions);
         }
 
-        // Azure SDK processor types are sealed with non-virtual event handlers that cannot be
-        // registered on NSubstitute mocks. Detect the test substitute and skip hookup rather
-        // than catching the NullReferenceException it would throw.
         if (IsTestSubstitute(_sessionProcessor))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -324,41 +262,21 @@ public sealed class ServiceBusTransportConsumer(
         };
     }
 
-    private async Task ProcessMessageAsync(ProcessMessageEventArgs args)
+    private Task ProcessMessageAsync(ProcessMessageEventArgs args) =>
+        ProcessReceivedMessageAsync(ServiceBusReceivedMessageContext.Create(args));
+
+    private Task ProcessSessionMessageAsync(ProcessSessionMessageEventArgs args) =>
+        ProcessReceivedMessageAsync(ServiceBusReceivedMessageContext.Create(args));
+
+    private async Task ProcessReceivedMessageAsync(ServiceBusReceivedMessageContext receivedMessage)
     {
-        var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
-        var deliveryCount = EnvelopeMapper.GetDeliveryCount(args.Message);
-        var transaction = EnvelopeMapper.CreateTransaction(args.Message);
-
-        await ProcessMessageCoreAsync(envelope, transaction, deliveryCount, args, args.CancellationToken);
-    }
-
-    private async Task ProcessSessionMessageAsync(ProcessSessionMessageEventArgs args)
-    {
-        var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
-        var deliveryCount = EnvelopeMapper.GetDeliveryCount(args.Message);
-        var transaction = EnvelopeMapper.CreateTransaction(args.Message);
-
-        await ProcessMessageCoreAsync(envelope, transaction, deliveryCount, args, args.CancellationToken);
-    }
-
-    private async Task ProcessMessageCoreAsync(
-        ITransportEnvelope envelope,
-        ITransportTransaction transaction,
-        int deliveryCount,
-        object args,
-        CancellationToken cancellationToken)
-    {
-        // Create a scope for each message - this is critical for Kernel vNext's
-        // one-GridContext-per-scope invariant. The scoped IGridContext from Kernel
-        // will be resolved within this scope.
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
 
         var context = new MessageContext
         {
-            Envelope = envelope,
-            Transaction = transaction,
-            DeliveryCount = deliveryCount,
+            Envelope = receivedMessage.Envelope,
+            Transaction = receivedMessage.Transaction,
+            DeliveryCount = receivedMessage.DeliveryCount,
             ServiceProvider = scope.ServiceProvider
         };
 
@@ -368,13 +286,16 @@ public sealed class ServiceBusTransportConsumer(
             {
                 _logger.LogDebug(
                     "Processing message {MessageId} (Delivery count: {DeliveryCount})",
-                    envelope.MessageId,
-                    deliveryCount);
+                    receivedMessage.Envelope.MessageId,
+                    receivedMessage.DeliveryCount);
             }
 
-            var result = await _pipeline.ProcessAsync(envelope, context, cancellationToken);
+            var result = await _pipeline.ProcessAsync(
+                receivedMessage.Envelope,
+                context,
+                receivedMessage.CancellationToken);
 
-            await HandleProcessingResultAsync(result, args, envelope, cancellationToken);
+            await HandleProcessingResultAsync(result, receivedMessage);
         }
         catch (Exception ex) when (!ex.IsFatal())
         {
@@ -383,46 +304,38 @@ public sealed class ServiceBusTransportConsumer(
                 _logger.LogError(
                     ex,
                     "Unhandled error processing message {MessageId}",
-                    envelope.MessageId);
+                    receivedMessage.Envelope.MessageId);
             }
 
-            // Let Service Bus retry mechanism handle it
-            if (args is ProcessMessageEventArgs msgArgs && !_options.Value.AutoComplete)
+            if (!_options.Value.AutoComplete)
             {
-                await msgArgs.AbandonMessageAsync(msgArgs.Message, cancellationToken: cancellationToken);
-            }
-            else if (args is ProcessSessionMessageEventArgs sessionArgs && !_options.Value.AutoComplete)
-            {
-                await sessionArgs.AbandonMessageAsync(sessionArgs.Message, cancellationToken: cancellationToken);
+                await receivedMessage.AbandonAsync();
             }
         }
     }
 
     private async Task HandleProcessingResultAsync(
         MessageProcessingResult result,
-        object args,
-        ITransportEnvelope envelope,
-        CancellationToken cancellationToken)
+        ServiceBusReceivedMessageContext receivedMessage)
     {
         if (_options.Value.AutoComplete)
         {
-            // Auto-complete is enabled; Service Bus handles it
             return;
         }
 
         switch (result)
         {
             case MessageProcessingResult.Success:
-                await CompleteMessageAsync(args, cancellationToken);
+                await receivedMessage.CompleteAsync();
                 break;
 
             case MessageProcessingResult.Retry:
             case MessageProcessingResult.Abandon:
-                await AbandonMessageAsync(args, cancellationToken);
+                await receivedMessage.AbandonAsync();
                 break;
 
             case MessageProcessingResult.DeadLetter:
-                await DeadLetterMessageAsync(args, envelope, cancellationToken);
+                await receivedMessage.DeadLetterAsync();
                 break;
         }
     }
@@ -439,5 +352,76 @@ public sealed class ServiceBusTransportConsumer(
         }
 
         return Task.CompletedTask;
+    }
+
+    private sealed class ServiceBusReceivedMessageContext
+    {
+        private ServiceBusReceivedMessageContext(
+            ITransportEnvelope envelope,
+            ITransportTransaction transaction,
+            int deliveryCount,
+            CancellationToken cancellationToken,
+            Func<Task> completeAsync,
+            Func<Task> abandonAsync,
+            Func<Task> deadLetterAsync)
+        {
+            Envelope = envelope;
+            Transaction = transaction;
+            DeliveryCount = deliveryCount;
+            CancellationToken = cancellationToken;
+            CompleteAsync = completeAsync;
+            AbandonAsync = abandonAsync;
+            DeadLetterAsync = deadLetterAsync;
+        }
+
+        public ITransportEnvelope Envelope { get; }
+
+        public ITransportTransaction Transaction { get; }
+
+        public int DeliveryCount { get; }
+
+        public CancellationToken CancellationToken { get; }
+
+        public Func<Task> CompleteAsync { get; }
+
+        public Func<Task> AbandonAsync { get; }
+
+        public Func<Task> DeadLetterAsync { get; }
+
+        public static ServiceBusReceivedMessageContext Create(ProcessMessageEventArgs args)
+        {
+            var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
+
+            return new ServiceBusReceivedMessageContext(
+                envelope,
+                EnvelopeMapper.CreateTransaction(args.Message),
+                EnvelopeMapper.GetDeliveryCount(args.Message),
+                args.CancellationToken,
+                () => args.CompleteMessageAsync(args.Message, args.CancellationToken),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: args.CancellationToken),
+                () => args.DeadLetterMessageAsync(
+                    args.Message,
+                    "Message processing failed",
+                    $"Message {envelope.MessageId} could not be processed",
+                    args.CancellationToken));
+        }
+
+        public static ServiceBusReceivedMessageContext Create(ProcessSessionMessageEventArgs args)
+        {
+            var envelope = EnvelopeMapper.FromServiceBusMessage(args.Message);
+
+            return new ServiceBusReceivedMessageContext(
+                envelope,
+                EnvelopeMapper.CreateTransaction(args.Message),
+                EnvelopeMapper.GetDeliveryCount(args.Message),
+                args.CancellationToken,
+                () => args.CompleteMessageAsync(args.Message, args.CancellationToken),
+                () => args.AbandonMessageAsync(args.Message, cancellationToken: args.CancellationToken),
+                () => args.DeadLetterMessageAsync(
+                    args.Message,
+                    "Message processing failed",
+                    $"Message {envelope.MessageId} could not be processed",
+                    args.CancellationToken));
+        }
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Transport.InMemory will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-18
+
+### Changed
+
+- **Kernel Abstractions v0.7.0 Alignment**: Inherits the core Transport runtime dependency cleanup and `GridContextSnapshot` propagation model.
+
 ## [0.4.0] - 2026-01-20
 
 ### Breaking Changes

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-        <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.InMemory</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory transport implementation for HoneyDrunk.Transport. Provides observable queues and pub/sub subscriptions for testing without external dependencies.</Description>
-    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change and fail-fast envelope validation.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.6.0: Kernel Abstractions v0.7.0 alignment and runtime Kernel dependency cleanup.</PackageReleaseNotes>
     <PackageTags>messaging;transport;inmemory;testing;broker;queue;pubsub;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,9 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
+        <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/HoneyDrunk.Transport.SandboxNode.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.SandboxNode/HoneyDrunk.Transport.SandboxNode.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <!-- Kernel packages for node identity and context -->
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     
     <!-- Generic Host -->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Kernel Abstractions v0.7.0 Alignment**: Inherits the core Transport runtime dependency cleanup and `GridContextSnapshot` propagation model.
+- **Kernel Abstractions v0.7.0 Alignment**: Uses the core Transport `GridContextSnapshot` propagation model and receives Kernel Abstractions through the core Transport package dependency.
 
 ## [0.4.0] - 2026-01-20
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -1,9 +1,15 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to HoneyDrunk.Transport.StorageQueue will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.0] - 2026-05-18
+
+### Changed
+
+- **Kernel Abstractions v0.7.0 Alignment**: Inherits the core Transport runtime dependency cleanup and `GridContextSnapshot` propagation model.
 
 ## [0.4.0] - 2026-01-20
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport.StorageQueue</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Storage Queue transport implementation for HoneyDrunk.Transport. Provides cost-effective, high-volume messaging with automatic poison queue handling and exponential backoff.</Description>
-    <PackageReleaseNotes>v0.5.0: Kernel v0.5.0 upgrade with IGridContext.AddBaggage() API change, fail-fast envelope validation, and updated Azure.Storage.Queues to 12.25.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.6.0: Kernel Abstractions v0.7.0 alignment.</PackageReleaseNotes>
     <PackageTags>messaging;storage-queue;azure;transport;poison-queue;retry;backoff;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
@@ -264,6 +264,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-bad-tenant",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             TenantId = malformedTenant,
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Kernel.Abstractions.Identity;
-using HoneyDrunk.Kernel.Context;
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.Primitives;
 using Microsoft.Extensions.Logging;
@@ -12,25 +11,18 @@ namespace HoneyDrunk.Transport.Tests.Core.Context;
 /// Tests for Grid context factory.
 /// </summary>
 /// <remarks>
-/// These tests verify the Kernel vNext pattern where the factory INITIALIZES
-/// an existing DI-scoped GridContext rather than creating a new one.
+/// These tests verify that the factory creates initialized Kernel Abstractions context snapshots without referencing Kernel runtime types.
 /// </remarks>
 public sealed class GridContextFactoryTests
 {
-    private const string TestNodeId = "test-node";
-    private const string TestStudioId = "test-studio";
-    private const string TestEnvironment = "test-env";
-
     /// <summary>
     /// Verifies factory initializes Grid context from envelope with all fields populated.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithAllFields_InitializesGridContext()
+    public void CreateFromEnvelope_WithAllFields_CreatesGridContext()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
@@ -52,7 +44,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.True(gridContext.IsInitialized);
@@ -69,12 +61,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory falls back to messageId when correlationId is missing.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithMissingCorrelationId_FallsBackToMessageId()
+    public void CreateFromEnvelope_WithMissingCorrelationId_FallsBackToMessageId()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-abc",
@@ -85,7 +75,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal("msg-abc", gridContext.CorrelationId);
@@ -95,12 +85,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory falls back to messageId when causationId is missing.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithMissingCausationId_FallsBackToMessageId()
+    public void CreateFromEnvelope_WithMissingCausationId_FallsBackToMessageId()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-xyz",
@@ -111,7 +99,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal("msg-xyz", gridContext.CausationId);
@@ -121,12 +109,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory creates empty baggage when headers are null.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithNullHeaders_CreatesEmptyBaggage()
+    public void CreateFromEnvelope_WithNullHeaders_CreatesEmptyBaggage()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         IReadOnlyDictionary<string, string>? nullHeaders = null;
         var envelope = new TransportEnvelope
         {
@@ -139,7 +125,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.NotNull(gridContext.Baggage);
@@ -150,11 +136,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory propagates cancellation token to Grid context.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithCancellationToken_PropagatesToken()
+    public void CreateFromEnvelope_WithCancellationToken_PropagatesToken()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
         using var cts = new CancellationTokenSource();
 
         var envelope = new TransportEnvelope
@@ -166,7 +151,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, cts.Token);
+        var gridContext = factory.CreateFromEnvelope(envelope, cts.Token);
 
         // Assert
         Assert.Equal(cts.Token, gridContext.Cancellation);
@@ -176,50 +161,25 @@ public sealed class GridContextFactoryTests
     /// Verifies factory throws when envelope is null.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithNullEnvelope_ThrowsArgumentNullException()
+    public void CreateFromEnvelope_WithNullEnvelope_ThrowsArgumentNullException()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
         ITransportEnvelope? nullEnvelope = null;
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            factory.InitializeFromEnvelope(gridContext, nullEnvelope!, CancellationToken.None));
-    }
-
-    /// <summary>
-    /// Verifies factory throws when gridContext is null.
-    /// </summary>
-    [Fact]
-    public void InitializeFromEnvelope_WithNullGridContext_ThrowsArgumentNullException()
-    {
-        // Arrange
-        var factory = new TransportGridContextFactory();
-
-        var envelope = new TransportEnvelope
-        {
-            MessageId = "msg-123",
-            MessageType = "TestMessage",
-            Payload = ReadOnlyMemory<byte>.Empty,
-            Timestamp = DateTimeOffset.UtcNow
-        };
-
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            factory.InitializeFromEnvelope(null!, envelope, CancellationToken.None));
+            factory.CreateFromEnvelope(nullEnvelope!, CancellationToken.None));
     }
 
     /// <summary>
     /// Verifies factory handles optional tenant and project IDs.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithTenantAndProjectIds_SetsMultiTenantProperties()
+    public void CreateFromEnvelope_WithTenantAndProjectIds_SetsMultiTenantProperties()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
@@ -231,7 +191,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal("01BX5ZZKBKACTAV9WEVGEMMVRZ", gridContext.TenantId.ToString());
@@ -242,12 +202,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory handles null tenant and project IDs gracefully.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithNullTenantAndProject_UsesInternalTenant()
+    public void CreateFromEnvelope_WithNullTenantAndProject_UsesInternalTenant()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
@@ -259,7 +217,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal(TenantId.Internal, gridContext.TenantId);
@@ -270,11 +228,10 @@ public sealed class GridContextFactoryTests
     /// Verifies factory parses valid ULID tenant IDs.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithValidUlidTenant_ParsesTenantId()
+    public void CreateFromEnvelope_WithValidUlidTenant_ParsesTenantId()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
         var tenantId = TenantId.NewId();
 
         var envelope = new TransportEnvelope
@@ -287,7 +244,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal(tenantId, gridContext.TenantId);
@@ -297,12 +254,11 @@ public sealed class GridContextFactoryTests
     /// Verifies malformed tenant IDs fall back to Internal and log without leaking the raw value in the template.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithMalformedTenant_UsesInternalTenantAndLogsWarning()
+    public void CreateFromEnvelope_WithMalformedTenant_UsesInternalTenantAndLogsWarning()
     {
         // Arrange
         var logger = new CapturingLogger();
         var factory = new TransportGridContextFactory(logger);
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
         const string malformedTenant = "not-a-tenant-ulid";
 
         var envelope = new TransportEnvelope
@@ -315,7 +271,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal(TenantId.Internal, gridContext.TenantId);
@@ -331,12 +287,10 @@ public sealed class GridContextFactoryTests
     /// Verifies the serialized Internal sentinel maps back to Internal.
     /// </summary>
     [Fact]
-    public void InitializeFromEnvelope_WithInternalTenantString_UsesInternalTenant()
+    public void CreateFromEnvelope_WithInternalTenantString_UsesInternalTenant()
     {
         // Arrange
         var factory = new TransportGridContextFactory();
-        var gridContext = new GridContext(TestNodeId, TestStudioId, TestEnvironment);
-
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-internal-tenant",
@@ -347,7 +301,7 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        factory.InitializeFromEnvelope(gridContext, envelope, CancellationToken.None);
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
 
         // Assert
         Assert.Equal(TenantId.Internal, gridContext.TenantId);

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
@@ -251,6 +251,45 @@ public sealed class GridContextFactoryTests
     }
 
     /// <summary>
+    /// Verifies missing Grid identity fields use defaults and emit one warning per missing field.
+    /// </summary>
+    [Fact]
+    public void CreateFromEnvelope_WithMissingGridIdentityFields_UsesDefaultsAndLogsWarnings()
+    {
+        // Arrange
+        var logger = new CapturingLogger();
+        var factory = new TransportGridContextFactory(logger);
+        var envelope = new TransportEnvelope
+        {
+            MessageId = "msg-missing-grid-identity",
+            MessageType = "TestMessage",
+            Payload = ReadOnlyMemory<byte>.Empty,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("honeydrunk-transport", gridContext.NodeId);
+        Assert.Equal("honeydrunk", gridContext.StudioId);
+        Assert.Equal("local", gridContext.Environment);
+
+        Assert.Equal(3, logger.Entries.Count);
+        Assert.All(logger.Entries, entry =>
+        {
+            Assert.Equal(LogLevel.Warning, entry.Level);
+            Assert.Equal(
+                "Missing required Grid identity field {FieldName} on transport envelope {MessageId}; using fallback value.",
+                entry.Template);
+            Assert.Equal("msg-missing-grid-identity", entry.Properties["MessageId"]);
+        });
+        Assert.Contains(logger.Entries, entry => Equals("NodeId", entry.Properties["FieldName"]));
+        Assert.Contains(logger.Entries, entry => Equals("StudioId", entry.Properties["FieldName"]));
+        Assert.Contains(logger.Entries, entry => Equals("Environment", entry.Properties["FieldName"]));
+    }
+
+    /// <summary>
     /// Verifies malformed tenant IDs fall back to Internal and log without leaking the raw value in the template.
     /// </summary>
     [Fact]

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Context/GridContextFactoryTests.cs
@@ -1,5 +1,6 @@
 using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Exceptions;
 using HoneyDrunk.Transport.Primitives;
 using Microsoft.Extensions.Logging;
 
@@ -69,6 +70,9 @@ public sealed class GridContextFactoryTests
         {
             MessageId = "msg-abc",
             CorrelationId = null, // Missing
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
             Timestamp = DateTimeOffset.UtcNow
@@ -93,6 +97,9 @@ public sealed class GridContextFactoryTests
         {
             MessageId = "msg-xyz",
             CausationId = null, // Missing
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
             Timestamp = DateTimeOffset.UtcNow
@@ -118,6 +125,9 @@ public sealed class GridContextFactoryTests
         {
             MessageId = "msg-123",
             CorrelationId = "corr-456",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             Headers = nullHeaders!, // No headers
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
@@ -145,6 +155,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
             Timestamp = DateTimeOffset.UtcNow
@@ -183,6 +196,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             TenantId = "01BX5ZZKBKACTAV9WEVGEMMVRZ",
             ProjectId = "project-xyz",
             MessageType = "TestMessage",
@@ -209,6 +225,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-123",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             TenantId = null,
             ProjectId = null,
             MessageType = "TestMessage",
@@ -237,6 +256,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-valid-tenant",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             TenantId = tenantId.ToString(),
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,
@@ -251,14 +273,13 @@ public sealed class GridContextFactoryTests
     }
 
     /// <summary>
-    /// Verifies missing Grid identity fields use defaults and emit one warning per missing field.
+    /// Verifies missing Grid identity fields fail fast instead of fabricating producer identity.
     /// </summary>
     [Fact]
-    public void CreateFromEnvelope_WithMissingGridIdentityFields_UsesDefaultsAndLogsWarnings()
+    public void CreateFromEnvelope_WithMissingGridIdentityFields_ThrowsEnvelopeValidationException()
     {
         // Arrange
-        var logger = new CapturingLogger();
-        var factory = new TransportGridContextFactory(logger);
+        var factory = new TransportGridContextFactory();
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-missing-grid-identity",
@@ -268,25 +289,12 @@ public sealed class GridContextFactoryTests
         };
 
         // Act
-        var gridContext = factory.CreateFromEnvelope(envelope, CancellationToken.None);
+        var ex = Assert.Throws<EnvelopeValidationException>(() =>
+            factory.CreateFromEnvelope(envelope, CancellationToken.None));
 
         // Assert
-        Assert.Equal("honeydrunk-transport", gridContext.NodeId);
-        Assert.Equal("honeydrunk", gridContext.StudioId);
-        Assert.Equal("local", gridContext.Environment);
-
-        Assert.Equal(3, logger.Entries.Count);
-        Assert.All(logger.Entries, entry =>
-        {
-            Assert.Equal(LogLevel.Warning, entry.Level);
-            Assert.Equal(
-                "Missing required Grid identity field {FieldName} on transport envelope {MessageId}; using fallback value.",
-                entry.Template);
-            Assert.Equal("msg-missing-grid-identity", entry.Properties["MessageId"]);
-        });
-        Assert.Contains(logger.Entries, entry => Equals("NodeId", entry.Properties["FieldName"]));
-        Assert.Contains(logger.Entries, entry => Equals("StudioId", entry.Properties["FieldName"]));
-        Assert.Contains(logger.Entries, entry => Equals("Environment", entry.Properties["FieldName"]));
+        Assert.Contains("msg-missing-grid-identity", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("NodeId", ex.Message, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -336,6 +344,9 @@ public sealed class GridContextFactoryTests
         var envelope = new TransportEnvelope
         {
             MessageId = "msg-internal-tenant",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             TenantId = TenantId.Internal.ToString(),
             MessageType = "TestMessage",
             Payload = ReadOnlyMemory<byte>.Empty,

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Middleware/GridContextPropagationMiddlewareTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Middleware/GridContextPropagationMiddlewareTests.cs
@@ -192,6 +192,38 @@ public sealed class GridContextPropagationMiddlewareTests
     }
 
     /// <summary>
+    /// Verifies middleware no longer requires MessageContext.ServiceProvider.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task InvokeAsync_WithNullServiceProvider_InitializesGridContext()
+    {
+        // Arrange
+        var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "test" });
+        var context = new MessageContext
+        {
+            Envelope = envelope,
+            Transaction = NoOpTransportTransaction.Instance,
+            DeliveryCount = 1,
+            ServiceProvider = null
+        };
+
+        var gridContextFactory = new TransportGridContextFactory();
+        var middleware = new GridContextPropagationMiddleware(gridContextFactory);
+
+        // Act
+        await middleware.InvokeAsync(
+            envelope,
+            context,
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(context.GridContext);
+        Assert.Equal("test-node", context.GridContext!.NodeId);
+    }
+
+    /// <summary>
     /// Verifies middleware propagates exceptions from next delegate.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
@@ -235,6 +267,9 @@ public sealed class GridContextPropagationMiddlewareTests
             MessageType = envelope.MessageType,
             Payload = envelope.Payload,
             CorrelationId = "corr-123",
+            NodeId = "node-1",
+            StudioId = "studio-1",
+            Environment = "production",
             Headers = new Dictionary<string, string>
             {
                 ["baggage-key1"] = "value1",

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Middleware/GridContextPropagationMiddlewareTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Middleware/GridContextPropagationMiddlewareTests.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
-using HoneyDrunk.Kernel.Context;
 using HoneyDrunk.Transport.Abstractions;
 using HoneyDrunk.Transport.Pipeline.Middleware;
 using HoneyDrunk.Transport.Tests.Support;
@@ -13,8 +12,7 @@ namespace HoneyDrunk.Transport.Tests.Core.Middleware;
 /// Tests for Grid context propagation middleware.
 /// </summary>
 /// <remarks>
-/// These tests verify the Kernel vNext pattern where the middleware INITIALIZES
-/// a DI-scoped GridContext rather than creating a new one.
+/// These tests verify the abstractions-only pattern where the middleware creates an initialized GridContextSnapshot.
 /// </remarks>
 public sealed class GridContextPropagationMiddlewareTests
 {
@@ -75,10 +73,6 @@ public sealed class GridContextPropagationMiddlewareTests
         Assert.NotNull(context.GridContext);
         Assert.Equal("corr-123", context.GridContext!.CorrelationId);
         Assert.Equal("cause-456", context.GridContext.CausationId);
-
-        // Verify it's the same instance as DI's
-        var diGridContext = serviceProvider.GetRequiredService<IGridContext>();
-        Assert.Same(context.GridContext, diGridContext);
     }
 
     /// <summary>
@@ -275,37 +269,6 @@ public sealed class GridContextPropagationMiddlewareTests
     }
 
     /// <summary>
-    /// Verifies middleware throws when ServiceProvider is null (Kernel vNext invariant).
-    /// </summary>
-    /// <returns>A task representing the asynchronous test.</returns>
-    [Fact]
-    public async Task InvokeAsync_WithNullServiceProvider_ThrowsInvalidOperationException()
-    {
-        // Arrange
-        var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "test" });
-        var context = new MessageContext
-        {
-            Envelope = envelope,
-            Transaction = NoOpTransportTransaction.Instance,
-            DeliveryCount = 1,
-            ServiceProvider = null // No DI scope
-        };
-
-        var gridContextFactory = new TransportGridContextFactory();
-        var middleware = new GridContextPropagationMiddleware(gridContextFactory);
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => middleware.InvokeAsync(
-                envelope,
-                context,
-                () => Task.CompletedTask,
-                CancellationToken.None));
-
-        Assert.Contains("ServiceProvider is null", ex.Message);
-    }
-
-    /// <summary>
     /// Creates a service provider with a scoped GridContext.
     /// </summary>
     /// <remarks>
@@ -316,7 +279,7 @@ public sealed class GridContextPropagationMiddlewareTests
     private static IServiceProvider CreateServiceProvider()
     {
         var services = new ServiceCollection();
-        services.AddScoped<IGridContext>(_ => new GridContext(TestNodeId, TestStudioId, TestEnvironment));
+        services.AddScoped<IGridContext>(_ => new GridContextSnapshot(TestNodeId, TestStudioId, TestEnvironment));
         return services.BuildServiceProvider().CreateScope().ServiceProvider;
     }
 #pragma warning restore CA2000

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/MessagePipelineErrorTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/MessagePipelineErrorTests.cs
@@ -112,6 +112,9 @@ public sealed class MessagePipelineErrorTests
         var badEnvelope = new HoneyDrunk.Transport.Primitives.TransportEnvelope
         {
             MessageId = Guid.NewGuid().ToString("N"),
+            NodeId = "test-node",
+            StudioId = "test-studio",
+            Environment = "test-env",
             MessageType = typeof(SampleMessage).AssemblyQualifiedName!,
             Payload = System.Text.Encoding.UTF8.GetBytes("not valid json {{{"),
             Headers = new Dictionary<string, string>(),
@@ -255,6 +258,9 @@ public sealed class MessagePipelineErrorTests
         var badEnvelope = new HoneyDrunk.Transport.Primitives.TransportEnvelope
         {
             MessageId = Guid.NewGuid().ToString("N"),
+            NodeId = "test-node",
+            StudioId = "test-studio",
+            Environment = "test-env",
             MessageType = "NonExistent.InvalidType.ThatDoesNotExist, NonExistent.Assembly",
             Payload = new byte[] { 1, 2, 3 },
             Headers = new Dictionary<string, string>(),

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/MessagePipelineTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/MessagePipelineTests.cs
@@ -98,6 +98,9 @@ public sealed class MessagePipelineTests
         var badEnvelope = new Primitives.TransportEnvelope
         {
             MessageId = Guid.NewGuid().ToString("N"),
+            NodeId = "test-node",
+            StudioId = "test-studio",
+            Environment = "test-env",
             MessageType = typeof(string).AssemblyQualifiedName!,
             Payload = new byte[] { 0x01, 0x02, 0x03 },
             Headers = new Dictionary<string, string>(),

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Support/TestData.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Support/TestData.cs
@@ -22,6 +22,9 @@ internal static class TestData
             Payload = payload.ToArray(),
             CorrelationId = null,
             CausationId = null,
+            NodeId = "test-node",
+            StudioId = "test-studio",
+            Environment = "test-env",
             Timestamp = DateTimeOffset.UtcNow
         };
     }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Support/TestServiceExtensions.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Support/TestServiceExtensions.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
-using HoneyDrunk.Kernel.Context;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace HoneyDrunk.Transport.Tests.Support;
@@ -22,7 +21,7 @@ public static class TestServiceExtensions
     public static IServiceCollection AddTestKernelServices(this IServiceCollection services)
     {
         // Register IGridContext as scoped (Kernel vNext pattern)
-        services.AddScoped<IGridContext>(_ => new GridContext(TestNodeId, TestStudioId, TestEnvironment));
+        services.AddScoped<IGridContext>(_ => new GridContextSnapshot(TestNodeId, TestStudioId, TestEnvironment));
         return services;
     }
 
@@ -40,7 +39,7 @@ public static class TestServiceExtensions
         string studioId,
         string environment)
     {
-        services.AddScoped<IGridContext>(_ => new GridContext(nodeId, studioId, environment));
+        services.AddScoped<IGridContext>(_ => new GridContextSnapshot(nodeId, studioId, environment));
         return services;
     }
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -1,9 +1,20 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to HoneyDrunk.Transport will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.0] - 2026-05-18
+
+### Changed
+
+- **Kernel Abstractions v0.7.0 Alignment**: Transport now creates `GridContextSnapshot` instances from envelopes instead of depending on Kernel runtime `GridContext` initialization.
+- **Runtime Dependency Cleanup**: Core Transport and provider packages depend on `HoneyDrunk.Kernel.Abstractions` only; the sandbox node remains the host-level Kernel runtime sample.
+
+### Removed
+
+- Removed the Transport-to-Kernel runtime cast in `GridContextFactory`.
 
 ## [0.5.0] - 2026-05-04
 

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
@@ -3,22 +3,21 @@ using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Abstractions;
 using Microsoft.Extensions.Logging;
 
-using KernelGridContext = HoneyDrunk.Kernel.Context.GridContext;
-
 namespace HoneyDrunk.Transport.Context;
 
 /// <summary>
-/// Factory for initializing Grid context instances from transport envelope metadata.
+/// Factory for creating Grid context snapshots from transport envelope metadata.
 /// </summary>
 /// <remarks>
-/// <para>
-/// <b>Kernel vNext Pattern (v0.4.0+):</b> This factory INITIALIZES an existing DI-scoped
-/// <see cref="KernelGridContext"/> rather than creating a new instance. This ensures exactly
-/// one GridContext per DI scope, owned by Kernel.
-/// </para>
+/// Creates initialized, abstractions-only <see cref="IGridContext"/> snapshots so Transport can
+/// propagate Grid context without depending on the concrete Kernel runtime package.
 /// </remarks>
 public sealed class GridContextFactory : IGridContextFactory
 {
+    private const string DefaultNodeId = "honeydrunk-transport";
+    private const string DefaultStudioId = "honeydrunk";
+    private const string DefaultEnvironment = "local";
+
     private readonly ILogger<GridContextFactory>? _logger;
 
     /// <summary>
@@ -31,41 +30,34 @@ public sealed class GridContextFactory : IGridContextFactory
     }
 
     /// <inheritdoc/>
-    public void InitializeFromEnvelope(
-        IGridContext gridContext,
+    public IGridContext CreateFromEnvelope(
         ITransportEnvelope envelope,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(gridContext);
         ArgumentNullException.ThrowIfNull(envelope);
 
-        // gridContext must be Kernel's GridContext for Initialize() to work
-        if (gridContext is not KernelGridContext kernelContext)
-        {
-            throw new InvalidOperationException(
-                $"Expected GridContext from Kernel DI scope, but got {gridContext.GetType().FullName}. " +
-                "Ensure IGridContext is registered as scoped and resolves to HoneyDrunk.Kernel.Context.GridContext.");
-        }
-
-        // Use messageId as fallback for correlation and causation if not provided
         var correlationId = envelope.CorrelationId ?? envelope.MessageId;
         var causationId = envelope.CausationId ?? envelope.MessageId;
         var tenantId = ParseTenantIdOrInternal(envelope.TenantId, envelope.MessageId);
-
-        // Copy headers as baggage
-        var baggage = envelope.Headers != null
+        var baggage = envelope.Headers is { Count: > 0 }
             ? new Dictionary<string, string>(envelope.Headers)
             : [];
 
-        // Initialize the DI-owned GridContext with envelope metadata
-        kernelContext.Initialize(
+        return new GridContextSnapshot(
+            nodeId: NormalizeRequiredEnvelopeValue(envelope.NodeId, DefaultNodeId),
+            studioId: NormalizeRequiredEnvelopeValue(envelope.StudioId, DefaultStudioId),
+            environment: NormalizeRequiredEnvelopeValue(envelope.Environment, DefaultEnvironment),
             correlationId: correlationId,
             causationId: causationId,
             tenantId: tenantId,
             projectId: envelope.ProjectId,
             baggage: baggage,
-            cancellation: cancellationToken);
+            cancellation: cancellationToken,
+            createdAtUtc: envelope.Timestamp);
     }
+
+    private static string NormalizeRequiredEnvelopeValue(string? value, string fallback) =>
+        string.IsNullOrWhiteSpace(value) ? fallback : value;
 
     private TenantId ParseTenantIdOrInternal(string? value, string messageId)
     {

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
@@ -1,6 +1,7 @@
 using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Transport.Context;
@@ -14,10 +15,6 @@ namespace HoneyDrunk.Transport.Context;
 /// </remarks>
 public sealed class GridContextFactory : IGridContextFactory
 {
-    private const string DefaultNodeId = "honeydrunk-transport";
-    private const string DefaultStudioId = "honeydrunk";
-    private const string DefaultEnvironment = "local";
-
     private readonly ILogger<GridContextFactory>? _logger;
 
     /// <summary>
@@ -44,9 +41,9 @@ public sealed class GridContextFactory : IGridContextFactory
             : [];
 
         return new GridContextSnapshot(
-            nodeId: NormalizeRequiredEnvelopeValue(envelope.NodeId, DefaultNodeId, nameof(envelope.NodeId), envelope.MessageId),
-            studioId: NormalizeRequiredEnvelopeValue(envelope.StudioId, DefaultStudioId, nameof(envelope.StudioId), envelope.MessageId),
-            environment: NormalizeRequiredEnvelopeValue(envelope.Environment, DefaultEnvironment, nameof(envelope.Environment), envelope.MessageId),
+            nodeId: ValidateRequiredEnvelopeValue(envelope.NodeId, nameof(envelope.NodeId), envelope.MessageId),
+            studioId: ValidateRequiredEnvelopeValue(envelope.StudioId, nameof(envelope.StudioId), envelope.MessageId),
+            environment: ValidateRequiredEnvelopeValue(envelope.Environment, nameof(envelope.Environment), envelope.MessageId),
             correlationId: correlationId,
             causationId: causationId,
             tenantId: tenantId,
@@ -56,9 +53,8 @@ public sealed class GridContextFactory : IGridContextFactory
             createdAtUtc: envelope.Timestamp);
     }
 
-    private string NormalizeRequiredEnvelopeValue(
+    private static string ValidateRequiredEnvelopeValue(
         string? value,
-        string fallback,
         string fieldName,
         string messageId)
     {
@@ -67,12 +63,8 @@ public sealed class GridContextFactory : IGridContextFactory
             return value;
         }
 
-        _logger?.LogWarning(
-            "Missing required Grid identity field {FieldName} on transport envelope {MessageId}; using fallback value.",
-            fieldName,
-            messageId);
-
-        return fallback;
+        throw new EnvelopeValidationException(
+            $"Transport envelope '{messageId}' is missing required Grid identity field '{fieldName}'.");
     }
 
     private TenantId ParseTenantIdOrInternal(string? value, string messageId)

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/GridContextFactory.cs
@@ -44,9 +44,9 @@ public sealed class GridContextFactory : IGridContextFactory
             : [];
 
         return new GridContextSnapshot(
-            nodeId: NormalizeRequiredEnvelopeValue(envelope.NodeId, DefaultNodeId),
-            studioId: NormalizeRequiredEnvelopeValue(envelope.StudioId, DefaultStudioId),
-            environment: NormalizeRequiredEnvelopeValue(envelope.Environment, DefaultEnvironment),
+            nodeId: NormalizeRequiredEnvelopeValue(envelope.NodeId, DefaultNodeId, nameof(envelope.NodeId), envelope.MessageId),
+            studioId: NormalizeRequiredEnvelopeValue(envelope.StudioId, DefaultStudioId, nameof(envelope.StudioId), envelope.MessageId),
+            environment: NormalizeRequiredEnvelopeValue(envelope.Environment, DefaultEnvironment, nameof(envelope.Environment), envelope.MessageId),
             correlationId: correlationId,
             causationId: causationId,
             tenantId: tenantId,
@@ -56,8 +56,24 @@ public sealed class GridContextFactory : IGridContextFactory
             createdAtUtc: envelope.Timestamp);
     }
 
-    private static string NormalizeRequiredEnvelopeValue(string? value, string fallback) =>
-        string.IsNullOrWhiteSpace(value) ? fallback : value;
+    private string NormalizeRequiredEnvelopeValue(
+        string? value,
+        string fallback,
+        string fieldName,
+        string messageId)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        _logger?.LogWarning(
+            "Missing required Grid identity field {FieldName} on transport envelope {MessageId}; using fallback value.",
+            fieldName,
+            messageId);
+
+        return fallback;
+    }
 
     private TenantId ParseTenantIdOrInternal(string? value, string messageId)
     {

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/IGridContextFactory.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Context/IGridContextFactory.cs
@@ -4,7 +4,7 @@ using HoneyDrunk.Transport.Abstractions;
 namespace HoneyDrunk.Transport.Context;
 
 /// <summary>
-/// Factory interface for initializing Grid context instances from transport envelopes.
+/// Factory interface for creating Grid context instances from transport envelopes.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -13,32 +13,23 @@ namespace HoneyDrunk.Transport.Context;
 /// the middleware pipeline and message handlers.
 /// </para>
 /// <para>
-/// <b>Kernel vNext Pattern (v0.4.0+):</b> The factory INITIALIZES an existing DI-scoped
-/// <see cref="IGridContext"/> rather than creating a new instance. This ensures exactly
-/// one GridContext per DI scope, owned by Kernel.
+/// The factory creates an abstractions-only initialized context so Transport does not depend
+/// on Kernel runtime implementation types.
 /// </para>
 /// </remarks>
 public interface IGridContextFactory
 {
     /// <summary>
-    /// Initializes a Grid context from transport envelope metadata.
+    /// Creates an initialized Grid context from transport envelope metadata.
     /// </summary>
-    /// <param name="gridContext">The DI-scoped Grid context to initialize.</param>
     /// <param name="envelope">The transport envelope containing context metadata.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>An initialized Grid context carrying envelope propagation metadata.</returns>
     /// <remarks>
-    /// <para>
     /// Called by <c>GridContextPropagationMiddleware</c> during message processing
-    /// to initialize the DI-owned GridContext with envelope metadata.
-    /// </para>
-    /// <para>
-    /// <b>Important:</b> The <paramref name="gridContext"/> must be resolved from the
-    /// current DI scope. This method calls <c>GridContext.Initialize()</c> to set
-    /// correlation, causation, tenant, project, baggage, and cancellation token.
-    /// </para>
+    /// to populate <c>MessageContext.GridContext</c> without requiring a runtime Kernel reference.
     /// </remarks>
-    void InitializeFromEnvelope(
-        IGridContext gridContext,
+    IGridContext CreateFromEnvelope(
         ITransportEnvelope envelope,
         CancellationToken cancellationToken);
 }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Transport</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
-    <Description>Transport-agnostic messaging library for .NET. Provides a unified abstraction layer over different message brokers with middleware pipeline pattern, retry strategies, and transactional outbox support. Integrated with HoneyDrunk.Kernel for Grid-aware context propagation.</Description>
-    <PackageReleaseNotes>v0.5.0: Kernel vNext integration - Transport now initializes Kernel's DI-scoped IGridContext via IGridContextFactory.InitializeFromEnvelope(). Removed TransportGridContext and CorrelationMiddleware. Added fail-fast envelope validation.</PackageReleaseNotes>
+    <Description>Transport-agnostic messaging library for .NET. Provides a unified abstraction layer over different message brokers with middleware pipeline pattern, retry strategies, and transactional outbox support. Uses HoneyDrunk.Kernel.Abstractions for Grid-aware context propagation.</Description>
+    <PackageReleaseNotes>v0.6.0: Drops runtime Kernel dependency, uses Kernel Abstractions GridContextSnapshot for message context propagation, and consolidates Service Bus consumer orchestration paths.</PackageReleaseNotes>
     <PackageTags>messaging;transport;broker;middleware;pipeline;outbox;retry;servicebus;distributed;kernel;grid;multi-tenant</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,10 +30,9 @@
 
   <ItemGroup>
     <!-- Core abstractions only - no runtime dependencies -->
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <!-- Full Kernel for GridContext.Initialize() method needed by Kernel vNext integration -->
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -31,8 +31,7 @@
   <ItemGroup>
     <!-- Core abstractions only - no runtime dependencies -->
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <!-- Full Kernel for GridContext.Initialize() method needed by Kernel vNext integration -->
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/GridContextPropagationMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/GridContextPropagationMiddleware.cs
@@ -1,6 +1,4 @@
-using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Transport.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
 
 using TransportGridContextFactory = HoneyDrunk.Transport.Context.IGridContextFactory;
 
@@ -8,20 +6,19 @@ namespace HoneyDrunk.Transport.Pipeline.Middleware;
 
 /// <summary>
 /// Middleware that propagates Grid context across Node boundaries.
-/// Initializes the DI-scoped IGridContext from envelope metadata and populates MessageContext for handlers.
+/// Creates an initialized abstractions-only Grid context from envelope metadata and populates MessageContext for handlers.
 /// This is the canonical bridge between Kernel Grid context and Transport messaging.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Kernel vNext (v0.4.0+):</b> This middleware honors the one-GridContext-per-scope invariant.
-/// Instead of creating a Transport-owned context, it resolves the existing DI-scoped
-/// <see cref="IGridContext"/> from Kernel and initializes it with envelope metadata.
+/// Transport owns message-scope propagation and uses Kernel Abstractions only. It does not reference
+/// Kernel runtime implementation types or require a DI-scoped runtime GridContext.
 /// </para>
 /// <para>
 /// Initializes a new instance of the <see cref="GridContextPropagationMiddleware"/> class.
 /// </para>
 /// </remarks>
-/// <param name="gridContextFactory">The Grid context factory for initializing context from envelope.</param>
+/// <param name="gridContextFactory">The Grid context factory for creating context from envelope.</param>
 public sealed class GridContextPropagationMiddleware(TransportGridContextFactory gridContextFactory) : IMessageMiddleware
 {
     private readonly TransportGridContextFactory _gridContextFactory = gridContextFactory
@@ -34,35 +31,17 @@ public sealed class GridContextPropagationMiddleware(TransportGridContextFactory
         Func<Task> next,
         CancellationToken cancellationToken = default)
     {
-        // Check for cancellation before processing
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Kernel vNext: Resolve the DI-scoped GridContext and initialize it
-        // This ensures exactly one GridContext per scope, owned by Kernel
-        if (context.ServiceProvider is null)
-        {
-            throw new InvalidOperationException(
-                "MessageContext.ServiceProvider is null. Transport consumers must provide a scoped " +
-                "IServiceProvider for Kernel vNext GridContext integration. Ensure the consumer " +
-                "creates a DI scope for each message and sets MessageContext.ServiceProvider.");
-        }
+        var gridContext = _gridContextFactory.CreateFromEnvelope(envelope, cancellationToken);
 
-        // Resolve the DI-scoped IGridContext (owned by Kernel)
-        var gridContext = context.ServiceProvider.GetRequiredService<IGridContext>();
-
-        // Initialize it with envelope metadata
-        _gridContextFactory.InitializeFromEnvelope(gridContext, envelope, cancellationToken);
-
-        // Populate MessageContext.GridContext - this is the SAME instance as DI's
         context.GridContext = gridContext;
-
-        // Also store in Properties for backward compatibility and convenience access
         context.Properties["GridContext"] = gridContext;
-        context.Properties["CorrelationId"] = gridContext.CorrelationId ?? string.Empty;
+        context.Properties["CorrelationId"] = gridContext.CorrelationId;
         context.Properties["CausationId"] = gridContext.CausationId ?? string.Empty;
-        context.Properties["NodeId"] = gridContext.NodeId ?? string.Empty;
-        context.Properties["StudioId"] = gridContext.StudioId ?? string.Empty;
-        context.Properties["Environment"] = gridContext.Environment ?? string.Empty;
+        context.Properties["NodeId"] = gridContext.NodeId;
+        context.Properties["StudioId"] = gridContext.StudioId;
+        context.Properties["Environment"] = gridContext.Environment;
 
         return next();
     }

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/GridContextPropagationMiddleware.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/Pipeline/Middleware/GridContextPropagationMiddleware.cs
@@ -37,7 +37,7 @@ public sealed class GridContextPropagationMiddleware(TransportGridContextFactory
 
         context.GridContext = gridContext;
         context.Properties["GridContext"] = gridContext;
-        context.Properties["CorrelationId"] = gridContext.CorrelationId;
+        context.Properties["CorrelationId"] = gridContext.CorrelationId ?? string.Empty;
         context.Properties["CausationId"] = gridContext.CausationId ?? string.Empty;
         context.Properties["NodeId"] = gridContext.NodeId;
         context.Properties["StudioId"] = gridContext.StudioId;


### PR DESCRIPTION
## Summary
- drops Transport library/runtime package dependency on `HoneyDrunk.Kernel` and uses `HoneyDrunk.Kernel.Abstractions` v0.7.0 plus `GridContextSnapshot` for inbound context propagation
- changes Transport `IGridContextFactory` back to creating initialized contexts from envelopes, including default Grid identity fallbacks and typed tenant parsing
- consolidates Azure Service Bus standard/session consumer processing into a shared received-message path for pipeline execution and settlement
- bumps Transport packages to 0.6.0 and updates changelogs consistently across package projects

## Validation
- `dotnet restore HoneyDrunk.Transport\HoneyDrunk.Transport.Tests\HoneyDrunk.Transport.Tests.csproj --ignore-failed-sources /p:TreatWarningsAsErrors=false /p:WarningsAsErrors=` (Azure Artifacts feed returned 401/NU1900 warnings)
- `dotnet build HoneyDrunk.Transport\HoneyDrunk.Transport.slnx --no-restore /p:TreatWarningsAsErrors=false /p:WarningsAsErrors=` (succeeded; Azure Artifacts feed returned NU1801/NU1900 warnings)
- `dotnet test HoneyDrunk.Transport\HoneyDrunk.Transport.slnx --no-build /p:TreatWarningsAsErrors=false /p:WarningsAsErrors=` (379 passed)
- `dotnet list HoneyDrunk.Transport\HoneyDrunk.Transport.slnx package --deprecated --source https://api.nuget.org/v3/index.json --no-restore` (existing test-only xunit 2.9.3 deprecated/legacy notice)
- `dotnet list HoneyDrunk.Transport\HoneyDrunk.Transport.slnx package --vulnerable --source https://api.nuget.org/v3/index.json --no-restore` (no vulnerable packages)
- `git diff --check`

## Notes
- Direct `dotnet list ... package --deprecated/--vulnerable` against all configured feeds is blocked locally by Azure Artifacts 401, so package scans were repeated against NuGet.org explicitly.
- SandboxNode intentionally still references runtime `HoneyDrunk.Kernel` as the app-host integration sample; library/provider projects do not.
