### PR TITLE
test: backfill transport coverage baseline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: PR
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -11,7 +13,7 @@ jobs:
   pr-core:
     name: PR Core
     permissions:
-      contents: read
+      contents: write
       checks: write
       pull-requests: write
       security-events: write  # CodeQL SARIF upload
@@ -24,6 +26,8 @@ jobs:
       enable-secret-scan: true
       enable-accessibility-check: false
       post-pr-summary: true
+      patch-coverage-threshold: 75
+      absolute-coverage-floor: 70
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ _TeamCity*
 
 # Coverlet is a free, cross platform Code Coverage Tool
 coverage*.json
+!**/.github/coverage-baseline.json
 coverage*.xml
 coverage*.info
 

--- a/HoneyDrunk.Transport/.github/coverage-baseline.json
+++ b/HoneyDrunk.Transport/.github/coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "totalLineCoverage": 70.1,
+  "commit": "pending-merge",
+  "measuredAtUtc": "2026-05-19T13:24:40Z"
+}

--- a/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Backfilled focused unit coverage across core, Azure Service Bus, InMemory, and Storage Queue transport surfaces to seed the 70% repository coverage baseline.
+- Added PR coverage gate baseline wiring with 75% patch coverage and 70% absolute coverage thresholds.
+
 ## [0.6.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Abstractions/MessageProcessingFailureTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Abstractions/MessageProcessingFailureTests.cs
@@ -1,0 +1,148 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Tests.Core.Abstractions;
+
+/// <summary>
+/// Tests for <see cref="MessageProcessingFailure"/> factory behavior.
+/// </summary>
+public sealed class MessageProcessingFailureTests
+{
+    /// <summary>
+    /// Gets transient exceptions for classification tests.
+    /// </summary>
+    public static TheoryData<Exception> TransientExceptions => new()
+    {
+        new TimeoutException("timeout"),
+        new HttpRequestException("service unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable)
+    };
+
+    /// <summary>
+    /// Gets permanent exceptions for classification tests.
+    /// </summary>
+    public static TheoryData<Exception> PermanentExceptions => new()
+    {
+        new ArgumentException("argument"),
+        new ArgumentNullException("value"),
+        new InvalidOperationException("invalid")
+    };
+
+    /// <summary>
+    /// Success creates a success result without failure metadata.
+    /// </summary>
+    [Fact]
+    public void Success_WhenCalled_ReturnsSuccessResult()
+    {
+        var result = MessageProcessingFailure.Success();
+
+        Assert.Equal(MessageProcessingResult.Success, result.Result);
+        Assert.Null(result.Reason);
+        Assert.Null(result.Exception);
+    }
+
+    /// <summary>
+    /// Retry preserves diagnostic metadata.
+    /// </summary>
+    [Fact]
+    public void Retry_WithMetadata_PreservesFailureDetails()
+    {
+        var exception = new TimeoutException("timeout");
+        var metadata = new Dictionary<string, object> { ["attempt"] = 2 };
+
+        var result = MessageProcessingFailure.Retry("try again", exception, "Transient", metadata);
+
+        Assert.Equal(MessageProcessingResult.Retry, result.Result);
+        Assert.Equal("try again", result.Reason);
+        Assert.Equal("Transient", result.Category);
+        Assert.Same(exception, result.Exception);
+        Assert.Same(metadata, result.Metadata);
+    }
+
+    /// <summary>
+    /// Dead-letter preserves diagnostic metadata.
+    /// </summary>
+    [Fact]
+    public void DeadLetter_WithMetadata_PreservesFailureDetails()
+    {
+        var exception = new InvalidOperationException("bad");
+        var metadata = new Dictionary<string, object> { ["field"] = "value" };
+
+        var result = MessageProcessingFailure.DeadLetter("do not retry", "Permanent", exception, metadata);
+
+        Assert.Equal(MessageProcessingResult.DeadLetter, result.Result);
+        Assert.Equal("do not retry", result.Reason);
+        Assert.Equal("Permanent", result.Category);
+        Assert.Same(exception, result.Exception);
+        Assert.Same(metadata, result.Metadata);
+    }
+
+    /// <summary>
+    /// Exceptions over the retry limit become dead-letter failures.
+    /// </summary>
+    [Fact]
+    public void FromException_WhenRetryLimitExceeded_ReturnsMaxRetriesDeadLetter()
+    {
+        var exception = new TimeoutException("timeout");
+
+        var result = MessageProcessingFailure.FromException(exception, deliveryCount: 6, maxRetries: 5);
+
+        Assert.Equal(MessageProcessingResult.DeadLetter, result.Result);
+        Assert.Equal("MaxRetriesExceeded", result.Category);
+        Assert.Same(exception, result.Exception);
+    }
+
+    /// <summary>
+    /// Transient exceptions are retried.
+    /// </summary>
+    /// <param name="exception">The exception to classify.</param>
+    [Theory]
+    [MemberData(nameof(TransientExceptions))]
+    public void FromException_WhenExceptionIsTransient_ReturnsRetry(Exception exception)
+    {
+        var result = MessageProcessingFailure.FromException(exception, deliveryCount: 1);
+
+        Assert.Equal(MessageProcessingResult.Retry, result.Result);
+        Assert.Equal("TransientError", result.Category);
+        Assert.Same(exception, result.Exception);
+    }
+
+    /// <summary>
+    /// Permanent exceptions are dead-lettered.
+    /// </summary>
+    /// <param name="exception">The exception to classify.</param>
+    [Theory]
+    [MemberData(nameof(PermanentExceptions))]
+    public void FromException_WhenExceptionIsPermanent_ReturnsPermanentDeadLetter(Exception exception)
+    {
+        var result = MessageProcessingFailure.FromException(exception, deliveryCount: 1);
+
+        Assert.Equal(MessageProcessingResult.DeadLetter, result.Result);
+        Assert.Equal("PermanentError", result.Category);
+        Assert.Same(exception, result.Exception);
+    }
+
+    /// <summary>
+    /// Unknown exceptions are retried cautiously.
+    /// </summary>
+    [Fact]
+    public void FromException_WhenExceptionIsUnknown_ReturnsUnknownRetry()
+    {
+        var exception = new UnknownFailureException("unknown");
+
+        var result = MessageProcessingFailure.FromException(exception, deliveryCount: 1);
+
+        Assert.Equal(MessageProcessingResult.Retry, result.Result);
+        Assert.Equal("UnknownError", result.Category);
+        Assert.Same(exception, result.Exception);
+    }
+
+    /// <summary>
+    /// Custom exception used to represent an unclassified failure.
+    /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="UnknownFailureException"/> class.
+    /// </remarks>
+    /// <param name="message">The exception message.</param>
+    private sealed class UnknownFailureException(string message) : Exception(message)
+    {
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Abstractions/PublishOptionsTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Abstractions/PublishOptionsTests.cs
@@ -1,0 +1,52 @@
+using HoneyDrunk.Transport.Abstractions;
+
+namespace HoneyDrunk.Transport.Tests.Core.Abstractions;
+
+/// <summary>
+/// Tests for <see cref="PublishOptions"/>.
+/// </summary>
+public sealed class PublishOptionsTests
+{
+    /// <summary>
+    /// Defaults are neutral and normal priority.
+    /// </summary>
+    [Fact]
+    public void PublishOptions_WhenCreated_HasExpectedDefaults()
+    {
+        var options = new PublishOptions();
+
+        Assert.Null(options.TimeToLive);
+        Assert.Null(options.ScheduledEnqueueTime);
+        Assert.Null(options.PartitionKey);
+        Assert.Null(options.SessionId);
+        Assert.Equal(MessagePriority.Normal, options.Priority);
+        Assert.Null(options.AdditionalOptions);
+    }
+
+    /// <summary>
+    /// Init-only options preserve custom values.
+    /// </summary>
+    [Fact]
+    public void PublishOptions_WithCustomValues_StoresValues()
+    {
+        var scheduled = DateTimeOffset.UtcNow.AddMinutes(10);
+        var additional = new Dictionary<string, object> { ["transport"] = "custom" };
+
+        var options = new PublishOptions
+        {
+            TimeToLive = TimeSpan.FromMinutes(5),
+            ScheduledEnqueueTime = scheduled,
+            PartitionKey = "partition-1",
+            SessionId = "session-1",
+            Priority = MessagePriority.High,
+            AdditionalOptions = additional
+        };
+
+        Assert.Equal(TimeSpan.FromMinutes(5), options.TimeToLive);
+        Assert.Equal(scheduled, options.ScheduledEnqueueTime);
+        Assert.Equal("partition-1", options.PartitionKey);
+        Assert.Equal("session-1", options.SessionId);
+        Assert.Equal(MessagePriority.High, options.Priority);
+        Assert.Same(additional, options.AdditionalOptions);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ConfigurableErrorHandlingStrategyTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ConfigurableErrorHandlingStrategyTests.cs
@@ -1,0 +1,94 @@
+using HoneyDrunk.Transport.Configuration;
+
+namespace HoneyDrunk.Transport.Tests.Core.Configuration;
+
+/// <summary>
+/// Tests for <see cref="ConfigurableErrorHandlingStrategy"/> rule selection.
+/// </summary>
+public sealed class ConfigurableErrorHandlingStrategyTests
+{
+    /// <summary>
+    /// Configured retry decisions are returned for exact exception matches.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenExactRetryRuleMatches_ReturnsConfiguredRetry()
+    {
+        var strategy = new ConfigurableErrorHandlingStrategy()
+            .RetryOn<TimeoutException>(TimeSpan.FromSeconds(7));
+
+        var decision = await strategy.HandleErrorAsync(new TimeoutException("timeout"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.Retry, decision.Action);
+        Assert.Equal(TimeSpan.FromSeconds(7), decision.RetryDelay);
+    }
+
+    /// <summary>
+    /// Configured dead-letter decisions are returned for exact exception matches.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenExactDeadLetterRuleMatches_ReturnsConfiguredDeadLetter()
+    {
+        var strategy = new ConfigurableErrorHandlingStrategy()
+            .DeadLetterOn<InvalidOperationException>();
+
+        var decision = await strategy.HandleErrorAsync(new InvalidOperationException("bad"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+        Assert.Null(decision.RetryDelay);
+    }
+
+    /// <summary>
+    /// Base exception rules apply to derived exception instances.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenBaseRuleMatchesDerivedException_ReturnsInheritedDecision()
+    {
+        var strategy = new ConfigurableErrorHandlingStrategy()
+            .DeadLetterOn<ArgumentException>();
+
+        var decision = await strategy.HandleErrorAsync(new ArgumentNullException("value"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+    }
+
+    /// <summary>
+    /// Delivery count at the configured maximum dead-letters before rule lookup.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenMaxDeliveryCountReached_DeadLettersBeforeRuleLookup()
+    {
+        var strategy = new ConfigurableErrorHandlingStrategy(maxDeliveryCount: 3)
+            .RetryOn<TimeoutException>(TimeSpan.FromSeconds(1));
+
+        var decision = await strategy.HandleErrorAsync(new TimeoutException("timeout"), deliveryCount: 3);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+        Assert.Contains("Maximum delivery count (3) exceeded", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Unknown exceptions retry with exponential backoff.
+    /// </summary>
+    /// <param name="deliveryCount">The delivery attempt count.</param>
+    /// <param name="expectedDelay">The expected retry delay.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(4, 8)]
+    [InlineData(10, 32)]
+    public async Task HandleErrorAsync_WhenNoRuleMatches_ReturnsBackoffRetry(int deliveryCount, int expectedDelay)
+    {
+        var strategy = new ConfigurableErrorHandlingStrategy(maxDeliveryCount: 100);
+
+        var decision = await strategy.HandleErrorAsync(new FormatException("unknown"), deliveryCount);
+
+        Assert.Equal(ErrorHandlingAction.Retry, decision.Action);
+        Assert.Equal(TimeSpan.FromSeconds(expectedDelay), decision.RetryDelay);
+        Assert.Equal("Unknown exception type - retry with backoff", decision.Reason);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ExceptionTypeMapStrategyTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Configuration/ExceptionTypeMapStrategyTests.cs
@@ -1,0 +1,115 @@
+using HoneyDrunk.Transport.Configuration;
+
+namespace HoneyDrunk.Transport.Tests.Core.Configuration;
+
+/// <summary>
+/// Tests for <see cref="ExceptionTypeMapStrategy"/> and its builder.
+/// </summary>
+public sealed class ExceptionTypeMapStrategyTests
+{
+    /// <summary>
+    /// Builder maps exact exception types to retry decisions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenExactRetryMappingExists_ReturnsRetryDecision()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .MapToRetry<TimeoutException>()
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new TimeoutException("timeout"), deliveryCount: 2);
+
+        Assert.Equal(ErrorHandlingAction.Retry, decision.Action);
+        Assert.Equal(TimeSpan.FromSeconds(2), decision.RetryDelay);
+        Assert.Contains("Mapped action for TimeoutException", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Builder maps exact exception types to dead-letter decisions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenExactDeadLetterMappingExists_ReturnsDeadLetterDecision()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .MapToDeadLetter<InvalidOperationException>()
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new InvalidOperationException("bad"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+        Assert.Null(decision.RetryDelay);
+        Assert.Contains("Mapped action for InvalidOperationException", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Base exception mappings apply to derived exception instances.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenBaseMappingMatchesDerivedException_ReturnsInheritedDecision()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .MapToDeadLetter<ArgumentException>()
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new ArgumentNullException("name"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+        Assert.Contains("Inherited action from ArgumentException", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Delivery count at the maximum dead-letters before mappings are evaluated.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenMaxDeliveryCountReached_DeadLettersBeforeMappingLookup()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .WithMaxDeliveryCount(2)
+            .MapToRetry<TimeoutException>()
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new TimeoutException("timeout"), deliveryCount: 2);
+
+        Assert.Equal(ErrorHandlingAction.DeadLetter, decision.Action);
+        Assert.Contains("Maximum delivery count (2) exceeded", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Unmapped exceptions use the configured default action.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenNoMappingMatches_UsesConfiguredDefaultAction()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .WithDefaultAction(ErrorHandlingAction.Abandon)
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new FormatException("unknown"), deliveryCount: 1);
+
+        Assert.Equal(ErrorHandlingAction.Abandon, decision.Action);
+        Assert.Contains("Default action", decision.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Retry decisions cap exponential backoff at 32 seconds.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleErrorAsync_WhenRetryDeliveryCountIsHigh_CapsBackoffDelay()
+    {
+        var strategy = ExceptionTypeMapStrategy.CreateBuilder()
+            .WithMaxDeliveryCount(200)
+            .MapToRetry<TimeoutException>()
+            .Build();
+
+        var decision = await strategy.HandleErrorAsync(new TimeoutException("timeout"), deliveryCount: 100);
+
+        Assert.Equal(ErrorHandlingAction.Retry, decision.Action);
+        Assert.Equal(TimeSpan.FromSeconds(32), decision.RetryDelay);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Exceptions/EnvelopeValidationExceptionConstructorTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Exceptions/EnvelopeValidationExceptionConstructorTests.cs
@@ -1,0 +1,45 @@
+using HoneyDrunk.Transport.Exceptions;
+
+namespace HoneyDrunk.Transport.Tests.Core.Exceptions;
+
+/// <summary>
+/// Tests for <see cref="EnvelopeValidationException"/> constructors.
+/// </summary>
+public sealed class EnvelopeValidationExceptionConstructorTests
+{
+    /// <summary>
+    /// Default constructor uses the standard validation message.
+    /// </summary>
+    [Fact]
+    public void Constructor_WhenDefault_UsesStandardMessage()
+    {
+        var exception = new EnvelopeValidationException();
+
+        Assert.Equal("Envelope validation failed", exception.Message);
+    }
+
+    /// <summary>
+    /// Message constructor preserves the provided message.
+    /// </summary>
+    [Fact]
+    public void Constructor_WhenMessageProvided_PreservesMessage()
+    {
+        var exception = new EnvelopeValidationException("bad envelope");
+
+        Assert.Equal("bad envelope", exception.Message);
+    }
+
+    /// <summary>
+    /// Message and inner exception constructor preserves both values.
+    /// </summary>
+    [Fact]
+    public void Constructor_WhenInnerExceptionProvided_PreservesMessageAndInnerException()
+    {
+        var inner = new InvalidOperationException("inner");
+
+        var exception = new EnvelopeValidationException("bad envelope", inner);
+
+        Assert.Equal("bad envelope", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Outbox/DefaultOutboxDispatcherTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Outbox/DefaultOutboxDispatcherTests.cs
@@ -1,0 +1,176 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Outbox;
+using HoneyDrunk.Transport.Tests.Support;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace HoneyDrunk.Transport.Tests.Core.Outbox;
+
+/// <summary>
+/// Tests for <see cref="DefaultOutboxDispatcher"/> dispatch behavior.
+/// </summary>
+public sealed class DefaultOutboxDispatcherTests
+{
+    /// <summary>
+    /// Empty batches return without publishing or marking messages.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DispatchPendingAsync_WhenNoMessagesExist_DoesNothing()
+    {
+        var store = Substitute.For<IOutboxStore>();
+        store.LoadPendingAsync(10, Arg.Any<CancellationToken>()).Returns([]);
+        var publisher = Substitute.For<ITransportPublisher>();
+        using var dispatcher = Create(store, publisher);
+
+        await dispatcher.DispatchPendingAsync(10);
+
+        await publisher.DidNotReceive().PublishAsync(
+            Arg.Any<ITransportEnvelope>(),
+            Arg.Any<IEndpointAddress>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Successfully published outbox messages are marked dispatched.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DispatchPendingAsync_WhenPublishSucceeds_MarksMessageDispatched()
+    {
+        var message = CreateMessage("outbox-1", attempts: 0);
+        var store = Substitute.For<IOutboxStore>();
+        store.LoadPendingAsync(100, Arg.Any<CancellationToken>()).Returns([message]);
+        var publisher = Substitute.For<ITransportPublisher>();
+        using var dispatcher = Create(store, publisher);
+
+        await dispatcher.DispatchPendingAsync();
+
+        await publisher.Received(1).PublishAsync(message.Envelope, message.Destination, Arg.Any<CancellationToken>());
+        await store.Received(1).MarkDispatchedAsync("outbox-1", Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Failed publish attempts below the retry limit are marked failed with a future retry time.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DispatchPendingAsync_WhenPublishFailsBelowRetryLimit_MarksFailedWithRetryTime()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var message = CreateMessage("outbox-2", attempts: 2);
+        var store = Substitute.For<IOutboxStore>();
+        store.LoadPendingAsync(100, Arg.Any<CancellationToken>()).Returns([message]);
+        var publisher = Substitute.For<ITransportPublisher>();
+        publisher.PublishAsync(message.Envelope, message.Destination, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("broker down"));
+        using var dispatcher = Create(store, publisher, new OutboxDispatcherOptions
+        {
+            BaseRetryDelay = TimeSpan.FromSeconds(1),
+            MaxRetryDelay = TimeSpan.FromMinutes(1),
+            MaxRetryAttempts = 5
+        });
+
+        await dispatcher.DispatchPendingAsync();
+
+        await store.Received(1).MarkFailedAsync(
+            "outbox-2",
+            "broker down",
+            Arg.Is<DateTimeOffset?>(value => value >= before.AddSeconds(3) && value <= DateTimeOffset.UtcNow.AddSeconds(10)),
+            Arg.Any<CancellationToken>());
+        await store.DidNotReceive().MarkPoisonedAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Failed publish attempts at the retry limit are marked poisoned.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DispatchPendingAsync_WhenPublishFailsAtRetryLimit_MarksPoisoned()
+    {
+        var message = CreateMessage("outbox-3", attempts: 5);
+        var store = Substitute.For<IOutboxStore>();
+        store.LoadPendingAsync(100, Arg.Any<CancellationToken>()).Returns([message]);
+        var publisher = Substitute.For<ITransportPublisher>();
+        publisher.PublishAsync(message.Envelope, message.Destination, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("broker down"));
+        using var dispatcher = Create(store, publisher, new OutboxDispatcherOptions { MaxRetryAttempts = 5 });
+
+        await dispatcher.DispatchPendingAsync();
+
+        await store.Received(1).MarkPoisonedAsync(
+            "outbox-3",
+            "Exceeded maximum retry attempts (5)",
+            Arg.Any<CancellationToken>());
+        await store.DidNotReceive().MarkFailedAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Dispatch handles mixed success and failure in one batch.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task DispatchPendingAsync_WhenBatchHasMixedOutcomes_ProcessesAllMessages()
+    {
+        var success = CreateMessage("success", attempts: 0);
+        var failure = CreateMessage("failure", attempts: 1);
+        var store = Substitute.For<IOutboxStore>();
+        store.LoadPendingAsync(100, Arg.Any<CancellationToken>()).Returns([success, failure]);
+        var publisher = Substitute.For<ITransportPublisher>();
+        publisher.PublishAsync(failure.Envelope, failure.Destination, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("broker down"));
+        using var dispatcher = Create(store, publisher);
+
+        await dispatcher.DispatchPendingAsync();
+
+        await store.Received(1).MarkDispatchedAsync("success", Arg.Any<CancellationToken>());
+        await store.Received(1).MarkFailedAsync(
+            "failure",
+            "broker down",
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Creates an outbox dispatcher for tests.
+    /// </summary>
+    /// <param name="store">The outbox store.</param>
+    /// <param name="publisher">The transport publisher.</param>
+    /// <param name="options">Optional dispatcher options.</param>
+    /// <returns>An outbox dispatcher.</returns>
+    private static DefaultOutboxDispatcher Create(
+        IOutboxStore store,
+        ITransportPublisher publisher,
+        OutboxDispatcherOptions? options = null)
+    {
+        return new DefaultOutboxDispatcher(
+            store,
+            publisher,
+            Options.Create(options ?? new OutboxDispatcherOptions()),
+            NullLogger<DefaultOutboxDispatcher>.Instance);
+    }
+
+    /// <summary>
+    /// Creates a pending outbox message.
+    /// </summary>
+    /// <param name="id">The outbox identifier.</param>
+    /// <param name="attempts">The current attempt count.</param>
+    /// <returns>An outbox message.</returns>
+    private static OutboxMessage CreateMessage(string id, int attempts)
+    {
+        return new OutboxMessage
+        {
+            Id = id,
+            Destination = TestData.Address("orders", "orders.queue"),
+            Envelope = TestData.CreateEnvelope(new SampleMessage { Value = id }),
+            State = OutboxMessageState.Pending,
+            Attempts = attempts,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/TransportExecutionContextTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Pipeline/TransportExecutionContextTests.cs
@@ -1,0 +1,45 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Pipeline;
+using HoneyDrunk.Transport.Tests.Support;
+
+namespace HoneyDrunk.Transport.Tests.Core.Pipeline;
+
+/// <summary>
+/// Tests for <see cref="TransportExecutionContext"/>.
+/// </summary>
+public sealed class TransportExecutionContextTests
+{
+    /// <summary>
+    /// ToMessageContext should copy broker properties and expose derived delivery count.
+    /// </summary>
+    [Fact]
+    public void ToMessageContext_CopiesExecutionState()
+    {
+        var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "payload" });
+        var context = new TransportExecutionContext
+        {
+            Envelope = envelope,
+            Transaction = NoOpTransportTransaction.Instance,
+            RetryAttempt = 2,
+            ProcessingDuration = TimeSpan.FromMilliseconds(42),
+            BrokerProperties =
+            {
+                ["LockToken"] = "abc",
+                ["SequenceNumber"] = 123L,
+            },
+        };
+
+        var messageContext = context.ToMessageContext();
+
+        Assert.Same(envelope, messageContext.Envelope);
+        Assert.Same(NoOpTransportTransaction.Instance, messageContext.Transaction);
+        Assert.Equal(3, context.DeliveryCount);
+        Assert.Equal(3, messageContext.DeliveryCount);
+        Assert.Equal(TimeSpan.FromMilliseconds(42), context.ProcessingDuration);
+        Assert.Equal("abc", messageContext.Properties["LockToken"]);
+        Assert.Equal(123L, messageContext.Properties["SequenceNumber"]);
+
+        context.BrokerProperties["LockToken"] = "changed";
+        Assert.Equal("abc", messageContext.Properties["LockToken"]);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Runtime/TransportRuntimeHostTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Core/Runtime/TransportRuntimeHostTests.cs
@@ -1,0 +1,166 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Health;
+using HoneyDrunk.Transport.Runtime;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace HoneyDrunk.Transport.Tests.Core.Runtime;
+
+/// <summary>
+/// Tests for <see cref="TransportRuntimeHost"/> lifecycle orchestration.
+/// </summary>
+public sealed class TransportRuntimeHostTests
+{
+    /// <summary>
+    /// Starting the host starts all consumers and marks runtime running.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartAsync_WhenStopped_StartsConsumersAndMarksRunning()
+    {
+        var first = Substitute.For<ITransportConsumer>();
+        var second = Substitute.For<ITransportConsumer>();
+        using var host = Create([first, second]);
+
+        await host.StartAsync();
+
+        Assert.True(host.IsRunning);
+        await first.Received(1).StartAsync(Arg.Any<CancellationToken>());
+        await second.Received(1).StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Starting an already running host is idempotent.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartAsync_WhenAlreadyRunning_DoesNotStartConsumersAgain()
+    {
+        var consumer = Substitute.For<ITransportConsumer>();
+        using var host = Create([consumer]);
+
+        await host.StartAsync();
+        await host.StartAsync();
+
+        await consumer.Received(1).StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Stop is a no-op when the runtime has not started.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StopAsync_WhenNotRunning_DoesNotStopConsumers()
+    {
+        var consumer = Substitute.For<ITransportConsumer>();
+        using var host = Create([consumer]);
+
+        await host.StopAsync();
+
+        Assert.False(host.IsRunning);
+        await consumer.DidNotReceive().StopAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Stopping the host stops all consumers and marks runtime stopped.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StopAsync_WhenRunning_StopsConsumersAndMarksStopped()
+    {
+        var consumer = Substitute.For<ITransportConsumer>();
+        using var host = Create([consumer]);
+
+        await host.StartAsync();
+        await host.StopAsync();
+
+        Assert.False(host.IsRunning);
+        await consumer.Received(1).StopAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Stop continues when a consumer throws a non-fatal exception.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StopAsync_WhenConsumerStopThrows_ContinuesStoppingOtherConsumers()
+    {
+        var failing = Substitute.For<ITransportConsumer>();
+        failing.StopAsync(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new InvalidOperationException("stop failed"));
+        var second = Substitute.For<ITransportConsumer>();
+        using var host = Create([failing, second]);
+
+        await host.StartAsync();
+        await host.StopAsync();
+
+        Assert.False(host.IsRunning);
+        await second.Received(1).StopAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Start propagates non-fatal consumer start failures and does not mark running.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartAsync_WhenConsumerStartThrows_PropagatesAndRemainsStopped()
+    {
+        var consumer = Substitute.For<ITransportConsumer>();
+        consumer.StartAsync(Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new InvalidOperationException("start failed"));
+        using var host = Create([consumer]);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartAsync());
+
+        Assert.Equal("start failed", ex.Message);
+        Assert.False(host.IsRunning);
+    }
+
+    /// <summary>
+    /// Health contributors are returned as registered.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetHealthContributorsAsync_ReturnsRegisteredContributors()
+    {
+        var contributor = Substitute.For<ITransportHealthContributor>();
+        using var host = new TransportRuntimeHost(
+            [],
+            [contributor],
+            NullLogger<TransportRuntimeHost>.Instance);
+
+        var contributors = await host.GetHealthContributorsAsync();
+
+        Assert.Same(contributor, Assert.Single(contributors));
+    }
+
+    /// <summary>
+    /// Explicit hosted-service start and stop delegate to runtime lifecycle methods.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task IHostedServiceLifecycle_DelegatesToRuntimeLifecycle()
+    {
+        var consumer = Substitute.For<ITransportConsumer>();
+        using var runtimeHost = Create([consumer]);
+        IHostedService host = runtimeHost;
+
+        await host.StartAsync(CancellationToken.None);
+        await host.StopAsync(CancellationToken.None);
+
+        await consumer.Received(1).StartAsync(Arg.Any<CancellationToken>());
+        await consumer.Received(1).StopAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Creates a runtime host for tests.
+    /// </summary>
+    /// <param name="consumers">The consumers to register.</param>
+    /// <returns>A runtime host.</returns>
+    private static TransportRuntimeHost Create(IEnumerable<ITransportConsumer> consumers)
+    {
+        return new TransportRuntimeHost(
+            consumers,
+            [],
+            NullLogger<TransportRuntimeHost>.Instance);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/BlobFallbackRecordTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/BlobFallbackRecordTests.cs
@@ -1,0 +1,51 @@
+using HoneyDrunk.Transport.AzureServiceBus.Internal;
+using System.Globalization;
+using System.Text.Json;
+
+namespace HoneyDrunk.Transport.Tests.Transports.AzureServiceBus;
+
+/// <summary>
+/// Tests for blob fallback serialization DTOs.
+/// </summary>
+public sealed class BlobFallbackRecordTests
+{
+    /// <summary>
+    /// Blob fallback records serialize with the wire property names expected by fallback tooling.
+    /// </summary>
+    [Fact]
+    public void BlobFallbackRecord_SerializesWithExpectedNames()
+    {
+        var record = new BlobFallbackRecord
+        {
+            MessageId = "msg-1",
+            CorrelationId = "corr-1",
+            CausationId = "cause-1",
+            Timestamp = DateTimeOffset.Parse("2026-01-02T03:04:05Z", CultureInfo.InvariantCulture),
+            MessageType = "Sample",
+            Headers = new Dictionary<string, string> { ["h"] = "v" },
+            PayloadBase64 = "cGF5bG9hZA==",
+            Destination = new BlobFallbackDestination
+            {
+                Address = "queue/name",
+                Properties = new Dictionary<string, string> { ["SessionId"] = "session-1" },
+            },
+            FailureTimestamp = DateTimeOffset.Parse("2026-01-02T03:05:05Z", CultureInfo.InvariantCulture),
+            FailureExceptionType = typeof(InvalidOperationException).FullName,
+            FailureMessage = "boom",
+        };
+
+        var json = JsonSerializer.Serialize(record);
+
+        Assert.Contains("\"messageId\":\"msg-1\"", json);
+        Assert.Contains("\"correlationId\":\"corr-1\"", json);
+        Assert.Contains("\"causationId\":\"cause-1\"", json);
+        Assert.Contains("\"messageType\":\"Sample\"", json);
+        Assert.Contains("\"payload\":\"cGF5bG9hZA==\"", json);
+        Assert.Contains("\"destination\"", json);
+        Assert.Contains("\"address\":\"queue/name\"", json);
+        Assert.Contains("\"properties\"", json);
+        Assert.Contains("\"failureAt\"", json);
+        Assert.Contains("\"failureType\"", json);
+        Assert.Contains("\"failureMessage\":\"boom\"", json);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportConsumerProcessingTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportConsumerProcessingTests.cs
@@ -1,0 +1,182 @@
+using Azure.Messaging.ServiceBus;
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.AzureServiceBus;
+using HoneyDrunk.Transport.AzureServiceBus.Configuration;
+using HoneyDrunk.Transport.Pipeline;
+using HoneyDrunk.Transport.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using System.Reflection;
+
+namespace HoneyDrunk.Transport.Tests.Transports.AzureServiceBus;
+
+/// <summary>
+/// Tests for Service Bus consumer message-processing settlement paths.
+/// </summary>
+public sealed class ServiceBusTransportConsumerProcessingTests
+{
+    /// <summary>
+    /// Processing success completes the message when auto-complete is disabled.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_WhenPipelineSucceeds_CompletesMessage()
+    {
+        var pipeline = Substitute.For<IMessagePipeline>();
+        pipeline.ProcessAsync(Arg.Any<ITransportEnvelope>(), Arg.Any<MessageContext>(), Arg.Any<CancellationToken>())
+            .Returns(MessageProcessingResult.Success);
+        await using var fixture = CreateConsumer(pipeline, autoComplete: false);
+        var completeCount = 0;
+        var context = CreateReceivedContext(onComplete: () => completeCount++);
+
+        await InvokeProcessingAsync(fixture.Consumer, "ProcessReceivedMessageAsync", context);
+
+        Assert.Equal(1, completeCount);
+    }
+
+    /// <summary>
+    /// Processing retry abandons the message when auto-complete is disabled.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_WhenPipelineRetries_AbandonsMessage()
+    {
+        var pipeline = Substitute.For<IMessagePipeline>();
+        pipeline.ProcessAsync(Arg.Any<ITransportEnvelope>(), Arg.Any<MessageContext>(), Arg.Any<CancellationToken>())
+            .Returns(MessageProcessingResult.Retry);
+        await using var fixture = CreateConsumer(pipeline, autoComplete: false);
+        var abandonCount = 0;
+        var context = CreateReceivedContext(onAbandon: () => abandonCount++);
+
+        await InvokeProcessingAsync(fixture.Consumer, "ProcessReceivedMessageAsync", context);
+
+        Assert.Equal(1, abandonCount);
+    }
+
+    /// <summary>
+    /// Processing dead-letter result dead-letters the message when auto-complete is disabled.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_WhenPipelineDeadLetters_DeadLettersMessage()
+    {
+        var pipeline = Substitute.For<IMessagePipeline>();
+        pipeline.ProcessAsync(Arg.Any<ITransportEnvelope>(), Arg.Any<MessageContext>(), Arg.Any<CancellationToken>())
+            .Returns(MessageProcessingResult.DeadLetter);
+        await using var fixture = CreateConsumer(pipeline, autoComplete: false);
+        var deadLetterCount = 0;
+        var context = CreateReceivedContext(onDeadLetter: () => deadLetterCount++);
+
+        await InvokeProcessingAsync(fixture.Consumer, "ProcessReceivedMessageAsync", context);
+
+        Assert.Equal(1, deadLetterCount);
+    }
+
+    /// <summary>
+    /// Processing exceptions abandon the message when auto-complete is disabled.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_WhenPipelineThrows_AbandonsMessage()
+    {
+        var pipeline = Substitute.For<IMessagePipeline>();
+        pipeline.ProcessAsync(Arg.Any<ITransportEnvelope>(), Arg.Any<MessageContext>(), Arg.Any<CancellationToken>())
+            .Returns<Task<MessageProcessingResult>>(_ => throw new InvalidOperationException("boom"));
+        await using var fixture = CreateConsumer(pipeline, autoComplete: false);
+        var abandonCount = 0;
+        var context = CreateReceivedContext(onAbandon: () => abandonCount++);
+
+        await InvokeProcessingAsync(fixture.Consumer, "ProcessReceivedMessageAsync", context);
+
+        Assert.Equal(1, abandonCount);
+    }
+
+    /// <summary>
+    /// Auto-complete mode leaves settlement to the Service Bus SDK.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_WhenAutoCompleteEnabled_DoesNotSettle()
+    {
+        var pipeline = Substitute.For<IMessagePipeline>();
+        pipeline.ProcessAsync(Arg.Any<ITransportEnvelope>(), Arg.Any<MessageContext>(), Arg.Any<CancellationToken>())
+            .Returns(MessageProcessingResult.Success);
+        await using var fixture = CreateConsumer(pipeline, autoComplete: true);
+        var completeCount = 0;
+        var context = CreateReceivedContext(onComplete: () => completeCount++);
+
+        await InvokeProcessingAsync(fixture.Consumer, "ProcessReceivedMessageAsync", context);
+
+        Assert.Equal(0, completeCount);
+    }
+
+    private static ConsumerFixture CreateConsumer(IMessagePipeline pipeline, bool autoComplete)
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var consumer = new ServiceBusTransportConsumer(
+            Substitute.For<ServiceBusClient>(),
+            pipeline,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new AzureServiceBusOptions { Address = "orders", AutoComplete = autoComplete }),
+            NullLogger<ServiceBusTransportConsumer>.Instance);
+
+        return new ConsumerFixture(consumer, provider);
+    }
+
+    private static object CreateReceivedContext(
+        Action? onComplete = null,
+        Action? onAbandon = null,
+        Action? onDeadLetter = null)
+    {
+        var type = typeof(ServiceBusTransportConsumer).GetNestedType("ServiceBusReceivedMessageContext", BindingFlags.NonPublic)!;
+        var constructor = type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).Single();
+        var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "message" });
+        return constructor.Invoke(
+        [
+            envelope,
+            NoOpTransportTransaction.Instance,
+            2,
+            CancellationToken.None,
+            ToFunc(onComplete),
+            ToFunc(onAbandon),
+            ToFunc(onDeadLetter),
+        ]);
+    }
+
+    private static Func<Task> ToFunc(Action? action) => () =>
+    {
+        action?.Invoke();
+        return Task.CompletedTask;
+    };
+
+    private static async Task InvokeProcessingAsync(
+        ServiceBusTransportConsumer consumer,
+        string methodName,
+        object context)
+    {
+        var method = typeof(ServiceBusTransportConsumer).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var task = (Task)method.Invoke(consumer, [context])!;
+        await task;
+    }
+
+    private sealed class ConsumerFixture : IAsyncDisposable
+    {
+        public ConsumerFixture(ServiceBusTransportConsumer consumer, ServiceProvider provider)
+        {
+            Consumer = consumer;
+            Provider = provider;
+        }
+
+        public ServiceBusTransportConsumer Consumer { get; }
+
+        private ServiceProvider Provider { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Consumer.DisposeAsync();
+            await Provider.DisposeAsync();
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportConsumerTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportConsumerTests.cs
@@ -235,6 +235,31 @@ public sealed class ServiceBusTransportConsumerTests
     }
 
     /// <summary>
+    /// Start on topic with sessions requires a subscription name.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task StartAsync_TopicWithSessionsWithoutSubscription_Throws()
+    {
+        var asb = new AzureServiceBusOptions
+        {
+            Address = "orders-topic",
+            EntityType = ServiceBusEntityType.Topic,
+            SessionEnabled = true,
+        };
+        var options = new TestOptions(asb);
+
+        var client = Substitute.For<ServiceBusClient>();
+        var pipeline = Substitute.For<IMessagePipeline>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var logger = Substitute.For<ILogger<ServiceBusTransportConsumer>>();
+
+        await using var consumer = new ServiceBusTransportConsumer(client, pipeline, scopeFactory, options, logger);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => consumer.StartAsync());
+    }
+
+    /// <summary>
     /// DisposeAsync can be called multiple times safely (idempotent).
     /// </summary>
     /// <returns>A task.</returns>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportPublisherAdditionalTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/AzureServiceBus/ServiceBusTransportPublisherAdditionalTests.cs
@@ -95,6 +95,73 @@ public sealed class ServiceBusTransportPublisherAdditionalTests
     }
 
     /// <summary>
+    /// Verifies typed endpoint metadata is applied to outgoing Service Bus messages.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task PublishAsync_AppliesTypedEndpointMetadata()
+    {
+        var options = new AzureServiceBusOptions { FullyQualifiedNamespace = "ns", Address = "q" };
+        var client = Substitute.For<ServiceBusClient>();
+        var sender = Substitute.For<ServiceBusSender>();
+        client.CreateSender(Arg.Any<string>()).Returns(sender);
+        var logger = Substitute.For<ILogger<ServiceBusTransportPublisher>>();
+
+        var iopts = Substitute.For<IOptions<AzureServiceBusOptions>>();
+        iopts.Value.Returns(options);
+
+        ServiceBusMessage? captured = null;
+        sender
+            .SendMessageAsync(Arg.Any<ServiceBusMessage>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                captured = ci.Arg<ServiceBusMessage>();
+                return Task.CompletedTask;
+            });
+
+        await using var publisher = new ServiceBusTransportPublisher(client, iopts, logger);
+
+        var scheduled = DateTimeOffset.UtcNow.AddMinutes(5);
+        var env = TestData.CreateEnvelope(new SampleMessage { Value = "x" });
+        var dest = EndpointAddress.Create(
+            name: "q",
+            address: "q",
+            sessionId: "session-1",
+            scheduledEnqueueTime: scheduled,
+            timeToLive: TimeSpan.FromMinutes(10));
+
+        await publisher.PublishAsync(env, dest);
+
+        Assert.NotNull(captured);
+        Assert.Equal("session-1", captured!.SessionId);
+        Assert.Equal(scheduled, captured.ScheduledEnqueueTime);
+        Assert.Equal(TimeSpan.FromMinutes(10), captured.TimeToLive);
+    }
+
+    /// <summary>
+    /// Empty batch publish initializes the sender and completes without sending a batch.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task PublishBatchAsync_WhenEmpty_CompletesWithoutSending()
+    {
+        var options = new AzureServiceBusOptions { FullyQualifiedNamespace = "ns", Address = "q" };
+        var client = Substitute.For<ServiceBusClient>();
+        var sender = Substitute.For<ServiceBusSender>();
+        client.CreateSender(Arg.Any<string>()).Returns(sender);
+        var logger = Substitute.For<ILogger<ServiceBusTransportPublisher>>();
+
+        var iopts = Substitute.For<IOptions<AzureServiceBusOptions>>();
+        iopts.Value.Returns(options);
+
+        await using var publisher = new ServiceBusTransportPublisher(client, iopts, logger);
+
+        await publisher.PublishBatchAsync([], EndpointAddress.Create("q", "q"));
+
+        await sender.DidNotReceive().SendMessagesAsync(Arg.Any<ServiceBusMessageBatch>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Ensures original publish exception is rethrown if fallback store also fails.
     /// </summary>
     /// <returns>A task.</returns>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryServiceCollectionExtensionsTests.cs
@@ -1,0 +1,41 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.InMemory;
+using HoneyDrunk.Transport.InMemory.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.Tests.Transports.InMemory;
+
+/// <summary>
+/// Tests for in-memory transport service registration helpers.
+/// </summary>
+public sealed class InMemoryServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Endpoint overload configures endpoint metadata and registers in-memory transport services.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task AddHoneyDrunkInMemoryTransport_WithEndpoint_RegistersServicesAndOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var builder = services.AddHoneyDrunkInMemoryTransport(
+            "orders-endpoint",
+            "orders",
+            options => options.MaxConcurrency = 3);
+
+        Assert.Same(builder, builder.WithConsumer());
+
+        await using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HoneyDrunk.Transport.Configuration.TransportOptions>>().Value;
+
+        Assert.Equal("orders-endpoint", options.EndpointName);
+        Assert.Equal("orders", options.Address);
+        Assert.Equal(3, options.MaxConcurrency);
+        Assert.IsType<InMemoryTransportPublisher>(provider.GetRequiredService<ITransportPublisher>());
+        Assert.IsType<InMemoryTransportConsumer>(provider.GetRequiredService<ITransportConsumer>());
+        Assert.NotNull(provider.GetRequiredService<ITransportTopology>());
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportConsumerTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportConsumerTests.cs
@@ -132,10 +132,10 @@ public sealed class InMemoryTransportConsumerTests
         services.AddTestKernelServices();
         services.AddHoneyDrunkTransportCore();
 
-        var handled = false;
+        var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         services.AddMessageHandler<SampleMessage>((msg, ctx, ct) =>
         {
-            handled = true;
+            handled.TrySetResult();
             return Task.CompletedTask;
         });
 
@@ -161,12 +161,9 @@ public sealed class InMemoryTransportConsumerTests
         var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "test" });
         await broker.PublishAsync("test-queue4", envelope);
 
-        // Wait for processing
-        await Task.Delay(200);
+        await handled.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await consumer.StopAsync();
-
-        Assert.True(handled);
     }
 
     // Place helper after methods to satisfy SA1201

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportLifecycleAdditionalTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/InMemory/InMemoryTransportLifecycleAdditionalTests.cs
@@ -1,0 +1,199 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.Configuration;
+using HoneyDrunk.Transport.InMemory;
+using HoneyDrunk.Transport.Pipeline;
+using HoneyDrunk.Transport.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace HoneyDrunk.Transport.Tests.Transports.InMemory;
+
+/// <summary>
+/// Additional lifecycle coverage for in-memory transport publisher and consumer.
+/// </summary>
+public sealed class InMemoryTransportLifecycleAdditionalTests
+{
+    /// <summary>
+    /// Publisher validates required envelope and destination arguments.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task PublishAsync_WhenArgumentsMissing_ThrowsArgumentNullException()
+    {
+        var publisher = CreatePublisher();
+        var envelope = TestData.CreateEnvelope(new SampleMessage { Value = "test" });
+        var destination = TestData.Address("orders", "orders");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => publisher.PublishAsync(null!, destination));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => publisher.PublishAsync(envelope, null!));
+    }
+
+    /// <summary>
+    /// Batch publishing publishes each envelope to the broker.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task PublishBatchAsync_WhenMultipleEnvelopes_PublishesEachEnvelope()
+    {
+        var broker = new InMemoryBroker(NullLogger<InMemoryBroker>.Instance);
+        var publisher = CreatePublisher(broker);
+        var destination = TestData.Address("orders", "orders");
+        var first = TestData.CreateEnvelope(new SampleMessage { Value = "one" });
+        var second = TestData.CreateEnvelope(new SampleMessage { Value = "two" });
+
+        await publisher.PublishBatchAsync([first, second], destination);
+
+        Assert.Equal(2, broker.GetMessageCount("orders"));
+    }
+
+    /// <summary>
+    /// Consumer start is guarded against duplicate starts.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartAsync_WhenAlreadyStarted_ThrowsInvalidOperationException()
+    {
+        await using var fixture = CreateConsumer();
+
+        await fixture.Consumer.StartAsync();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Consumer.StartAsync());
+
+        Assert.Equal("Consumer is already started", ex.Message);
+    }
+
+    /// <summary>
+    /// Stop is safe before start and after start.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StopAsync_WhenCalledBeforeAndAfterStart_IsIdempotent()
+    {
+        await using var fixture = CreateConsumer();
+
+        await fixture.Consumer.StopAsync();
+        await fixture.Consumer.StartAsync();
+        await fixture.Consumer.StopAsync();
+        await fixture.Consumer.StopAsync();
+    }
+
+    /// <summary>
+    /// Retry processing result republishes the message to the same address.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Consumer_WhenPipelineRequestsRetry_RepublishesMessage()
+    {
+        var broker = new InMemoryBroker(NullLogger<InMemoryBroker>.Instance);
+        var pipeline = Substitute.For<IMessagePipeline>();
+        var processed = 0;
+        pipeline.ProcessAsync(
+                Arg.Any<ITransportEnvelope>(),
+                Arg.Any<MessageContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var current = Interlocked.Increment(ref processed);
+                return current == 1
+                    ? MessageProcessingResult.Retry
+                    : MessageProcessingResult.Success;
+            });
+        await using var fixture = CreateConsumer(broker, pipeline);
+        var publisher = CreatePublisher(broker);
+        var destination = TestData.Address("orders", "orders");
+
+        await fixture.Consumer.StartAsync();
+        await publisher.PublishAsync(TestData.CreateEnvelope(new SampleMessage { Value = "retry" }), destination);
+        await WaitUntilAsync(() => Volatile.Read(ref processed) >= 2);
+
+        await pipeline.Received(2).ProcessAsync(
+            Arg.Any<ITransportEnvelope>(),
+            Arg.Any<MessageContext>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Disposed consumers reject subsequent starts.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task StartAsync_WhenDisposed_ThrowsObjectDisposedException()
+    {
+        await using var fixture = CreateConsumer();
+        await fixture.Consumer.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => fixture.Consumer.StartAsync());
+    }
+
+    /// <summary>
+    /// Creates an in-memory publisher.
+    /// </summary>
+    /// <param name="broker">Optional broker instance.</param>
+    /// <returns>An in-memory publisher.</returns>
+    private static InMemoryTransportPublisher CreatePublisher(InMemoryBroker? broker = null)
+    {
+        return new InMemoryTransportPublisher(
+            broker ?? new InMemoryBroker(NullLogger<InMemoryBroker>.Instance),
+            NullLogger<InMemoryTransportPublisher>.Instance);
+    }
+
+    /// <summary>
+    /// Creates an in-memory consumer fixture.
+    /// </summary>
+    /// <param name="broker">Optional broker instance.</param>
+    /// <param name="pipeline">Optional message pipeline.</param>
+    /// <returns>An in-memory consumer fixture.</returns>
+    private static ConsumerFixture CreateConsumer(
+        InMemoryBroker? broker = null,
+        IMessagePipeline? pipeline = null)
+    {
+        var provider = new ServiceCollection().BuildServiceProvider();
+        var consumer = new InMemoryTransportConsumer(
+            broker ?? new InMemoryBroker(NullLogger<InMemoryBroker>.Instance),
+            pipeline ?? Substitute.For<IMessagePipeline>(),
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new TransportOptions { Address = "orders", EndpointName = "orders" }),
+            NullLogger<InMemoryTransportConsumer>.Instance);
+
+        return new ConsumerFixture(consumer, provider);
+    }
+
+    /// <summary>
+    /// Waits until the supplied condition becomes true.
+    /// </summary>
+    /// <param name="condition">The condition to observe.</param>
+    /// <returns>A task representing the asynchronous wait.</returns>
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!condition())
+        {
+            if (DateTimeOffset.UtcNow > deadline)
+            {
+                throw new TimeoutException("Condition was not met before the timeout elapsed.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+
+    private sealed class ConsumerFixture : IAsyncDisposable
+    {
+        public ConsumerFixture(InMemoryTransportConsumer consumer, ServiceProvider provider)
+        {
+            Consumer = consumer;
+            Provider = provider;
+        }
+
+        public InMemoryTransportConsumer Consumer { get; }
+
+        private ServiceProvider Provider { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Consumer.DisposeAsync();
+            await Provider.DisposeAsync();
+        }
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/PoisonQueueMoverTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/PoisonQueueMoverTests.cs
@@ -1,0 +1,108 @@
+using Azure;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using HoneyDrunk.Transport.StorageQueue.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using System.Globalization;
+using System.Text.Json;
+
+namespace HoneyDrunk.Transport.Tests.Transports.StorageQueue;
+
+/// <summary>
+/// Tests for <see cref="PoisonQueueMover"/>.
+/// </summary>
+public sealed class PoisonQueueMoverTests
+{
+    /// <summary>
+    /// MoveMessageToPoisonQueueAsync writes a diagnostic poison payload with error metadata.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task MoveMessageToPoisonQueueAsync_WithError_SendsDiagnosticEnvelope()
+    {
+        var mover = new PoisonQueueMover(NullLogger<PoisonQueueMover>.Instance);
+        var poisonQueueClient = Substitute.For<QueueClient>();
+        var message = CreateQueueMessage();
+        string? captured = null;
+
+        poisonQueueClient
+            .SendMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<string>();
+                return Task.FromResult(Substitute.For<Response<SendReceipt>>());
+            });
+
+        var error = new InvalidOperationException("handler failed");
+
+        await mover.MoveMessageToPoisonQueueAsync(poisonQueueClient, message, error, 5, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        using var document = JsonDocument.Parse(captured!);
+        var root = document.RootElement;
+        Assert.Equal("message-1", root.GetProperty("originalMessageId").GetString());
+        Assert.Equal("body", root.GetProperty("originalMessage").GetString());
+        Assert.Equal(5, root.GetProperty("dequeueCount").GetInt64());
+        Assert.Equal(typeof(InvalidOperationException).FullName, root.GetProperty("errorType").GetString());
+        Assert.Equal("handler failed", root.GetProperty("errorMessage").GetString());
+        Assert.Equal("pop-1", root.GetProperty("metadata").GetProperty("PopReceipt").GetString());
+    }
+
+    /// <summary>
+    /// MoveMessageToPoisonQueueAsync allows explicit dead-lettering without an exception.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task MoveMessageToPoisonQueueAsync_WithoutError_SerializesNullErrorMetadata()
+    {
+        var mover = new PoisonQueueMover(NullLogger<PoisonQueueMover>.Instance);
+        var poisonQueueClient = Substitute.For<QueueClient>();
+        var message = CreateQueueMessage();
+        string? captured = null;
+
+        poisonQueueClient
+            .SendMessageAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<string>();
+                return Task.FromResult(Substitute.For<Response<SendReceipt>>());
+            });
+
+        await mover.MoveMessageToPoisonQueueAsync(poisonQueueClient, message, null, 7, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        using var document = JsonDocument.Parse(captured!);
+        var root = document.RootElement;
+        Assert.Equal(7, root.GetProperty("dequeueCount").GetInt64());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("errorType").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("errorMessage").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("errorStackTrace").ValueKind);
+    }
+
+    /// <summary>
+    /// Null dependencies are rejected before any queue call is attempted.
+    /// </summary>
+    /// <returns>A task.</returns>
+    [Fact]
+    public async Task MoveMessageToPoisonQueueAsync_WithNullArguments_Throws()
+    {
+        var mover = new PoisonQueueMover(NullLogger<PoisonQueueMover>.Instance);
+        var message = CreateQueueMessage();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            mover.MoveMessageToPoisonQueueAsync(null!, message, null, 1, CancellationToken.None));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            mover.MoveMessageToPoisonQueueAsync(Substitute.For<QueueClient>(), null!, null, 1, CancellationToken.None));
+    }
+
+    private static QueueMessage CreateQueueMessage() => QueuesModelFactory.QueueMessage(
+        messageId: "message-1",
+        popReceipt: "pop-1",
+        body: BinaryData.FromString("body"),
+        dequeueCount: 3,
+        insertedOn: DateTimeOffset.Parse("2026-01-02T03:04:05Z", CultureInfo.InvariantCulture),
+        expiresOn: DateTimeOffset.Parse("2026-01-09T03:04:05Z", CultureInfo.InvariantCulture),
+        nextVisibleOn: DateTimeOffset.Parse("2026-01-02T03:05:05Z", CultureInfo.InvariantCulture));
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueOptionsValidationTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueOptionsValidationTests.cs
@@ -1,0 +1,208 @@
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using System.ComponentModel.DataAnnotations;
+
+namespace HoneyDrunk.Transport.Tests.Transports.StorageQueue;
+
+/// <summary>
+/// Tests for <see cref="StorageQueueOptions"/> custom validation.
+/// </summary>
+public sealed class StorageQueueOptionsValidationTests
+{
+    /// <summary>
+    /// Valid connection string settings produce no custom validation failures.
+    /// </summary>
+    [Fact]
+    public void Validate_WithConnectionStringAndValidSettings_ReturnsNoErrors()
+    {
+        var options = new StorageQueueOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            QueueName = "orders"
+        };
+
+        var errors = Validate(options);
+
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// Valid endpoint settings produce no custom validation failures.
+    /// </summary>
+    [Fact]
+    public void Validate_WithAccountEndpointAndValidSettings_ReturnsNoErrors()
+    {
+        var options = new StorageQueueOptions
+        {
+            AccountEndpoint = new Uri("https://account.queue.core.windows.net"),
+            QueueName = "orders"
+        };
+
+        var errors = Validate(options);
+
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// Missing authentication source returns a validation error.
+    /// </summary>
+    [Fact]
+    public void Validate_WithoutConnectionStringOrEndpoint_ReturnsAuthenticationError()
+    {
+        var options = new StorageQueueOptions { QueueName = "orders" };
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("Either ConnectionString or AccountEndpoint", error.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains(nameof(StorageQueueOptions.ConnectionString), error.MemberNames);
+        Assert.Contains(nameof(StorageQueueOptions.AccountEndpoint), error.MemberNames);
+    }
+
+    /// <summary>
+    /// Resource-exhausting concurrency is rejected.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenMaxConcurrencyTooHigh_ReturnsConcurrencyError()
+    {
+        var options = ValidOptions();
+        options.MaxConcurrency = 101;
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("MaxConcurrency cannot exceed 100", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Batch processing concurrency cannot exceed the fetched message count.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenBatchProcessingExceedsPrefetch_ReturnsBatchError()
+    {
+        var options = ValidOptions();
+        options.PrefetchMaxMessages = 4;
+        options.BatchProcessingConcurrency = 5;
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("BatchProcessingConcurrency (5) cannot exceed PrefetchMaxMessages (4)", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Empty queue polling interval must not exceed the maximum polling interval.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenEmptyPollingExceedsMaxPolling_ReturnsPollingError()
+    {
+        var options = ValidOptions();
+        options.EmptyQueuePollingInterval = TimeSpan.FromSeconds(10);
+        options.MaxPollingInterval = TimeSpan.FromSeconds(5);
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("EmptyQueuePollingInterval cannot be greater", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Visibility timeout below the service minimum is rejected.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenVisibilityTimeoutTooShort_ReturnsVisibilityError()
+    {
+        var options = ValidOptions();
+        options.VisibilityTimeout = TimeSpan.FromMilliseconds(500);
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("VisibilityTimeout must be at least 1 second", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Visibility timeout above the service maximum is rejected.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenVisibilityTimeoutTooLong_ReturnsVisibilityError()
+    {
+        var options = ValidOptions();
+        options.VisibilityTimeout = TimeSpan.FromDays(8);
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("VisibilityTimeout cannot exceed 7 days", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Message TTL below the service minimum is rejected.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenMessageTimeToLiveTooShort_ReturnsTtlError()
+    {
+        var options = ValidOptions();
+        options.MessageTimeToLive = TimeSpan.FromMilliseconds(500);
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("MessageTimeToLive must be at least 1 second", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Message TTL above the service maximum is rejected.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenMessageTimeToLiveTooLong_ReturnsTtlError()
+    {
+        var options = ValidOptions();
+        options.MessageTimeToLive = TimeSpan.FromDays(8);
+
+        var error = Assert.Single(Validate(options));
+
+        Assert.Contains("MessageTimeToLive cannot exceed 7 days", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Custom poison queue name overrides the default name.
+    /// </summary>
+    [Fact]
+    public void GetPoisonQueueName_WhenCustomNameSet_ReturnsCustomName()
+    {
+        var options = new StorageQueueOptions
+        {
+            QueueName = "orders",
+            PoisonQueueName = "orders-dead"
+        };
+
+        Assert.Equal("orders-dead", options.GetPoisonQueueName());
+    }
+
+    /// <summary>
+    /// Missing poison queue name defaults from the primary queue name.
+    /// </summary>
+    [Fact]
+    public void GetPoisonQueueName_WhenCustomNameMissing_ReturnsDefaultName()
+    {
+        var options = new StorageQueueOptions { QueueName = "orders" };
+
+        Assert.Equal("orders-poison", options.GetPoisonQueueName());
+    }
+
+    /// <summary>
+    /// Creates valid options for focused validation tests.
+    /// </summary>
+    /// <returns>Valid storage queue options.</returns>
+    private static StorageQueueOptions ValidOptions()
+    {
+        return new StorageQueueOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            QueueName = "orders"
+        };
+    }
+
+    /// <summary>
+    /// Runs custom validation for options.
+    /// </summary>
+    /// <param name="options">The options to validate.</param>
+    /// <returns>The validation results.</returns>
+    private static List<ValidationResult> Validate(StorageQueueOptions options)
+    {
+        return options.Validate(new ValidationContext(options)).ToList();
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueProcessorBackoffStateTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueProcessorBackoffStateTests.cs
@@ -1,0 +1,65 @@
+using HoneyDrunk.Transport.StorageQueue.Internal;
+using System.Reflection;
+
+namespace HoneyDrunk.Transport.Tests.Transports.StorageQueue;
+
+/// <summary>
+/// Tests for the per-consumer backoff state used by <see cref="StorageQueueProcessor"/>.
+/// </summary>
+public sealed class StorageQueueProcessorBackoffStateTests
+{
+    /// <summary>
+    /// Empty receive backoff grows up to the configured maximum and reset restores the initial interval.
+    /// </summary>
+    [Fact]
+    public void ConsumerBackoffState_AppliesExponentialBackoffAndReset()
+    {
+        var state = CreateState(TimeSpan.FromMilliseconds(100));
+
+        Invoke(state, "IncrementEmptyReceive");
+        Invoke(state, "ApplyExponentialBackoff", TimeSpan.FromMilliseconds(200));
+        Assert.Equal(TimeSpan.FromMilliseconds(100), CurrentPollingInterval(state));
+
+        Invoke(state, "IncrementEmptyReceive");
+        Invoke(state, "ApplyExponentialBackoff", TimeSpan.FromMilliseconds(200));
+        Assert.Equal(TimeSpan.FromMilliseconds(150), CurrentPollingInterval(state));
+
+        Invoke(state, "IncrementEmptyReceive");
+        Invoke(state, "ApplyExponentialBackoff", TimeSpan.FromMilliseconds(200));
+        Assert.Equal(TimeSpan.FromMilliseconds(200), CurrentPollingInterval(state));
+
+        Invoke(state, "Reset", TimeSpan.FromMilliseconds(100));
+        Assert.Equal(TimeSpan.FromMilliseconds(100), CurrentPollingInterval(state));
+    }
+
+    /// <summary>
+    /// Reset is a no-op when there have been no empty receives.
+    /// </summary>
+    [Fact]
+    public void ConsumerBackoffState_ResetWithoutEmptyReceives_LeavesIntervalUnchanged()
+    {
+        var state = CreateState(TimeSpan.FromMilliseconds(250));
+
+        Invoke(state, "Reset", TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(250), CurrentPollingInterval(state));
+    }
+
+    private static object CreateState(TimeSpan initialPollingInterval)
+    {
+        var type = typeof(StorageQueueProcessor).GetNestedType("ConsumerBackoffState", BindingFlags.NonPublic)!;
+        return Activator.CreateInstance(type, initialPollingInterval)!;
+    }
+
+    private static TimeSpan CurrentPollingInterval(object state)
+    {
+        var property = state.GetType().GetProperty("CurrentPollingInterval")!;
+        return (TimeSpan)property.GetValue(state)!;
+    }
+
+    private static void Invoke(object state, string methodName, params object[] args)
+    {
+        var method = state.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public)!;
+        method.Invoke(state, args);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/StorageQueue/StorageQueueServiceCollectionExtensionsTests.cs
@@ -1,0 +1,154 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.StorageQueue.Configuration;
+using HoneyDrunk.Transport.StorageQueue.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Transport.Tests.Transports.StorageQueue;
+
+/// <summary>
+/// Tests for Azure Storage Queue service registration extensions.
+/// </summary>
+public sealed class StorageQueueServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Gets invalid fluent storage queue settings.
+    /// </summary>
+    public static TheoryData<Action> InvalidFluentSettings => new()
+    {
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithMaxDequeueCount(0),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithMaxDequeueCount(101),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithVisibilityTimeout(TimeSpan.Zero),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithVisibilityTimeout(TimeSpan.FromDays(8)),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithMessageTimeToLive(TimeSpan.Zero),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithMessageTimeToLive(TimeSpan.FromDays(8)),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithPrefetchCount(0),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithPrefetchCount(33),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithConcurrency(0),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithConcurrency(101),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithBatchPublishConcurrency(0),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithBatchPublishConcurrency(129),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithBatchProcessingConcurrency(0),
+        () => new ServiceCollection().AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders").WithBatchProcessingConcurrency(33)
+    };
+
+    /// <summary>
+    /// Delegate registration wires transport services and configured options.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task AddHoneyDrunkTransportStorageQueue_WithConfigureAction_RegistersTransportServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddHoneyDrunkTransportStorageQueue(options =>
+        {
+            options.ConnectionString = "UseDevelopmentStorage=true";
+            options.QueueName = "orders";
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<StorageQueueOptions>>().Value;
+
+        Assert.Equal("UseDevelopmentStorage=true", options.ConnectionString);
+        Assert.Equal("orders", options.QueueName);
+        Assert.NotNull(provider.GetRequiredService<ITransportPublisher>());
+        Assert.NotNull(provider.GetRequiredService<ITransportConsumer>());
+        Assert.Equal("StorageQueue", provider.GetRequiredService<ITransportTopology>().Name);
+    }
+
+    /// <summary>
+    /// Connection-string overload maps endpoint name and address from the queue name.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkTransportStorageQueue_WithConnectionString_SetsEndpointFields()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddHoneyDrunkTransportStorageQueue(
+            "UseDevelopmentStorage=true",
+            "orders",
+            options => options.MaxConcurrency = 3);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<StorageQueueOptions>>().Value;
+
+        Assert.Equal("UseDevelopmentStorage=true", options.ConnectionString);
+        Assert.Equal("orders", options.QueueName);
+        Assert.Equal("orders", options.Address);
+        Assert.Equal("orders", options.EndpointName);
+        Assert.Equal(3, options.MaxConcurrency);
+    }
+
+    /// <summary>
+    /// Fluent storage queue options compose into the configured options snapshot.
+    /// </summary>
+    [Fact]
+    public void FluentStorageQueueOptions_WhenComposed_UpdateConfiguredOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddHoneyDrunkTransportStorageQueue("UseDevelopmentStorage=true", "orders")
+            .WithPoisonQueue("orders-dead")
+            .WithMaxDequeueCount(9)
+            .WithVisibilityTimeout(TimeSpan.FromMinutes(2))
+            .WithMessageTimeToLive(TimeSpan.FromHours(1))
+            .WithPrefetchCount(12)
+            .WithConcurrency(7)
+            .WithBatchPublishConcurrency(8)
+            .WithBatchProcessingConcurrency(4)
+            .WithoutAutoCreateQueue();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<StorageQueueOptions>>().Value;
+
+        Assert.Equal("orders-dead", options.PoisonQueueName);
+        Assert.Equal(9, options.MaxDequeueCount);
+        Assert.Equal(TimeSpan.FromMinutes(2), options.VisibilityTimeout);
+        Assert.Equal(TimeSpan.FromHours(1), options.MessageTimeToLive);
+        Assert.Equal(12, options.PrefetchMaxMessages);
+        Assert.Equal(7, options.MaxConcurrency);
+        Assert.Equal(8, options.MaxBatchPublishConcurrency);
+        Assert.Equal(4, options.BatchProcessingConcurrency);
+        Assert.False(options.CreateIfNotExists);
+    }
+
+    /// <summary>
+    /// Null service collections are rejected by the primary overload.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkTransportStorageQueue_WhenServicesNull_Throws()
+    {
+        IServiceCollection? services = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            services!.AddHoneyDrunkTransportStorageQueue(_ => { }));
+    }
+
+    /// <summary>
+    /// Null configuration delegates are rejected.
+    /// </summary>
+    [Fact]
+    public void AddHoneyDrunkTransportStorageQueue_WhenConfigureNull_Throws()
+    {
+        var services = new ServiceCollection();
+        Action<StorageQueueOptions>? configure = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            services.AddHoneyDrunkTransportStorageQueue(configure!));
+    }
+
+    /// <summary>
+    /// Invalid fluent numeric settings are rejected.
+    /// </summary>
+    /// <param name="apply">The invalid configuration call.</param>
+    [Theory]
+    [MemberData(nameof(InvalidFluentSettings))]
+    public void FluentStorageQueueOptions_WhenInvalid_ThrowArgumentOutOfRange(Action apply)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(apply);
+    }
+}

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/TopologyTests.cs
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/Transports/TopologyTests.cs
@@ -1,0 +1,93 @@
+using HoneyDrunk.Transport.Abstractions;
+using HoneyDrunk.Transport.AzureServiceBus.DependencyInjection;
+using HoneyDrunk.Transport.InMemory.DependencyInjection;
+using HoneyDrunk.Transport.StorageQueue.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Transport.Tests.Transports;
+
+/// <summary>
+/// Tests for transport topology capability descriptors.
+/// </summary>
+public sealed class TopologyTests
+{
+    /// <summary>
+    /// In-memory topology advertises its supported test-friendly capabilities.
+    /// </summary>
+    [Fact]
+    public void InMemoryTopology_WhenResolved_ReportsExpectedCapabilities()
+    {
+        using var provider = BuildProvider(services => services.AddHoneyDrunkInMemoryTransport());
+
+        var topology = provider.GetRequiredService<ITransportTopology>();
+
+        Assert.Equal("InMemory", topology.Name);
+        Assert.True(topology.SupportsTopics);
+        Assert.True(topology.SupportsSubscriptions);
+        Assert.False(topology.SupportsSessions);
+        Assert.True(topology.SupportsOrdering);
+        Assert.False(topology.SupportsScheduledMessages);
+        Assert.True(topology.SupportsBatching);
+        Assert.False(topology.SupportsTransactions);
+        Assert.False(topology.SupportsDeadLetterQueue);
+        Assert.False(topology.SupportsPriority);
+        Assert.Null(topology.MaxMessageSize);
+    }
+
+    /// <summary>
+    /// Service Bus topology advertises enterprise broker capabilities.
+    /// </summary>
+    [Fact]
+    public void ServiceBusTopology_WhenResolved_ReportsExpectedCapabilities()
+    {
+        using var provider = BuildProvider(services => services.AddHoneyDrunkServiceBusTransport(
+            "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
+            "orders"));
+
+        var topology = provider.GetRequiredService<ITransportTopology>();
+
+        Assert.Equal("AzureServiceBus", topology.Name);
+        Assert.True(topology.SupportsTopics);
+        Assert.True(topology.SupportsSubscriptions);
+        Assert.True(topology.SupportsSessions);
+        Assert.True(topology.SupportsOrdering);
+        Assert.True(topology.SupportsScheduledMessages);
+        Assert.True(topology.SupportsBatching);
+        Assert.True(topology.SupportsTransactions);
+        Assert.True(topology.SupportsDeadLetterQueue);
+        Assert.False(topology.SupportsPriority);
+        Assert.Equal(256 * 1024, topology.MaxMessageSize);
+    }
+
+    /// <summary>
+    /// Storage Queue topology advertises simple queue capabilities and limits.
+    /// </summary>
+    [Fact]
+    public void StorageQueueTopology_WhenResolved_ReportsExpectedCapabilities()
+    {
+        using var provider = BuildProvider(services => services.AddHoneyDrunkTransportStorageQueue(
+            "UseDevelopmentStorage=true",
+            "orders"));
+
+        var topology = provider.GetRequiredService<ITransportTopology>();
+
+        Assert.Equal("StorageQueue", topology.Name);
+        Assert.False(topology.SupportsTopics);
+        Assert.False(topology.SupportsSubscriptions);
+        Assert.False(topology.SupportsSessions);
+        Assert.False(topology.SupportsOrdering);
+        Assert.False(topology.SupportsScheduledMessages);
+        Assert.True(topology.SupportsBatching);
+        Assert.False(topology.SupportsTransactions);
+        Assert.False(topology.SupportsDeadLetterQueue);
+        Assert.False(topology.SupportsPriority);
+        Assert.Equal(64 * 1024, topology.MaxMessageSize);
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Summary

- Backfills HoneyDrunk.Transport coverage from the measured 48.1% baseline to 70.1% total line coverage.
- Adds focused tests across core abstractions/configuration/outbox/runtime, Azure Service Bus publisher/consumer/fallback paths, InMemory registration/lifecycle, and Storage Queue validation/DI/poison/backoff paths.
- Seeds `.github/coverage-baseline.json` and wires the PR workflow for 75% patch coverage + 70% absolute coverage, with main-branch push ratchet enabled.
- Updates repository/package changelogs with the coverage backfill and gate wiring.

## Validation

- `dotnet test HoneyDrunk.Transport\\HoneyDrunk.Transport.slnx /p:NuGetAudit=false --no-restore`
  - Passed: 479
- `dotnet test HoneyDrunk.Transport\\HoneyDrunk.Transport.slnx /p:NuGetAudit=false --no-restore --collect:"XPlat Code Coverage" --results-directory TestResults`
  - Passed: 479
- `reportgenerator -reports:TestResults\\513913aa-7151-4f67-924d-60427bd88a88\\coverage.cobertura.xml -targetdir:coverage-report -reporttypes:JsonSummary`
  - Total line coverage: 70.1%

Closes #26
