### PR TITLE
ci: grant issues permission to weekly deps

### DIFF
--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   weekly-deps:


### PR DESCRIPTION
## Summary

- grants `issues: write` to `.github/workflows/weekly-deps.yml`
- unblocks the called `HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main` reporting job, which declares `issues: write`

## Why

Transport weekly dependency runs are failing at startup before jobs are created because the caller workflow grants only `contents: write` and `pull-requests: write`, while the reusable workflow includes a dependency-report consolidation job that requires `issues: write`.

## Validation

- `git diff --check`
- failure diagnosis from latest Transport run: startup failure references `HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main`
- after merge, manually dispatch `Weekly Dependencies` on Transport once to verify before rolling the permission fix to the rest of the Grid

Out-of-band reason: Emergency CI workflow startup fix for Transport weekly dependency automation; no generated packet exists for this one-repo verification pass.

Authorship: agent-codex
