### PR TITLE
ci: move workflow actions to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-﻿name: Publish to NuGet
+name: Publish to NuGet
 
 on:
   push:
@@ -68,10 +68,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: HoneyDrunkStudios/HoneyDrunk.Actions
           ref: main
@@ -92,7 +92,7 @@ jobs:
           docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport#readme'
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.version-tag }}
           name: HoneyDrunk.Transport ${{ needs.prepare.outputs.version-tag }}


### PR DESCRIPTION
## Summary
- Updates workflow action pins from Node 20-backed majors to Node 24-compatible majors.
- Keeps the change limited to GitHub Actions workflow maintenance.

Authorship: agent-codex

Packet: N/A
Out-of-band reason: Direct maintenance request to eliminate GitHub Actions Node 20 deprecation warnings across HoneyDrunk workflows.

## Verification
- GitHub action metadata audit: all edited JavaScript action refs resolve to 
ode24.
- git diff --check

Size justification: N/A

