### PR TITLE
ci: harden Grid Review secret delivery

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: Grid Review Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 permissions:


### PR DESCRIPTION
## Summary
- harden ADR-0044 Grid Review request workflow secret delivery
- move the secret-bearing caller from pull_request to pull_request_target
- keep the shared HoneyDrunk.Actions reusable workflow on @main

## Validation
- python C:\Users\tatte\.openclaw\workspace\validate-yaml.py .github\workflows\pr-review.yml
- git diff --check

Out-of-band reason: follow-up security hardening for already-rolled-out ADR-0044 Grid Review workflow trigger; no new packet was generated because this patches the rollout rail itself.
Authorship: agent-codex