### PR TITLE
test: align Transport with ADR-0047 test stack

### DIFF
--- a/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Aligned Transport test tooling with ADR-0047 by adopting HoneyDrunk.Standards.Tests 0.2.9 and refreshing HoneyDrunk.Standards to 0.2.9 across package projects.
+
 ### Added
 
 - Backfilled focused unit coverage across core, Azure Service Bus, InMemory, and Storage Queue transport surfaces to seed the 70% repository coverage baseline.

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Transport.AzureServiceBus will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.6.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.AzureServiceBus/HoneyDrunk.Transport.AzureServiceBus.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <!-- HoneyDrunk.Kernel.Abstractions comes transitively from HoneyDrunk.Transport -->
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Transport.InMemory will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.6.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.InMemory/HoneyDrunk.Transport.InMemory.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Transport.StorageQueue will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.6.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.StorageQueue/HoneyDrunk.Transport.StorageQueue.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <!-- HoneyDrunk.Kernel.Abstractions comes transitively from HoneyDrunk.Transport -->
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport.Tests/HoneyDrunk.Transport.Tests.csproj
@@ -12,29 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="Azure.Core" Version="1.53.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Transport will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.6.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
+++ b/HoneyDrunk.Transport/HoneyDrunk.Transport/HoneyDrunk.Transport.csproj
@@ -32,7 +32,7 @@
     <!-- Core abstractions only - no runtime dependencies -->
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Transport/docs/Testing.md
+++ b/HoneyDrunk.Transport/docs/Testing.md
@@ -69,8 +69,8 @@ public class OrderCreatedHandlerTests
     public async Task HandleAsync_ValidMessage_ReturnsSuccess()
     {
         // Arrange - pure unit test, no DI
-        var repository = new Mock<IOrderRepository>();
-        var handler = new OrderCreatedHandler(repository.Object);
+        var repository = Substitute.For<IOrderRepository>();
+        var handler = new OrderCreatedHandler(repository);
         
         var message = new OrderCreated(OrderId: 123, CustomerId: 456);
         var context = new MessageContext
@@ -85,19 +85,19 @@ public class OrderCreatedHandlerTests
         
         // Assert
         Assert.Equal(MessageProcessingResult.Success, result);
-        repository.Verify(r => r.ProcessOrderAsync(123, It.IsAny<CancellationToken>()), Times.Once);
+        await repository.Received(1).ProcessOrderAsync(123, Arg.Any<CancellationToken>());
     }
     
     [Fact]
     public async Task HandleAsync_RepositoryThrows_ReturnsRetry()
     {
         // Arrange
-        var repository = new Mock<IOrderRepository>();
+        var repository = Substitute.For<IOrderRepository>();
         repository
-            .Setup(r => r.ProcessOrderAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ProcessOrderAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new TimeoutException());
         
-        var handler = new OrderCreatedHandler(repository.Object);
+        var handler = new OrderCreatedHandler(repository);
         var message = new OrderCreated(123, 456);
         var context = TestMessageContext.Create(message);
         
@@ -112,8 +112,8 @@ public class OrderCreatedHandlerTests
     public async Task HandleAsync_ValidationFails_ReturnsDeadLetter()
     {
         // Arrange
-        var repository = new Mock<IOrderRepository>();
-        var handler = new OrderCreatedHandler(repository.Object);
+        var repository = Substitute.For<IOrderRepository>();
+        var handler = new OrderCreatedHandler(repository);
         var invalidMessage = new OrderCreated(OrderId: -1, CustomerId: 456);
         var context = TestMessageContext.Create(invalidMessage);
         
@@ -122,7 +122,7 @@ public class OrderCreatedHandlerTests
         
         // Assert
         Assert.Equal(MessageProcessingResult.DeadLetter, result);
-        repository.Verify(r => r.ProcessOrderAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        await repository.DidNotReceive().ProcessOrderAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 }
 ```
@@ -142,10 +142,10 @@ public class ValidationMiddlewareTests
     public async Task InvokeAsync_ValidMessage_CallsNext()
     {
         // Arrange
-        var validator = new Mock<IValidator>();
-        validator.Setup(v => v.ValidateAsync(It.IsAny<object>())).ReturnsAsync(true);
+        var validator = Substitute.For<IValidator>();
+        validator.ValidateAsync(Arg.Any<object>()).Returns(Task.FromResult(true));
         
-        var middleware = new ValidationMiddleware(validator.Object);
+        var middleware = new ValidationMiddleware(validator);
         var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
         var context = TestMessageContext.Create<OrderCreated>();
         var nextCalled = false;
@@ -165,10 +165,10 @@ public class ValidationMiddlewareTests
     public async Task InvokeAsync_InvalidMessage_ThrowsWithoutCallingNext()
     {
         // Arrange
-        var validator = new Mock<IValidator>();
-        validator.Setup(v => v.ValidateAsync(It.IsAny<object>())).ReturnsAsync(false);
+        var validator = Substitute.For<IValidator>();
+        validator.ValidateAsync(Arg.Any<object>()).Returns(Task.FromResult(false));
         
-        var middleware = new ValidationMiddleware(validator.Object);
+        var middleware = new ValidationMiddleware(validator);
         var envelope = TestEnvelopeFactory.CreateEnvelope(new OrderCreated(123, 456));
         var context = TestMessageContext.Create<OrderCreated>();
         var nextCalled = false;
@@ -622,7 +622,7 @@ public class OutboxIntegrationTests
         // Arrange
         using var db = CreateTestDatabase();
         var outbox = new EfCoreOutboxStore(db);
-        var publisher = new Mock<ITransportPublisher>();
+        var publisher = Substitute.For<ITransportPublisher>();
         var logger = NullLogger<DefaultOutboxDispatcher>.Instance;
         var options = Options.Create(new OutboxDispatcherOptions
         {
@@ -631,7 +631,7 @@ public class OutboxIntegrationTests
         });
         
         // Create dispatcher directly (not as hosted service)
-        var dispatcher = new DefaultOutboxDispatcher(outbox, publisher.Object, options, logger);
+        var dispatcher = new DefaultOutboxDispatcher(outbox, publisher, options, logger);
         
         // Save a message
         var destination = EndpointAddress.Create("orders", "orders");
@@ -643,11 +643,11 @@ public class OutboxIntegrationTests
         await dispatcher.DispatchPendingAsync(CancellationToken.None);
         
         // Assert
-        publisher.Verify(p => p.PublishAsync(
-            It.IsAny<ITransportEnvelope>(),
-            It.Is<IEndpointAddress>(d => d.Name == "orders"),
-            It.IsAny<PublishOptions?>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+        await publisher.Received(1).PublishAsync(
+            Arg.Any<ITransportEnvelope>(),
+            Arg.Is<IEndpointAddress>(d => d.Name == "orders"),
+            Arg.Any<PublishOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }
 ```


### PR DESCRIPTION
## Summary

- adopt `HoneyDrunk.Standards.Tests` 0.2.9 in `HoneyDrunk.Transport.Tests` and remove direct xUnit/coverlet/NSubstitute test-stack package references
- refresh `HoneyDrunk.Standards` references from 0.2.7 to 0.2.9 across Transport package projects
- update Transport testing docs to use NSubstitute examples and document ADR-0047 alignment in changelogs

## Validation

- `git diff --check`
- `dotnet restore HoneyDrunk.Transport/HoneyDrunk.Transport.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet test HoneyDrunk.Transport/HoneyDrunk.Transport.slnx -c Release --no-restore`
  - `HoneyDrunk.Transport.Tests`: 479 passed

## ADR / Issues

Contributes to HoneyDrunk.Architecture#188 and HoneyDrunk.Architecture#189.