### PR TITLE
ci: use hive token for weekly dependency issues

### DIFF
--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -22,4 +22,4 @@ jobs:
       create-update-prs: true
       actions-ref: 'main'
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}


### PR DESCRIPTION
## Summary

- switches weekly dependency issue maintenance from `GITHUB_TOKEN` to `HIVE_FIELD_MIRROR_TOKEN`
- preserves the already-verified `issues: write` permission required by `nightly-deps.yml`

## Why

Transport's verified weekly dependency run created `📦 Outdated Dependencies`, but because the issue was created by `app/github-actions` via `GITHUB_TOKEN`, GitHub suppressed the downstream `issues: opened` workflow event and the Hive Field Mirror did not add it to the Hive project.

Using the Hive token for dependency issue maintenance lets issue-created/edited events flow through the normal Hive mirror path instead of being suppressed as recursive `GITHUB_TOKEN` automation.

## Validation

- `git diff --check`
- verified prior Transport weekly-deps run succeeded after the permission fix: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/actions/runs/26415087947
- after merge, rerun Transport `Weekly Dependencies` and confirm `📦 Outdated Dependencies` is mirrored into the Hive project

Out-of-band reason: Follow-up fix to make weekly dependency tracking issues trigger Hive project mirroring; no generated packet exists for this operational correction.

Authorship: agent-codex
